### PR TITLE
feat(agent): Item 7 — version handshake

### DIFF
--- a/apps/web/app/(dashboard)/agents/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/agents/[id]/page.tsx
@@ -144,12 +144,14 @@ export default async function AgentDetailPage({ params }: { params: Promise<{ id
       )}
 
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16, marginBottom: 20 }}>
-        <StatCard label="Platform"  value={`${agent.platform ?? '—'} / ${agent.arch ?? '—'}`} />
-        <StatCard label="Hostname"  value={agent.hostname ?? '—'} />
-        <StatCard label="IP"        value={agent.ip ?? '—'} />
-        <StatCard label="Version"   value={agent.agentVersion ?? '—'} />
-        <StatCard label="VSS"       value={agent.vssAvailable ? 'Available' : agent.platform === 'windows' ? 'Unavailable' : 'N/A'} />
-        <StatCard label="Last seen" value={agent.lastSeenAt?.toISOString().slice(0, 16).replace('T', ' ') ?? '—'} />
+        <StatCard label="Platform"         value={`${agent.platform ?? '—'} / ${agent.arch ?? '—'}`} />
+        <StatCard label="Hostname"         value={agent.hostname ?? '—'} />
+        <StatCard label="IP"               value={agent.ip ?? '—'} />
+        <StatCard label="Agent version"    value={agent.agentVersion ?? '—'} />
+        <StatCard label="Restic version"   value={agent.resticVersion ?? '—'} />
+        <StatCard label="Protocol"         value={agent.protocolVersion ?? '—'} />
+        <StatCard label="VSS"              value={agent.vssAvailable ? 'Available' : agent.platform === 'windows' ? 'Unavailable' : 'N/A'} />
+        <StatCard label="Last seen"        value={agent.lastSeenAt?.toISOString().slice(0, 16).replace('T', ' ') ?? '—'} />
       </div>
 
       {/* Capabilities */}

--- a/apps/web/public/agent/bundle.js
+++ b/apps/web/public/agent/bundle.js
@@ -2228,7 +2228,7 @@ var require_websocket = __commonJS({
     var http = require("http");
     var net = require("net");
     var tls = require("tls");
-    var { randomBytes, createHash } = require("crypto");
+    var { randomBytes, createHash: createHash2 } = require("crypto");
     var { Duplex, Readable } = require("stream");
     var { URL: URL2 } = require("url");
     var PerMessageDeflate2 = require_permessage_deflate();
@@ -2888,7 +2888,7 @@ var require_websocket = __commonJS({
           abortHandshake(websocket, socket, "Invalid Upgrade header");
           return;
         }
-        const digest = createHash("sha1").update(key + GUID).digest("base64");
+        const digest = createHash2("sha1").update(key + GUID).digest("base64");
         if (res.headers["sec-websocket-accept"] !== digest) {
           abortHandshake(websocket, socket, "Invalid Sec-WebSocket-Accept header");
           return;
@@ -3255,7 +3255,7 @@ var require_websocket_server = __commonJS({
     var EventEmitter = require("events");
     var http = require("http");
     var { Duplex } = require("stream");
-    var { createHash } = require("crypto");
+    var { createHash: createHash2 } = require("crypto");
     var extension2 = require_extension();
     var PerMessageDeflate2 = require_permessage_deflate();
     var subprotocol2 = require_subprotocol();
@@ -3556,7 +3556,7 @@ var require_websocket_server = __commonJS({
           );
         }
         if (this._state > RUNNING) return abortHandshake(socket, 503);
-        const digest = createHash("sha1").update(key + GUID).digest("base64");
+        const digest = createHash2("sha1").update(key + GUID).digest("base64");
         const headers = [
           "HTTP/1.1 101 Switching Protocols",
           "Upgrade: websocket",
@@ -3654,6 +3654,9 @@ var wrapper_default = import_websocket.default;
 
 // src/agent.ts
 var os = __toESM(require("os"));
+var import_crypto = require("crypto");
+var import_fs = require("fs");
+var import_child_process2 = require("child_process");
 
 // ../engine/dist/restic.js
 var import_child_process = require("child_process");
@@ -4006,6 +4009,42 @@ function getHttpBase() {
   const proto = u.protocol === "wss:" ? "https:" : "http:";
   return `${proto}//${u.host}`;
 }
+function computeSelfHash() {
+  try {
+    const buf = (0, import_fs.readFileSync)(process.argv[1]);
+    return (0, import_crypto.createHash)("sha256").update(buf).digest("hex");
+  } catch {
+    return "";
+  }
+}
+var SELF_HASH = computeSelfHash();
+async function selfUpdate() {
+  const scriptPath = process.argv[1];
+  if (!scriptPath) {
+    console.error("[agent] selfUpdate: cannot determine script path");
+    return;
+  }
+  try {
+    const base = getHttpBase();
+    const res = await fetch(`${base}/agent/bundle.js`, {
+      signal: AbortSignal.timeout(3e4)
+    });
+    if (!res.ok) throw new Error(`bundle download failed: ${res.status}`);
+    const buf = Buffer.from(await res.arrayBuffer());
+    const tmp = `${scriptPath}.tmp`;
+    (0, import_fs.writeFileSync)(tmp, buf);
+    (0, import_fs.renameSync)(tmp, scriptPath);
+    console.log("[agent] Bundle updated \u2014 restarting \u2026");
+    (0, import_child_process2.spawn)(process.execPath, process.argv.slice(1), {
+      env: process.env,
+      detached: true,
+      stdio: "inherit"
+    }).unref();
+    process.exit(0);
+  } catch (err) {
+    console.error("[agent] selfUpdate failed:", err instanceof Error ? err.message : err);
+  }
+}
 async function ensureRepoInitialized(engine, repoId) {
   try {
     const base = getHttpBase();
@@ -4031,6 +4070,34 @@ async function ensureRepoInitialized(engine, repoId) {
 }
 var BINARY = process.env["RESTIC_BINARY_PATH"];
 var VERSION = "0.1.0";
+var PROTOCOL_VERSION = "1";
+async function queryResticVersion() {
+  return new Promise((resolve) => {
+    const proc = (0, import_child_process2.spawn)(BINARY ?? "restic", ["version"], { stdio: ["ignore", "pipe", "ignore"] });
+    let out = "";
+    proc.stdout?.on("data", (d) => {
+      out += d.toString();
+    });
+    proc.on("close", () => {
+      const m = out.match(/^restic\s+(\S+)/m);
+      resolve(m ? m[1] : "");
+    });
+    proc.on("error", () => resolve(""));
+    setTimeout(() => {
+      proc.kill();
+      resolve("");
+    }, 1e4);
+  });
+}
+function buildCapabilities() {
+  const caps = ["backup", "restore"];
+  if (process.platform === "win32") caps.push("vss");
+  return caps;
+}
+var RESTIC_VERSION = "";
+void queryResticVersion().then((v) => {
+  RESTIC_VERSION = v;
+});
 function getIp() {
   const ifaces = os.networkInterfaces();
   for (const iface of Object.values(ifaces)) {
@@ -4088,6 +4155,17 @@ async function handleMessage(raw) {
   if (msg.type === "welcome") {
     console.log(`[agent] Authenticated \u2014 agent ID: ${msg.agentId}, server: ${msg.serverVersion}`);
     backoffMs = 1e3;
+    if (msg.bundleHash && SELF_HASH) {
+      if (msg.bundleHash !== SELF_HASH) {
+        console.log(`[agent] Bundle hash mismatch (server: ${msg.bundleHash.slice(0, 8)} local: ${SELF_HASH.slice(0, 8)}) \u2014 self-updating`);
+        void selfUpdate();
+      } else {
+        console.log(`[agent] Bundle hash OK: ${msg.bundleHash.slice(0, 8)}`);
+      }
+    }
+  } else if (msg.type === "force_update") {
+    console.log("[agent] Force-update requested by server \u2014 self-updating");
+    void selfUpdate();
   } else if (msg.type === "pong") {
   } else if (msg.type === "run_backup") {
     void runBackup(msg.jobId, msg.config);
@@ -4191,6 +4269,9 @@ function connect() {
       hostname: os.hostname(),
       ip: getIp(),
       agentVersion: VERSION,
+      protocolVersion: PROTOCOL_VERSION,
+      resticVersion: RESTIC_VERSION || void 0,
+      capabilities: buildCapabilities(),
       platform: process.platform === "win32" ? "windows" : "linux",
       osInfo: {
         os: process.platform,

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -260,7 +260,10 @@ void app.prepare().then(() => {
             ...(msg.hostname     ? { hostname:     msg.hostname }           : {}),
             ...(msg.ip           ? { ip:           msg.ip }                 : {}),
             ...(msg.platform     ? { platform:     msg.platform }           : {}),
-            ...(msg.agentVersion ? { agentVersion: msg.agentVersion }       : {}),
+            ...(msg.agentVersion    ? { agentVersion:    msg.agentVersion }                      : {}),
+            ...(msg.protocolVersion ? { protocolVersion: msg.protocolVersion }                  : {}),
+            ...(msg.resticVersion   ? { resticVersion:   msg.resticVersion }                    : {}),
+            ...(msg.capabilities    ? { capabilities:    JSON.stringify(msg.capabilities) }     : {}),
             ...(osInfo?.arch     ? { arch:         osInfo.arch }            : {}),
             ...(osInfo           ? { osInfo:       JSON.stringify(osInfo) } : {}),
           }).where(eq(agents.id, agentId))

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -48,7 +48,7 @@ export interface OsInfo {
 }
 
 export type AgentMessage =
-  | { type: 'hello'; token: string; hostname: string; ip: string; osInfo: OsInfo; agentVersion: string; platform: 'linux' | 'windows' }
+  | { type: 'hello'; token: string; hostname: string; ip: string; osInfo: OsInfo; agentVersion: string; platform: 'linux' | 'windows'; protocolVersion: string; resticVersion?: string; capabilities?: string[] }
   | { type: 'ping' }
   | { type: 'metrics'; metrics: AgentMetrics }
   | { type: 'backup_start'; jobId: string; config: BackupJobConfig }
@@ -78,3 +78,4 @@ export type ServerMessage =
   | { type: 'list_resources'; requestId: string }
   | { type: 'test_repo'; requestId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
   | { type: 'test_mount'; requestId: string; mountConfig: MountConfig }
+  | { type: 'force_update' }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,5 +1,8 @@
 import WebSocket from 'ws'
 import * as os from 'os'
+import { createHash } from 'crypto'
+import { readFileSync, writeFileSync, renameSync } from 'fs'
+import { spawn as spawnProcess } from 'child_process'
 import { ResticEngine } from '@backupos/engine'
 import type { AgentMessage, ServerMessage, BackupJobConfig } from '@backupos/agent-protocol'
 
@@ -27,6 +30,39 @@ function getHttpBase(): string {
   return `${proto}//${u.host}`
 }
 
+function computeSelfHash(): string {
+  try {
+    const buf = readFileSync(process.argv[1]!)
+    return createHash('sha256').update(buf).digest('hex')
+  } catch { return '' }
+}
+const SELF_HASH = computeSelfHash()
+
+async function selfUpdate(): Promise<void> {
+  const scriptPath = process.argv[1]
+  if (!scriptPath) { console.error('[agent] selfUpdate: cannot determine script path'); return }
+  try {
+    const base = getHttpBase()
+    const res = await fetch(`${base}/agent/bundle.js`, {
+      signal: AbortSignal.timeout(30_000),
+    })
+    if (!res.ok) throw new Error(`bundle download failed: ${res.status}`)
+    const buf = Buffer.from(await res.arrayBuffer())
+    const tmp = `${scriptPath}.tmp`
+    writeFileSync(tmp, buf)
+    renameSync(tmp, scriptPath)
+    console.log('[agent] Bundle updated — restarting …')
+    spawnProcess(process.execPath, process.argv.slice(1), {
+      env:      process.env,
+      detached: true,
+      stdio:    'inherit',
+    }).unref()
+    process.exit(0)
+  } catch (err) {
+    console.error('[agent] selfUpdate failed:', err instanceof Error ? err.message : err)
+  }
+}
+
 async function ensureRepoInitialized(engine: ResticEngine, repoId: string): Promise<void> {
   try {
     const base = getHttpBase()
@@ -50,8 +86,32 @@ async function ensureRepoInitialized(engine: ResticEngine, repoId: string): Prom
     try { await engine.init() } catch { /* already initialised */ }
   }
 }
-const BINARY     = process.env['RESTIC_BINARY_PATH']
-const VERSION    = '0.1.0'
+const BINARY          = process.env['RESTIC_BINARY_PATH']
+const VERSION         = '0.1.0'
+const PROTOCOL_VERSION = '1'
+
+async function queryResticVersion(): Promise<string> {
+  return new Promise((resolve) => {
+    const proc = spawnProcess(BINARY ?? 'restic', ['version'], { stdio: ['ignore', 'pipe', 'ignore'] })
+    let out = ''
+    proc.stdout?.on('data', (d: Buffer) => { out += d.toString() })
+    proc.on('close', () => {
+      const m = out.match(/^restic\s+(\S+)/m)
+      resolve(m ? m[1]! : '')
+    })
+    proc.on('error', () => resolve(''))
+    setTimeout(() => { proc.kill(); resolve('') }, 10_000)
+  })
+}
+
+function buildCapabilities(): string[] {
+  const caps: string[] = ['backup', 'restore']
+  if (process.platform === 'win32') caps.push('vss')
+  return caps
+}
+
+let RESTIC_VERSION = ''
+void queryResticVersion().then(v => { RESTIC_VERSION = v })
 
 function getIp(): string {
   const ifaces = os.networkInterfaces()
@@ -115,6 +175,18 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
   if (msg.type === 'welcome') {
     console.log(`[agent] Authenticated — agent ID: ${msg.agentId}, server: ${msg.serverVersion}`)
     backoffMs = 1_000
+    if (msg.bundleHash && SELF_HASH) {
+      if (msg.bundleHash !== SELF_HASH) {
+        console.log(`[agent] Bundle hash mismatch (server: ${msg.bundleHash.slice(0, 8)} local: ${SELF_HASH.slice(0, 8)}) — self-updating`)
+        void selfUpdate()
+      } else {
+        console.log(`[agent] Bundle hash OK: ${msg.bundleHash.slice(0, 8)}`)
+      }
+    }
+
+  } else if (msg.type === 'force_update') {
+    console.log('[agent] Force-update requested by server — self-updating')
+    void selfUpdate()
 
   } else if (msg.type === 'pong') {
     // heartbeat acknowledged
@@ -237,12 +309,15 @@ function connect(): void {
   ws.on('open', () => {
     console.log('[agent] WebSocket open — sending hello')
     const hello: AgentMessage = {
-      type:         'hello',
-      token:        TOKEN,
-      hostname:     os.hostname(),
-      ip:           getIp(),
-      agentVersion: VERSION,
-      platform:     process.platform === 'win32' ? 'windows' : 'linux',
+      type:            'hello',
+      token:           TOKEN,
+      hostname:        os.hostname(),
+      ip:              getIp(),
+      agentVersion:    VERSION,
+      protocolVersion: PROTOCOL_VERSION,
+      resticVersion:   RESTIC_VERSION || undefined,
+      capabilities:    buildCapabilities(),
+      platform:        process.platform === 'win32' ? 'windows' : 'linux',
       osInfo: {
         os:     process.platform,
         arch:   process.arch,

--- a/packages/db/migrations/0024_agent_version_fields.sql
+++ b/packages/db/migrations/0024_agent_version_fields.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agents ADD COLUMN protocol_version TEXT;
+ALTER TABLE agents ADD COLUMN restic_version TEXT;
+ALTER TABLE agents ADD COLUMN capabilities TEXT;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1745798400000,
       "tag": "0023_timestamps_to_ms",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1745884800000,
+      "tag": "0024_agent_version_fields",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -17,6 +17,9 @@ export const agents = sqliteTable('agents', {
   lastSeenAt:   integer('last_seen_at',   { mode: 'timestamp_ms' }),
   enrolledAt:   integer('enrolled_at',    { mode: 'timestamp_ms' }).notNull(),
   publicKey:    text('public_key').notNull(), // Ed25519
+  protocolVersion: text('protocol_version'),
+  resticVersion:   text('restic_version'),
+  capabilities:    text('capabilities'),       // JSON array of strings
   updateChannel:     text('update_channel').default('stable'),   // 'stable' | 'beta' | 'pinned'
   hypervisorDriver:  integer('hypervisor_driver',  { mode: 'boolean' }),
   appHooksAvailable: integer('app_hooks_available', { mode: 'boolean' }),


### PR DESCRIPTION
## Summary
- Agent sends `protocolVersion`, `resticVersion`, and `capabilities` in the `hello` message
- Server stores all three to new DB columns via migration 0024
- Agent detail page now shows Restic version and Protocol fields
- Added `force_update` to `ServerMessage` protocol type
- Agent compares its own SHA-256 hash against server `bundleHash` on welcome and self-updates if different

## Test plan
- [ ] Deploy and restart agent on Dockee01
- [ ] `SELECT protocol_version, restic_version, capabilities FROM agents WHERE name = 'Dockee01'` → all three populated
- [ ] Agent detail page shows Restic version (e.g. `0.17.x`) and Protocol (`1`)
- [ ] Server log on connect shows `[agent] Bundle hash OK: <8chars>` or triggers self-update if bundle changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)