### PR TITLE
fix(agent): check-then-init repo, fix stdin hang, add restic timeouts

### DIFF
--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -162,6 +162,7 @@ export async function triggerJob(id: string): Promise<void> {
         type:   'run_backup',
         jobId:  id,
         config: {
+          repoId:       job.repositoryId!,
           repoUrl:      repoConfig.repositoryUrl,
           repoPassword: repoConfig.password,
           paths,
@@ -240,7 +241,7 @@ export async function retryRun(jobId: string): Promise<void> {
       const result = await dispatchToAgent(job.agentId, {
         type:   'run_backup',
         jobId,
-        config: { repoUrl: repoConfig.repositoryUrl, repoPassword: repoConfig.password, paths, exclude: srcConfig.exclude, tags, envVars: repoConfig.envVars },
+        config: { repoId: job.repositoryId!, repoUrl: repoConfig.repositoryUrl, repoPassword: repoConfig.password, paths, exclude: srcConfig.exclude, tags, envVars: repoConfig.envVars },
       })
       if (!result.ok) {
         console.error('[retryRun] dispatch failed reason=%s knownIds=%j', result.reason, result.knownIds)

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -114,6 +114,7 @@ async function dispatchToAgent(db: Db, job: Job): Promise<boolean> {
     type:   'run_backup',
     jobId:  job.id,
     config: {
+      repoId:       job.repositoryId ?? '',
       repoUrl:      cfg['repositoryUrl'] ?? '',
       repoPassword: decryptField(repo.resticPassword),
       paths,

--- a/apps/web/public/agent/bundle.js
+++ b/apps/web/public/agent/bundle.js
@@ -2230,7 +2230,7 @@ var require_websocket = __commonJS({
     var tls = require("tls");
     var { randomBytes, createHash } = require("crypto");
     var { Duplex, Readable } = require("stream");
-    var { URL } = require("url");
+    var { URL: URL2 } = require("url");
     var PerMessageDeflate2 = require_permessage_deflate();
     var Receiver2 = require_receiver();
     var Sender2 = require_sender();
@@ -2723,11 +2723,11 @@ var require_websocket = __commonJS({
         );
       }
       let parsedUrl;
-      if (address instanceof URL) {
+      if (address instanceof URL2) {
         parsedUrl = address;
       } else {
         try {
-          parsedUrl = new URL(address);
+          parsedUrl = new URL2(address);
         } catch {
           throw new SyntaxError(`Invalid URL: ${address}`);
         }
@@ -2864,7 +2864,7 @@ var require_websocket = __commonJS({
           req.abort();
           let addr;
           try {
-            addr = new URL(location, address);
+            addr = new URL2(location, address);
           } catch (e) {
             const err = new SyntaxError(`Invalid URL: ${location}`);
             emitErrorAndClose(websocket, err);
@@ -3665,7 +3665,7 @@ var ResticEngine = class {
     this.binary = config.binaryPath ?? "restic";
   }
   async init() {
-    const result = await this.run(["init"]);
+    const result = await this.run(["init"], void 0, 6e4);
     if (result.exitCode !== 0) {
       throw new ResticError("init", result);
     }
@@ -3708,7 +3708,7 @@ var ResticEngine = class {
           }
         } catch {
         }
-      } : void 0);
+      } : void 0, void 0, 144e5);
       if (result.exitCode !== 0)
         throw new ResticError("backup", result);
       const summary = this.parseSummaryLine(result.stdout);
@@ -3735,7 +3735,7 @@ var ResticEngine = class {
     if (tags)
       for (const t of tags)
         args.push("--tag", t);
-    const result = await this.run(args);
+    const result = await this.run(args, void 0, 3e4);
     if (result.exitCode !== 0)
       throw new ResticError("snapshots", result);
     const raw = JSON.parse(result.stdout);
@@ -3749,7 +3749,7 @@ var ResticEngine = class {
     }));
   }
   async ls(snapshotId) {
-    const result = await this.run(["ls", snapshotId, "--json"]);
+    const result = await this.run(["ls", snapshotId, "--json"], void 0, 3e4);
     if (result.exitCode !== 0)
       throw new ResticError("ls", result);
     const files = [];
@@ -3774,7 +3774,7 @@ var ResticEngine = class {
     const args = ["check"];
     if (readData)
       args.push("--read-data");
-    const result = await this.run(args);
+    const result = await this.run(args, void 0, 18e5);
     const ok = result.exitCode === 0;
     const lines = result.stderr.split("\n").filter(Boolean);
     return {
@@ -3789,7 +3789,7 @@ var ResticEngine = class {
       for (const p of include)
         args.push("--include", p);
     const before = Date.now();
-    const result = await this.run(args);
+    const result = await this.run(args, void 0, 144e5);
     if (result.exitCode !== 0)
       throw new ResticError("restore", result);
     const match = result.stderr.match(/(\d+) files? restored/);
@@ -3816,7 +3816,7 @@ var ResticEngine = class {
         args.push("--keep-tag", t);
     if (prune)
       args.push("--prune");
-    const result = await this.run(args);
+    const result = await this.run(args, void 0, 18e5);
     if (result.exitCode !== 0)
       throw new ResticError("forget", result);
     const raw = JSON.parse(result.stdout);
@@ -3827,12 +3827,12 @@ var ResticEngine = class {
     };
   }
   async prune() {
-    const result = await this.run(["prune"]);
+    const result = await this.run(["prune"], void 0, 18e5);
     if (result.exitCode !== 0)
       throw new ResticError("prune", result);
   }
   async stats() {
-    const result = await this.run(["stats", "--json"]);
+    const result = await this.run(["stats", "--json"], void 0, 3e4);
     if (result.exitCode !== 0)
       throw new ResticError("stats", result);
     const raw = JSON.parse(result.stdout);
@@ -3853,22 +3853,38 @@ var ResticEngine = class {
     }).unref();
   }
   async unmount(mountPoint) {
-    const result = await this.run(["umount", mountPoint]);
+    const result = await this.run(["umount", mountPoint], void 0, 3e4);
     if (result.exitCode !== 0)
       throw new ResticError("umount", result);
   }
   // ── Private ──────────────────────────────────────────────────────────────
-  // Uses spawn (never shell — no injection possible)
-  run(args, extraEnv) {
-    return this.runStreaming(args, void 0, extraEnv);
+  run(args, extraEnv, timeoutMs) {
+    return this.runStreaming(args, void 0, extraEnv, timeoutMs);
   }
-  // Like run() but calls onLine for each stdout line as it arrives
-  runStreaming(args, onLine, extraEnv) {
-    return new Promise((resolve) => {
-      const proc = (0, import_child_process.spawn)(this.binary, args, { env: this.buildEnv(extraEnv) });
+  runStreaming(args, onLine, extraEnv, timeoutMs) {
+    return new Promise((resolve, reject) => {
+      const proc = (0, import_child_process.spawn)(this.binary, args, {
+        env: this.buildEnv(extraEnv),
+        stdio: ["ignore", "pipe", "pipe"]
+      });
+      let settled = false;
       const outLines = [];
       const err = [];
       let partial = "";
+      let timer;
+      if (timeoutMs) {
+        timer = setTimeout(() => {
+          if (settled)
+            return;
+          settled = true;
+          proc.kill("SIGTERM");
+          setTimeout(() => {
+            if (!proc.killed)
+              proc.kill("SIGKILL");
+          }, 1e4);
+          reject(new Error(`restic timed out after ${timeoutMs}ms during ${args[0] ?? "unknown"}`));
+        }, timeoutMs);
+      }
       proc.stdout.on("data", (chunk) => {
         const text = partial + chunk.toString("utf8");
         const parts = text.split("\n");
@@ -3881,6 +3897,11 @@ var ResticEngine = class {
       });
       proc.stderr.on("data", (chunk) => err.push(chunk));
       proc.on("close", (code) => {
+        if (settled)
+          return;
+        settled = true;
+        if (timer)
+          clearTimeout(timer);
         if (partial) {
           outLines.push(partial);
           if (onLine)
@@ -3893,6 +3914,11 @@ var ResticEngine = class {
         });
       });
       proc.on("error", (e) => {
+        if (settled)
+          return;
+        settled = true;
+        if (timer)
+          clearTimeout(timer);
         resolve({ stdout: "", stderr: e.message, exitCode: 1 });
       });
     });
@@ -3931,18 +3957,52 @@ var ResticError = class extends Error {
 };
 
 // src/agent.ts
-var SERVER_URL = process.env["BACKUPOS_URL"] ?? "ws://localhost:3000/ws/agent";
-var TOKEN = process.env["BACKUPOS_TOKEN"] ?? "";
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`[agent] ${name} is required.`);
+    console.error(`[agent] If installed via systemd, ensure the unit at`);
+    console.error(`[agent]   /etc/systemd/system/backupos-agent.service`);
+    console.error(`[agent] contains: EnvironmentFile=/opt/backupos-agent/.env`);
+    console.error(`[agent] and that the .env file has ${name}=<value>.`);
+    console.error(`[agent] Run the install script in update mode to self-heal:`);
+    console.error(`[agent]   sudo bash /opt/backupos-agent/install.sh update`);
+    process.exit(1);
+  }
+  return v;
+}
+var SERVER_URL = requireEnv("BACKUPOS_URL");
+var TOKEN = requireEnv("BACKUPOS_TOKEN");
+function getHttpBase() {
+  const u = new URL(SERVER_URL);
+  const proto = u.protocol === "wss:" ? "https:" : "http:";
+  return `${proto}//${u.host}`;
+}
+async function ensureRepoInitialized(engine, repoId) {
+  try {
+    const base = getHttpBase();
+    const stateRes = await fetch(`${base}/internal/repository/${repoId}/state`, {
+      headers: { "x-agent-token": TOKEN },
+      signal: AbortSignal.timeout(1e4)
+    });
+    if (!stateRes.ok) throw new Error(`state check returned ${stateRes.status}`);
+    const { initializedAt } = await stateRes.json();
+    if (initializedAt !== null) return;
+    await engine.init();
+    await fetch(`${base}/internal/repository/${repoId}/initialized`, {
+      method: "POST",
+      headers: { "x-agent-token": TOKEN },
+      signal: AbortSignal.timeout(1e4)
+    });
+  } catch {
+    try {
+      await engine.init();
+    } catch {
+    }
+  }
+}
 var BINARY = process.env["RESTIC_BINARY_PATH"];
 var VERSION = "0.1.0";
-if (!TOKEN) {
-  console.error("[agent] BACKUPOS_TOKEN is required.");
-  console.error("[agent] If installed via systemd, ensure the unit has:");
-  console.error("[agent]   EnvironmentFile=/opt/backupos-agent/.env");
-  console.error("[agent] and that /opt/backupos-agent/.env contains BACKUPOS_TOKEN=<value>.");
-  console.error("[agent] Self-heal with: curl -fsSL $SERVER_URL/install.sh | sudo bash -s update");
-  process.exit(1);
-}
 function getIp() {
   const ifaces = os.networkInterfaces();
   for (const iface of Object.values(ifaces)) {
@@ -4029,10 +4089,7 @@ async function runBackup(jobId, config) {
       envVars: config.envVars ?? {},
       binaryPath: BINARY
     });
-    try {
-      await engine.init();
-    } catch {
-    }
+    await ensureRepoInitialized(engine, config.repoId);
     const result = await engine.backup({
       paths: config.paths,
       exclude: config.exclude,

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -183,6 +183,38 @@ void app.prepare().then(() => {
       return
     }
 
+    // Repository init-state — used by agent to check/set initializedAt (Fix A)
+    if (req.method === 'GET' && /^\/internal\/repository\/[^/]+\/state$/.test(parsed.pathname ?? '')) {
+      void (async () => {
+        const agentToken = req.headers['x-agent-token'] as string | undefined
+        if (!agentToken) { res.writeHead(401, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ error: 'missing x-agent-token' })); return }
+        const db = getDb()
+        const [agentRow] = await db.select().from(agents).where(eq(agents.publicKey, agentToken)).limit(1)
+        if (!agentRow) { res.writeHead(403, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ error: 'invalid token' })); return }
+        const repoId = (parsed.pathname ?? '').split('/')[3]!
+        const [repo] = await db.select({ initializedAt: repositories.initializedAt }).from(repositories).where(eq(repositories.id, repoId)).limit(1)
+        if (!repo) { res.writeHead(404, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ error: 'repository not found' })); return }
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ initializedAt: repo.initializedAt ? repo.initializedAt.getTime() : null }))
+      })()
+      return
+    }
+
+    if (req.method === 'POST' && /^\/internal\/repository\/[^/]+\/initialized$/.test(parsed.pathname ?? '')) {
+      void (async () => {
+        const agentToken = req.headers['x-agent-token'] as string | undefined
+        if (!agentToken) { res.writeHead(401, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ error: 'missing x-agent-token' })); return }
+        const db = getDb()
+        const [agentRow] = await db.select().from(agents).where(eq(agents.publicKey, agentToken)).limit(1)
+        if (!agentRow) { res.writeHead(403, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ error: 'invalid token' })); return }
+        const repoId = (parsed.pathname ?? '').split('/')[3]!
+        await db.update(repositories).set({ initializedAt: new Date() }).where(eq(repositories.id, repoId))
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: true }))
+      })()
+      return
+    }
+
     void handle(req, res, parsed)
   })
 

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -11,6 +11,7 @@ export interface MountConfig {
 }
 
 export interface BackupJobConfig {
+  repoId: string
   repoUrl: string
   repoPassword: string
   paths: string[]

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -20,6 +20,36 @@ function requireEnv(name: string): string {
 
 const SERVER_URL = requireEnv('BACKUPOS_URL')
 const TOKEN      = requireEnv('BACKUPOS_TOKEN')
+
+function getHttpBase(): string {
+  const u = new URL(SERVER_URL)
+  const proto = u.protocol === 'wss:' ? 'https:' : 'http:'
+  return `${proto}//${u.host}`
+}
+
+async function ensureRepoInitialized(engine: ResticEngine, repoId: string): Promise<void> {
+  try {
+    const base = getHttpBase()
+    const stateRes = await fetch(`${base}/internal/repository/${repoId}/state`, {
+      headers: { 'x-agent-token': TOKEN },
+      signal: AbortSignal.timeout(10_000),
+    })
+    if (!stateRes.ok) throw new Error(`state check returned ${stateRes.status}`)
+    const { initializedAt } = await stateRes.json() as { initializedAt: number | null }
+    if (initializedAt !== null) return
+
+    await engine.init()
+
+    await fetch(`${base}/internal/repository/${repoId}/initialized`, {
+      method: 'POST',
+      headers: { 'x-agent-token': TOKEN },
+      signal: AbortSignal.timeout(10_000),
+    })
+  } catch {
+    // Fallback: unconditional init (server unreachable or unknown repo)
+    try { await engine.init() } catch { /* already initialised */ }
+  }
+}
 const BINARY     = process.env['RESTIC_BINARY_PATH']
 const VERSION    = '0.1.0'
 
@@ -121,8 +151,7 @@ async function runBackup(jobId: string, config: BackupJobConfig): Promise<void> 
       binaryPath:    BINARY,
     })
 
-    // Idempotent — succeeds even if repo already exists
-    try { await engine.init() } catch { /* already initialised */ }
+    await ensureRepoInitialized(engine, config.repoId)
 
     const result = await engine.backup({
       paths:   config.paths,

--- a/packages/db/migrations/0022_repo_initialized_at.sql
+++ b/packages/db/migrations/0022_repo_initialized_at.sql
@@ -1,0 +1,3 @@
+ALTER TABLE repositories ADD COLUMN initialized_at INTEGER;
+-- Backfill: any repo that has been successfully checked is already initialized
+UPDATE repositories SET initialized_at = COALESCE(last_checked_at, created_at) WHERE last_check_status = 'ok';

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1745625600000,
       "tag": "0021_server_public_url",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1745712000000,
+      "tag": "0022_repo_initialized_at",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -38,6 +38,7 @@ export const repositories = sqliteTable('repositories', {
   resticPassword:  text('restic_password').notNull(), // encrypted with ENCRYPTION_KEY
   sizeBytes:       integer('size_bytes'),
   snapshotCount:   integer('snapshot_count'),
+  initializedAt:   integer('initialized_at',    { mode: 'timestamp' }),
   lastCheckedAt:   integer('last_checked_at',   { mode: 'timestamp' }),
   lastCheckStatus: text('last_check_status'),   // 'ok' | 'errors' | 'unknown'
   createdAt:          integer('created_at',           { mode: 'timestamp' }).notNull(),

--- a/packages/engine/src/restic.ts
+++ b/packages/engine/src/restic.ts
@@ -27,7 +27,7 @@ export class ResticEngine {
   }
 
   async init(): Promise<void> {
-    const result = await this.run(['init'])
+    const result = await this.run(['init'], undefined, 60_000)
     if (result.exitCode !== 0) {
       throw new ResticError('init', result)
     }
@@ -49,25 +49,29 @@ export class ResticEngine {
       if (opts.oneFileSystem) args.push('--one-file-system')
       if (opts.useVSS)        args.push('--use-fs-snapshot')
 
-      const result = await this.runStreaming(args, opts.onProgress
-        ? (line) => {
-            try {
-              const obj = JSON.parse(line) as { message_type: string }
-              if (obj.message_type === 'status') {
-                const s = obj as unknown as ResticStatusJson
-                opts.onProgress!({
-                  pct:              s.percent_done,
-                  bytesDone:        s.bytes_done,
-                  bytesTotal:       s.total_bytes,
-                  filesDone:        s.files_done,
-                  filesTotal:       s.total_files,
-                  secondsElapsed:   s.seconds_elapsed,
-                  secondsRemaining: s.seconds_remaining,
-                })
-              }
-            } catch { /* not JSON */ }
-          }
-        : undefined,
+      const result = await this.runStreaming(
+        args,
+        opts.onProgress
+          ? (line) => {
+              try {
+                const obj = JSON.parse(line) as { message_type: string }
+                if (obj.message_type === 'status') {
+                  const s = obj as unknown as ResticStatusJson
+                  opts.onProgress!({
+                    pct:              s.percent_done,
+                    bytesDone:        s.bytes_done,
+                    bytesTotal:       s.total_bytes,
+                    filesDone:        s.files_done,
+                    filesTotal:       s.total_files,
+                    secondsElapsed:   s.seconds_elapsed,
+                    secondsRemaining: s.seconds_remaining,
+                  })
+                }
+              } catch { /* not JSON */ }
+            }
+          : undefined,
+        undefined,
+        14_400_000,
       )
       if (result.exitCode !== 0) throw new ResticError('backup', result)
 
@@ -95,7 +99,7 @@ export class ResticEngine {
     const args = ['snapshots', '--json']
     if (tags) for (const t of tags) args.push('--tag', t)
 
-    const result = await this.run(args)
+    const result = await this.run(args, undefined, 30_000)
     if (result.exitCode !== 0) throw new ResticError('snapshots', result)
 
     const raw = JSON.parse(result.stdout) as ResticSnapshotJson[]
@@ -110,7 +114,7 @@ export class ResticEngine {
   }
 
   async ls(snapshotId: string): Promise<SnapshotFile[]> {
-    const result = await this.run(['ls', snapshotId, '--json'])
+    const result = await this.run(['ls', snapshotId, '--json'], undefined, 30_000)
     if (result.exitCode !== 0) throw new ResticError('ls', result)
 
     const files: SnapshotFile[] = []
@@ -134,7 +138,7 @@ export class ResticEngine {
     const args = ['check']
     if (readData) args.push('--read-data')
 
-    const result = await this.run(args)
+    const result = await this.run(args, undefined, 1_800_000)
     const ok = result.exitCode === 0
 
     const lines = result.stderr.split('\n').filter(Boolean)
@@ -154,7 +158,7 @@ export class ResticEngine {
     if (include) for (const p of include) args.push('--include', p)
 
     const before = Date.now()
-    const result = await this.run(args)
+    const result = await this.run(args, undefined, 14_400_000)
     if (result.exitCode !== 0) throw new ResticError('restore', result)
 
     const match = result.stderr.match(/(\d+) files? restored/)
@@ -176,7 +180,7 @@ export class ResticEngine {
     if (policy.keepTags)    for (const t of policy.keepTags) args.push('--keep-tag', t)
     if (prune) args.push('--prune')
 
-    const result = await this.run(args)
+    const result = await this.run(args, undefined, 1_800_000)
     if (result.exitCode !== 0) throw new ResticError('forget', result)
 
     const raw = JSON.parse(result.stdout) as ResticForgetJson[]
@@ -188,12 +192,12 @@ export class ResticEngine {
   }
 
   async prune(): Promise<void> {
-    const result = await this.run(['prune'])
+    const result = await this.run(['prune'], undefined, 1_800_000)
     if (result.exitCode !== 0) throw new ResticError('prune', result)
   }
 
   async stats(): Promise<RepoStats> {
-    const result = await this.run(['stats', '--json'])
+    const result = await this.run(['stats', '--json'], undefined, 30_000)
     if (result.exitCode !== 0) throw new ResticError('stats', result)
 
     const raw = JSON.parse(result.stdout) as ResticStatsJson
@@ -216,32 +220,47 @@ export class ResticEngine {
   }
 
   async unmount(mountPoint: string): Promise<void> {
-    const result = await this.run(['umount', mountPoint])
+    const result = await this.run(['umount', mountPoint], undefined, 30_000)
     if (result.exitCode !== 0) throw new ResticError('umount', result)
   }
 
   // ── Private ──────────────────────────────────────────────────────────────
 
-  // Uses spawn (never shell — no injection possible)
   private run(
     args: string[],
     extraEnv?: Record<string, string>,
+    timeoutMs?: number,
   ): Promise<ExecResult> {
-    return this.runStreaming(args, undefined, extraEnv)
+    return this.runStreaming(args, undefined, extraEnv, timeoutMs)
   }
 
-  // Like run() but calls onLine for each stdout line as it arrives
   private runStreaming(
     args: string[],
     onLine?: (line: string) => void,
     extraEnv?: Record<string, string>,
+    timeoutMs?: number,
   ): Promise<ExecResult> {
-    return new Promise((resolve) => {
-      const proc = spawn(this.binary, args, { env: this.buildEnv(extraEnv) })
+    return new Promise((resolve, reject) => {
+      const proc = spawn(this.binary, args, {
+        env:   this.buildEnv(extraEnv),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
 
+      let settled = false
       const outLines: string[] = []
       const err: Buffer[] = []
       let partial = ''
+
+      let timer: ReturnType<typeof setTimeout> | undefined
+      if (timeoutMs) {
+        timer = setTimeout(() => {
+          if (settled) return
+          settled = true
+          proc.kill('SIGTERM')
+          setTimeout(() => { if (!proc.killed) proc.kill('SIGKILL') }, 10_000)
+          reject(new Error(`restic timed out after ${timeoutMs}ms during ${args[0] ?? 'unknown'}`))
+        }, timeoutMs)
+      }
 
       proc.stdout.on('data', (chunk: Buffer) => {
         const text = partial + chunk.toString('utf8')
@@ -256,6 +275,9 @@ export class ResticEngine {
       proc.stderr.on('data', (chunk: Buffer) => err.push(chunk))
 
       proc.on('close', (code) => {
+        if (settled) return
+        settled = true
+        if (timer) clearTimeout(timer)
         if (partial) {
           outLines.push(partial)
           if (onLine) onLine(partial)
@@ -268,6 +290,9 @@ export class ResticEngine {
       })
 
       proc.on('error', (e) => {
+        if (settled) return
+        settled = true
+        if (timer) clearTimeout(timer)
         resolve({ stdout: '', stderr: e.message, exitCode: 1 })
       })
     })


### PR DESCRIPTION
## Summary

- **Fix A** — agent now fetches `initializedAt` from `/internal/repository/:id/state` before running `restic init`; only inits if null, then POSTs `/internal/repository/:id/initialized`. Eliminates the 6-minute hang on already-initialised repos.
- **Fix B** — restic spawned with `stdio: ['ignore', 'pipe', 'pipe']` so stdin is `/dev/null`; restic can no longer block waiting for a passphrase on stdin.
- **Fix D** — `ResticEngine.runStreaming` accepts a `timeoutMs` parameter; all commands have appropriate timeouts (init 60s, backup 4h, check/forget/prune 30m, restore 4h, others 30s). Uses SIGTERM → 10s → SIGKILL pattern.
- `repoId` added to `BackupJobConfig` protocol and populated at all three dispatch sites (`jobs.ts` triggerJob, retryRun, `scheduler.ts`).
- DB migration `0022` adds `initialized_at` to `repositories` with a backfill for already-healthy repos.

## Test plan

- [ ] Deploy to Dockee01, run a backup against a repo that already has `initialized_at` set — confirm no `restic init` call in logs
- [ ] Delete `initialized_at` for a repo row, trigger backup — confirm init runs once, row gets stamped
- [ ] Kill restic mid-backup (`kill -STOP $(pgrep restic)`) — confirm backup fails within timeout with a clear error, not a hang
- [ ] Verify `restic backup` no longer prompts for password (stdin closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)