### PR TITLE
feat(agent): Item 5 — per-run heartbeats every 5s

### DIFF
--- a/apps/web/app/(dashboard)/jobs/[id]/runs/[runId]/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/[id]/runs/[runId]/page.tsx
@@ -91,6 +91,35 @@ export default async function RunDetailPage({ params }: { params: Promise<{ id: 
         <CopyCommandButton runId={run.id} />
       </div>
 
+      {/* Live status — phase + heartbeat freshness (running only) */}
+      {run.status === 'running' && (run.phase ?? run.lastHeartbeatAt) && (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 16, flexWrap: 'wrap' }}>
+          {run.phase && (
+            <span style={{
+              fontSize: 12, padding: '3px 10px', borderRadius: 'var(--radius-sm)',
+              border: '1px solid var(--border)', backgroundColor: 'var(--surf2)', color: 'var(--fg)',
+            }}>
+              Phase: {run.phase}
+            </span>
+          )}
+          {run.lastHeartbeatAt && (() => {
+            const ageMs  = Date.now() - run.lastHeartbeatAt!.getTime()
+            const ageSec = Math.round(ageMs / 1000)
+            const c      = ageMs < 15_000 ? 'var(--ok)' : ageMs < 60_000 ? 'var(--warn)' : 'var(--err)'
+            return (
+              <span style={{
+                fontSize: 12, padding: '3px 10px', borderRadius: 'var(--radius-sm)',
+                border: `1px solid color-mix(in srgb, var(--border) 60%, ${c} 40%)`,
+                backgroundColor: `color-mix(in srgb, var(--surf2) 90%, ${c} 10%)`,
+                color: c,
+              }}>
+                last heartbeat {ageSec}s ago
+              </span>
+            )
+          })()}
+        </div>
+      )}
+
       {/* Stats */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12, marginBottom: 24 }}>
         {([

--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -195,6 +195,7 @@ export async function retryRun(jobId: string): Promise<void> {
       const result = await dispatchToAgent(job.agentId, {
         type:   'run_backup',
         jobId,
+        runId,
         config: { repoId: job.repositoryId!, repoUrl: cfg['repositoryUrl'] ?? '', repoPassword: password, paths, exclude: srcConfig.exclude, tags, envVars: cfg },
       })
       if (!result.ok) {

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -119,6 +119,7 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
   const msg: ServerMessage = {
     type:   'run_backup',
     jobId:  job.id,
+    runId,
     config: {
       repoId:       job.repositoryId ?? '',
       repoUrl:      cfg['repositoryUrl'] ?? '',

--- a/apps/web/public/agent/bundle.js
+++ b/apps/web/public/agent/bundle.js
@@ -4113,6 +4113,17 @@ var ws = null;
 var heartbeatTimer = null;
 var shuttingDown = false;
 var activeJobs = /* @__PURE__ */ new Map();
+setInterval(() => {
+  for (const [jobId, job] of activeJobs) {
+    send({
+      type: "backup_heartbeat",
+      jobId,
+      runId: job.runId,
+      phase: job.phase,
+      lastResticEventAt: job.lastResticEventAt
+    });
+  }
+}, 5e3);
 function send(msg) {
   if (ws?.readyState === wrapper_default.OPEN) {
     ws.send(JSON.stringify(msg));
@@ -4168,24 +4179,24 @@ async function handleMessage(raw) {
     void selfUpdate();
   } else if (msg.type === "pong") {
   } else if (msg.type === "run_backup") {
-    void runBackup(msg.jobId, msg.config);
+    void runBackup(msg.jobId, msg.runId, msg.config);
   } else if (msg.type === "cancel_backup") {
-    const ctrl = activeJobs.get(msg.jobId);
-    if (ctrl) {
-      ctrl.abort();
+    const job = activeJobs.get(msg.jobId);
+    if (job) {
+      job.ctrl.abort();
       console.log(`[agent] Cancelled job ${msg.jobId}`);
     }
   } else if (msg.type === "verify_repo") {
     void verifyRepo(msg.repoId, msg.repoUrl, msg.repoPassword, msg.readData, msg.envVars);
   }
 }
-async function runBackup(jobId, config) {
+async function runBackup(jobId, runId, config) {
   if (activeJobs.has(jobId)) {
     console.warn(`[agent] Job ${jobId} already running \u2014 ignoring duplicate dispatch`);
     return;
   }
   const ctrl = new AbortController();
-  activeJobs.set(jobId, ctrl);
+  activeJobs.set(jobId, { ctrl, runId, phase: "starting", lastResticEventAt: Date.now() });
   send({ type: "backup_start", jobId, config });
   console.log(`[agent] Starting backup for job ${jobId} \u2014 paths: ${config.paths.join(", ")}`);
   let runLog = "";
@@ -4205,6 +4216,11 @@ async function runBackup(jobId, config) {
       exclude: config.exclude,
       tags: config.tags,
       onProgress: (s) => {
+        const active = activeJobs.get(jobId);
+        if (active) {
+          active.phase = "uploading";
+          active.lastResticEventAt = Date.now();
+        }
         send({
           type: "backup_progress",
           jobId,

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -447,6 +447,12 @@ void app.prepare().then(() => {
             .where(eq(backupJobs.id, msg.jobId)).limit(1)
           await sendAlert('backup_failed', { jobId: msg.jobId, jobName: job?.name ?? 'unknown', error: msg.error })
 
+        } else if (msg.type === 'backup_heartbeat' && agentId) {
+          await db.update(backupRuns).set({
+            lastHeartbeatAt: new Date(),
+            phase:           msg.phase,
+          }).where(eq(backupRuns.id, msg.runId))
+
         } else if (msg.type === 'resources_result') {
           console.log('[detect] resources_result requestId=%s resources=%j', msg.requestId, msg.resources)
           resolveDetect(msg.requestId, msg.resources)

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -52,6 +52,7 @@ export type AgentMessage =
   | { type: 'ping' }
   | { type: 'metrics'; metrics: AgentMetrics }
   | { type: 'backup_start'; jobId: string; config: BackupJobConfig }
+  | { type: 'backup_heartbeat'; jobId: string; runId: string; phase: 'starting' | 'scanning' | 'uploading' | 'finalizing'; lastResticEventAt: number }
   | { type: 'backup_progress'; jobId: string; pct: number; filesProcessed: number; bytesProcessed: number; filesTotal: number; bytesTotal: number; secondsRemaining?: number }
   | { type: 'backup_complete'; jobId: string; snapshotId: string; stats: BackupStats; log?: string }
   | { type: 'backup_failed'; jobId: string; error: string; detail: string; log?: string }
@@ -71,7 +72,7 @@ export interface DetectedResources {
 export type ServerMessage =
   | { type: 'welcome'; agentId: string; serverVersion: string; bundleHash?: string }
   | { type: 'pong' }
-  | { type: 'run_backup'; jobId: string; config: BackupJobConfig }
+  | { type: 'run_backup'; jobId: string; runId: string; config: BackupJobConfig }
   | { type: 'run_restore'; restoreId: string; specYaml: string; snapshotId: string }
   | { type: 'cancel_backup'; jobId: string }
   | { type: 'verify_repo'; repoId: string; repoUrl: string; repoPassword: string; readData: boolean; envVars?: Record<string, string> }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -130,8 +130,24 @@ let ws: WebSocket | null = null
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null
 let shuttingDown = false
 
-// Active jobs — keyed by jobId — allow cancel
-const activeJobs = new Map<string, AbortController>()
+type BackupPhase = 'starting' | 'scanning' | 'uploading' | 'finalizing'
+interface ActiveJob { ctrl: AbortController; runId: string; phase: BackupPhase; lastResticEventAt: number }
+
+// Active jobs — keyed by jobId
+const activeJobs = new Map<string, ActiveJob>()
+
+// Emit a heartbeat for every in-flight backup every 5 seconds
+setInterval(() => {
+  for (const [jobId, job] of activeJobs) {
+    send({
+      type:              'backup_heartbeat',
+      jobId,
+      runId:             job.runId,
+      phase:             job.phase,
+      lastResticEventAt: job.lastResticEventAt,
+    })
+  }
+}, 5_000)
 
 function send(msg: AgentMessage): void {
   if (ws?.readyState === WebSocket.OPEN) {
@@ -192,25 +208,25 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
     // heartbeat acknowledged
 
   } else if (msg.type === 'run_backup') {
-    void runBackup(msg.jobId, msg.config)
+    void runBackup(msg.jobId, msg.runId, msg.config)
 
   } else if (msg.type === 'cancel_backup') {
-    const ctrl = activeJobs.get(msg.jobId)
-    if (ctrl) { ctrl.abort(); console.log(`[agent] Cancelled job ${msg.jobId}`) }
+    const job = activeJobs.get(msg.jobId)
+    if (job) { job.ctrl.abort(); console.log(`[agent] Cancelled job ${msg.jobId}`) }
 
   } else if (msg.type === 'verify_repo') {
     void verifyRepo(msg.repoId, msg.repoUrl, msg.repoPassword, msg.readData, msg.envVars)
   }
 }
 
-async function runBackup(jobId: string, config: BackupJobConfig): Promise<void> {
+async function runBackup(jobId: string, runId: string, config: BackupJobConfig): Promise<void> {
   if (activeJobs.has(jobId)) {
     console.warn(`[agent] Job ${jobId} already running — ignoring duplicate dispatch`)
     return
   }
 
   const ctrl = new AbortController()
-  activeJobs.set(jobId, ctrl)
+  activeJobs.set(jobId, { ctrl, runId, phase: 'starting', lastResticEventAt: Date.now() })
 
   send({ type: 'backup_start', jobId, config })
   console.log(`[agent] Starting backup for job ${jobId} — paths: ${config.paths.join(', ')}`)
@@ -236,6 +252,11 @@ async function runBackup(jobId: string, config: BackupJobConfig): Promise<void> 
       exclude: config.exclude,
       tags:    config.tags,
       onProgress: (s) => {
+        const active = activeJobs.get(jobId)
+        if (active) {
+          active.phase = 'uploading'
+          active.lastResticEventAt = Date.now()
+        }
         send({
           type:             'backup_progress',
           jobId,

--- a/packages/db/migrations/0025_run_heartbeat.sql
+++ b/packages/db/migrations/0025_run_heartbeat.sql
@@ -1,0 +1,2 @@
+ALTER TABLE backup_runs ADD COLUMN last_heartbeat_at INTEGER;
+ALTER TABLE backup_runs ADD COLUMN phase TEXT;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1745884800000,
       "tag": "0024_agent_version_fields",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1745971200000,
+      "tag": "0025_run_heartbeat",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -137,8 +137,10 @@ export const backupRuns = sqliteTable('backup_runs', {
   errorMessage: text('error_message'),
   errorDetail:  text('error_detail'),       // JSON — full error context
 
-  startedAt:   integer('started_at',   { mode: 'timestamp_ms' }).notNull(),
-  completedAt: integer('completed_at', { mode: 'timestamp_ms' }),
+  startedAt:       integer('started_at',        { mode: 'timestamp_ms' }).notNull(),
+  completedAt:     integer('completed_at',      { mode: 'timestamp_ms' }),
+  lastHeartbeatAt: integer('last_heartbeat_at', { mode: 'timestamp_ms' }),
+  phase:           text('phase'),
 
   log:    text('log'),
   phases: text('phases'),


### PR DESCRIPTION
## Summary
- Agent emits `backup_heartbeat` every 5s for each active backup (jobId, runId, phase, lastResticEventAt)
- Phase transitions: `starting` → `uploading` when first restic status event arrives
- Server persists `last_heartbeat_at` and `phase` to `backup_runs` (migration 0025)
- Run detail page shows phase pill + heartbeat-freshness indicator (green <15s, yellow <60s, red >60s) while running
- `runId` now included in `run_backup` ServerMessage so agent references the exact run row

## Deploy note
**After deploying the server, update the agent on Dockee01:**
```
sudo bash /opt/backupos-agent/install.sh update
```
The agent bundle must be updated to pick up heartbeat emission.

## Acceptance test
```sql
-- While a backup is running, poll this every second:
SELECT id, status, phase, last_heartbeat_at,
  datetime(last_heartbeat_at/1000,'unixepoch') AS hb_at
FROM backup_runs ORDER BY started_at DESC LIMIT 1;
```
- `last_heartbeat_at` should update every ~5s
- `phase` should show `uploading` once restic is active
- Run detail page shows "Phase: uploading" + "last heartbeat Xs ago"

🤖 Generated with [Claude Code](https://claude.com/claude-code)