### PR TITLE
fix(scheduler): honor explicit next_run_at triggers, not only cron

### DIFF
--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -124,61 +124,13 @@ async function resolveBandwidthLimitKbps(db: ReturnType<typeof getDb>, jobId: st
 }
 
 export async function triggerJob(id: string): Promise<void> {
-  const db  = getDb()
-  const now = new Date()
+  const db = getDb()
 
   const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, id)).limit(1)
   if (!job || !job.repositoryId) { redirect(`/jobs/${id}`) }
 
-  const bandwidthLimitKbps = await resolveBandwidthLimitKbps(db, id)
-  const runId = crypto.randomUUID()
-
-  await db.insert(backupRuns).values({
-    id:           runId,
-    jobId:        id,
-    repositoryId: job.repositoryId,
-    agentId:      job.agentId ?? null,
-    status:       'running',
-    trigger:      'manual',
-    startedAt:    now,
-    bandwidthLimitKbps,
-  })
-  await db.update(backupJobs).set({ lastRunAt: now }).where(eq(backupJobs.id, id))
-
-  if (job.agentId) {
-    const [repo] = await db.select().from(repositories)
-      .where(eq(repositories.id, job.repositoryId!)).limit(1)
-
-    if (repo) {
-      const repoConfig = JSON.parse(decryptField(repo.config)) as { repositoryUrl: string; password: string; envVars?: Record<string, string> }
-      const srcConfig  = JSON.parse(job.sourceConfig) as { paths?: string[]; volumes?: string[]; exclude?: string[] }
-      const tags       = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${id}`]
-
-      const paths = job.sourceType === 'docker_volume'
-        ? (srcConfig.volumes ?? []).map(v => `/var/lib/docker/volumes/${v}/_data`)
-        : (srcConfig.paths ?? [])
-
-      const result = await dispatchToAgent(job.agentId, {
-        type:   'run_backup',
-        jobId:  id,
-        config: {
-          repoId:       job.repositoryId!,
-          repoUrl:      repoConfig.repositoryUrl,
-          repoPassword: repoConfig.password,
-          paths,
-          exclude:      srcConfig.exclude,
-          tags,
-          envVars:      repoConfig.envVars,
-        },
-      })
-      if (!result.ok) {
-        console.error('[triggerJob] dispatch failed reason=%s knownIds=%j', result.reason, result.knownIds)
-      }
-    }
-  } else {
-    // No agent assigned — run locally in a detached promise
-    void import('@/lib/scheduler').then(({ executeRun }) => executeRun(id, runId))
-  }
+  // Set nextRunAt to now — the scheduler trigger tick (≤5s) picks it up and dispatches
+  await db.update(backupJobs).set({ nextRunAt: new Date() }).where(eq(backupJobs.id, id))
 
   redirect(`/jobs/${id}`)
 }

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -1,6 +1,6 @@
 import * as cron from 'node-cron'
 import { parseExpression } from 'cron-parser'
-import { getDb, backupJobs, backupRuns, repositories, agents, backupDefaults, eq, and, lt } from '@backupos/db'
+import { getDb, backupJobs, backupRuns, repositories, agents, backupDefaults, eq, and, lt, lte, isNotNull } from '@backupos/db'
 import { decryptField } from './repo-crypto'
 import { ResticEngine } from '@backupos/engine'
 import { sendAlert } from './alerts'
@@ -44,10 +44,14 @@ export async function initScheduler(): Promise<void> {
       continue
     }
 
-    cron.schedule(job.schedule, () => { void runJob(db, job) }, { timezone: 'UTC' })
+    cron.schedule(job.schedule, () => { void runJob(db, job, 'cron') }, { timezone: 'UTC' })
     void stampNextRun(db, job.id, job.schedule)
     console.log(`[scheduler] Scheduled "${job.name}" (${job.schedule})`)
   }
+
+  // Trigger-driven tick: fire any job with nextRunAt <= now (Run Now, SQL trigger, etc.)
+  setInterval(() => { void triggerTick(db) }, 5_000)
+  console.log('[scheduler] Trigger tick active (5s interval)')
 
   // Check for disconnected agents every 5 minutes
   cron.schedule('*/5 * * * *', () => { void checkAgents(db) }, { timezone: 'UTC' })
@@ -85,7 +89,7 @@ export async function executeRun(jobId: string, runId: string): Promise<void> {
   await runJobCore(db, job, runId)
 }
 
-async function dispatchToAgent(db: Db, job: Job): Promise<boolean> {
+async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Promise<boolean> {
   if (!job.agentId || !job.repositoryId) return false
 
   const [repo] = await db.select().from(repositories)
@@ -102,7 +106,7 @@ async function dispatchToAgent(db: Db, job: Job): Promise<boolean> {
 
   await db.insert(backupRuns).values({
     id: runId, jobId: job.id, repositoryId: job.repositoryId,
-    agentId: job.agentId, status: 'running', trigger: 'scheduled', startedAt: now,
+    agentId: job.agentId, status: 'running', trigger, startedAt: now,
   })
 
   await db.update(backupJobs).set({ lastRunAt: now }).where(eq(backupJobs.id, job.id))
@@ -134,16 +138,18 @@ async function dispatchToAgent(db: Db, job: Job): Promise<boolean> {
     return false
   }
 
+  // Reset nextRunAt so the trigger tick doesn't re-fire this job
+  await stampNextRun(db, job.id, job.schedule)
   console.log(`[scheduler] Dispatched job "${job.name}" to agent ${job.agentId}`)
   return true
 }
 
-async function runJob(db: Db, job: Job): Promise<void> {
+async function runJob(db: Db, job: Job, trigger: 'cron' | 'manual'): Promise<void> {
   if (!job.repositoryId) return
 
   // Prefer agent execution when one is assigned and currently connected
   if (job.agentId && connectedAgentIds().includes(job.agentId)) {
-    const dispatched = await dispatchToAgent(db, job)
+    const dispatched = await dispatchToAgent(db, job, trigger)
     if (dispatched) return
   }
 
@@ -154,10 +160,34 @@ async function runJob(db: Db, job: Job): Promise<void> {
     repositoryId: job.repositoryId,
     agentId:      job.agentId ?? null,
     status:       'running',
-    trigger:      'scheduled',
+    trigger,
     startedAt:    new Date(),
   })
   await runJobCore(db, job, runId)
+}
+
+async function triggerTick(db: Db): Promise<void> {
+  const now = new Date()
+  const jobs = await db.select().from(backupJobs).where(
+    and(
+      eq(backupJobs.enabled, true),
+      isNotNull(backupJobs.nextRunAt),
+      lte(backupJobs.nextRunAt, now),
+    )
+  ).all()
+
+  for (const job of jobs) {
+    const [active] = await db.select({ id: backupRuns.id }).from(backupRuns).where(
+      and(eq(backupRuns.jobId, job.id), eq(backupRuns.status, 'running'))
+    ).limit(1).all()
+    if (active) continue
+
+    // Reset nextRunAt before dispatching so the next tick doesn't re-fire
+    const next = nextRunDate(job.schedule)
+    await db.update(backupJobs).set({ nextRunAt: next ?? null }).where(eq(backupJobs.id, job.id))
+
+    await runJob(db, job, 'manual')
+  }
 }
 
 function fmtBytes(b: number): string {


### PR DESCRIPTION
## Summary

- Add a 5-second `triggerTick` that queries for any enabled job with `next_run_at <= now`, checks for an active run (duplicate guard), resets `next_run_at` to the next cron time, then fires via `runJob`
- `dispatchToAgent` now calls `stampNextRun` after a successful agent dispatch — previously left `next_run_at` stale which would have caused the tick to re-fire the job
- `triggerJob` server action (Run Now button) simplified to `UPDATE backup_jobs SET next_run_at = now WHERE id = ?` — the tick picks it up within 5 seconds via the same dispatch path as cron
- All trigger column values corrected: `'cron'` for scheduler-fired runs, `'manual'` for tick-fired runs; original code used `'scheduled'` which isn't a valid schema value

## Test plan

- [ ] `UPDATE backup_jobs SET next_run_at = datetime('now') WHERE name = '...'` — run row appears within 10s with `trigger='manual'`
- [ ] After pickup, `next_run_at` is reset to next cron time (not left in the past)
- [ ] UI Run Now button still dispatches and completes end-to-end
- [ ] Second SQL update while a run is active → no duplicate run spawned
- [ ] Cron-fired job still works — no regression in scheduled execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)