### PR TITLE
fix(dispatch): always use decryptField(repo.resticPassword) for repoPassword

### DIFF
--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -184,16 +184,18 @@ export async function retryRun(jobId: string): Promise<void> {
     const [repo] = await db.select().from(repositories)
       .where(eq(repositories.id, job.repositoryId!)).limit(1)
     if (repo) {
-      const repoConfig = JSON.parse(decryptField(repo.config)) as { repositoryUrl: string; password: string; envVars?: Record<string, string> }
-      const srcConfig  = JSON.parse(job.sourceConfig) as { paths?: string[]; volumes?: string[]; exclude?: string[] }
-      const tags       = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${jobId}`]
+      const cfg       = JSON.parse(decryptField(repo.config)) as Record<string, string>
+      const password  = decryptField(repo.resticPassword)
+      if (!password) throw new Error(`dispatch: failed to decrypt repo password for repository ${repo.id}`)
+      const srcConfig = JSON.parse(job.sourceConfig) as { paths?: string[]; volumes?: string[]; exclude?: string[] }
+      const tags      = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${jobId}`]
       const paths = job.sourceType === 'docker_volume'
         ? (srcConfig.volumes ?? []).map(v => `/var/lib/docker/volumes/${v}/_data`)
         : (srcConfig.paths ?? [])
       const result = await dispatchToAgent(job.agentId, {
         type:   'run_backup',
         jobId,
-        config: { repoId: job.repositoryId!, repoUrl: repoConfig.repositoryUrl, repoPassword: repoConfig.password, paths, exclude: srcConfig.exclude, tags, envVars: repoConfig.envVars },
+        config: { repoId: job.repositoryId!, repoUrl: cfg['repositoryUrl'] ?? '', repoPassword: password, paths, exclude: srcConfig.exclude, tags, envVars: cfg },
       })
       if (!result.ok) {
         console.error('[retryRun] dispatch failed reason=%s knownIds=%j', result.reason, result.knownIds)

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -97,6 +97,8 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
   if (!repo) return false
 
   const cfg       = JSON.parse(decryptField(repo.config)) as Record<string, string>
+  const password  = decryptField(repo.resticPassword)
+  if (!password) throw new Error(`dispatch: failed to decrypt repo password for repository ${repo.id}`)
   const srcConfig = JSON.parse(job.sourceConfig) as SourceConfig
   const paths     = resolveBackupPaths(job.sourceType, srcConfig)
   if (paths.length === 0) return false
@@ -120,7 +122,7 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
     config: {
       repoId:       job.repositoryId ?? '',
       repoUrl:      cfg['repositoryUrl'] ?? '',
-      repoPassword: decryptField(repo.resticPassword),
+      repoPassword: password,
       paths,
       exclude:  srcConfig.exclude,
       tags,

--- a/apps/web/public/agent/bundle.js
+++ b/apps/web/public/agent/bundle.js
@@ -4083,6 +4083,9 @@ async function runBackup(jobId, config) {
   send({ type: "backup_start", jobId, config });
   console.log(`[agent] Starting backup for job ${jobId} \u2014 paths: ${config.paths.join(", ")}`);
   try {
+    if (!config.repoPassword) {
+      throw new Error("runBackup: repoPassword is missing from dispatch payload. Server-side dispatch is broken \u2014 check that decryptField(repo.resticPassword) is being included in the WS message.");
+    }
     const engine = new ResticEngine({
       repositoryUrl: config.repoUrl,
       password: config.repoPassword,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -144,6 +144,10 @@ async function runBackup(jobId: string, config: BackupJobConfig): Promise<void> 
   console.log(`[agent] Starting backup for job ${jobId} — paths: ${config.paths.join(', ')}`)
 
   try {
+    if (!config.repoPassword) {
+      throw new Error('runBackup: repoPassword is missing from dispatch payload. Server-side dispatch is broken — check that decryptField(repo.resticPassword) is being included in the WS message.')
+    }
+
     const engine = new ResticEngine({
       repositoryUrl: config.repoUrl,
       password:      config.repoPassword,


### PR DESCRIPTION
## Summary

- **Root cause**: `retryRun` in `jobs.ts` read the repo password as `repoConfig.password` after `JSON.parse(decryptField(repo.config))`. The `password` key does not exist in `repo.config` JSON — it lives in the separate `repo.restic_password` column. Result: `repoPassword: undefined` in every `retryRun` dispatch, silently dropped by Node spawn, `RESTIC_PASSWORD` absent from restic env.
- **`scheduler.ts` `dispatchToAgent`** already used `decryptField(repo.resticPassword)` correctly — this was confirmed by audit. A server-side guard is added there too for defence in depth.
- **Agent bundle rebuilt** to include the pre-spawn guard.

## Files changed (4)

| File | What changed |
|------|-------------|
| `apps/web/app/actions/jobs.ts` | `retryRun`: `repoConfig.password` → `decryptField(repo.resticPassword)` + server guard |
| `apps/web/lib/scheduler.ts` | `dispatchToAgent`: server guard added (logic was already correct) |
| `packages/agent/src/agent.ts` | pre-spawn guard: throws with actionable message if `repoPassword` missing |
| `apps/web/public/agent/bundle.js` | rebuilt with agent guard |

## Answers to the spec's verification questions

- **scheduler.ts needed a fix?** No — the password lookup was already `decryptField(repo.resticPassword)`. Only the guard was added.
- **Agent-side guard in place?** Yes — throws before `ResticEngine` construction.
- **Server-side guard in place?** Yes — in both `jobs.ts` and `scheduler.ts`.

## Test plan

- [ ] SQL trigger: `UPDATE backup_jobs SET next_run_at = datetime('now') WHERE ...` → run appears within 10s
- [ ] While running: `PID=$(pgrep -f "restic backup"); sudo cat /proc/$PID/environ | tr '\0' '\n' | grep RESTIC_` — must show `RESTIC_PASSWORD=<value>`
- [ ] Run completes with `status=success`, non-null `files_new`, `total_size`, `duration`
- [ ] Retry button on a completed run also dispatches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)