### PR TITLE
fix(scheduler): Item 6 — heartbeat-based stuck-run cleanup

### DIFF
--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -1,6 +1,6 @@
 import * as cron from 'node-cron'
 import { parseExpression } from 'cron-parser'
-import { getDb, backupJobs, backupRuns, repositories, agents, backupDefaults, eq, and, lt, lte, isNotNull } from '@backupos/db'
+import { getDb, backupJobs, backupRuns, repositories, agents, backupDefaults, eq, and, or, lt, lte, isNotNull, isNull } from '@backupos/db'
 import { decryptField } from './repo-crypto'
 import { ResticEngine } from '@backupos/engine'
 import { sendAlert } from './alerts'
@@ -49,8 +49,8 @@ export async function initScheduler(): Promise<void> {
     console.log(`[scheduler] Scheduled "${job.name}" (${job.schedule})`)
   }
 
-  // Trigger-driven tick: fire any job with nextRunAt <= now (Run Now, SQL trigger, etc.)
-  setInterval(() => { void triggerTick(db) }, 5_000)
+  // Trigger-driven tick: fire any job with nextRunAt <= now; also sweep for stuck runs
+  setInterval(() => { void triggerTick(db); void checkRunHealth(db) }, 5_000)
   console.log('[scheduler] Trigger tick active (5s interval)')
 
   // Check for disconnected agents every 5 minutes
@@ -326,6 +326,49 @@ async function runJobCore(db: Db, job: Job, runId: string): Promise<void> {
   }
 }
 
+async function markRunFailed(db: Db, runId: string, errorMessage: string): Promise<void> {
+  await db.update(backupRuns).set({
+    status: 'failed', completedAt: new Date(), errorMessage,
+  }).where(eq(backupRuns.id, runId))
+}
+
+async function checkRunHealth(db: Db): Promise<void> {
+  const heartbeatCutoff = new Date(Date.now() - 60_000)       // 60s
+  const fatalCutoff     = new Date(Date.now() - 5 * 60_000)   // 5min
+
+  const stale = await db.select().from(backupRuns).where(
+    and(
+      eq(backupRuns.status, 'running'),
+      or(
+        and(isNull(backupRuns.lastHeartbeatAt), lt(backupRuns.startedAt, fatalCutoff)),
+        lt(backupRuns.lastHeartbeatAt, heartbeatCutoff),
+      ),
+    ),
+  ).all()
+
+  for (const run of stale) {
+    const heartbeatAge = run.lastHeartbeatAt ? Date.now() - run.lastHeartbeatAt.getTime() : null
+    const startAge     = Date.now() - run.startedAt.getTime()
+
+    if (heartbeatAge !== null && heartbeatAge < 5 * 60_000) {
+      // Stale 60s–5min: only kill if the agent is also disconnected
+      const alive = run.agentId ? connectedAgentIds().includes(run.agentId) : false
+      if (alive) continue
+      await markRunFailed(db, run.id, `agent disconnected, no heartbeat for ${Math.round(heartbeatAge / 1000)}s`)
+      continue
+    }
+
+    // Fatal: > 5min or never heartbeat
+    await markRunFailed(
+      db,
+      run.id,
+      heartbeatAge !== null
+        ? `no heartbeat for ${Math.round(heartbeatAge / 1000)}s — run abandoned`
+        : `no heartbeat received and run started ${Math.round(startAge / 1000)}s ago — agent likely never started restic`,
+    )
+  }
+}
+
 // In-memory set prevents duplicate missed-backup alerts within a server session
 const missedAlertSent = new Set<string>()
 
@@ -372,21 +415,4 @@ async function checkAgents(db: Db): Promise<void> {
     await sendAlert('agent_disconnected', { agentId: agent.id, agentName: agent.name })
   }
 
-  // Mark runs stuck in 'running' for more than 2 hours as failed
-  const staleRunCutoff = new Date(Date.now() - 2 * 60 * 60 * 1000)
-  const staleRuns = await db
-    .select()
-    .from(backupRuns)
-    .where(and(eq(backupRuns.status, 'running'), lt(backupRuns.startedAt, staleRunCutoff)))
-    .all()
-
-  for (const run of staleRuns) {
-    await db.update(backupRuns).set({
-      status: 'failed', completedAt: new Date(),
-      errorMessage: 'Run timed out — no completion message received from agent',
-    }).where(eq(backupRuns.id, run.id))
-    if (run.jobId) {
-      await db.update(backupJobs).set({ lastRunStatus: 'failed' }).where(eq(backupJobs.id, run.jobId))
-    }
-  }
 }

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -492,6 +492,11 @@ void app.prepare().then(() => {
         if (agentId) {
           unregisterAgent(agentId)
           await db.update(agents).set({ status: 'disconnected' }).where(eq(agents.id, agentId))
+          // Immediately fail any runs in-flight on this agent
+          await db.update(backupRuns).set({
+            status: 'failed', completedAt: new Date(),
+            errorMessage: 'agent disconnected mid-run',
+          }).where(and(eq(backupRuns.agentId, agentId), eq(backupRuns.status, 'running')))
           await db.insert(auditLog).values({
             id: crypto.randomUUID(), action: 'agent_disconnected',
             resourceType: 'agent', resourceId: agentId,


### PR DESCRIPTION
## Summary
- Replaces 2-hour wall-clock timeout with a two-stage heartbeat-based sweep on the 5s tick
- **Stage 1 (60s stale):** if agent still connected → skip; if disconnected → mark failed
- **Stage 2 (>5min or never heartbeat):** mark failed unconditionally
- **On WS close:** immediately fail all in-flight runs for the disconnecting agent without waiting for the sweep
- Removes old 2-hour stuck-run block from `checkAgents` entirely

## Acceptance tests
**Test 1 — Clean disconnect:** trigger slow backup → `sudo systemctl stop backupos-agent` → run fails within 10s with `agent disconnected mid-run`

**Test 2 — Network partition:** trigger backup → `sudo iptables -A OUTPUT -p tcp --dport 3093 -j DROP` → run fails within 70s with `agent disconnected, no heartbeat for Xs`

**Test 3 — Synthetic stuck run:**
```sql
INSERT INTO backup_runs (id, job_id, agent_id, repository_id, status, trigger, started_at)
VALUES ('synthetic-stuck-test', ..., 'running', 'manual',
  cast(strftime('%s','now') as integer) * 1000 - 360000);
```
→ marked failed within 10s with `no heartbeat received and run started Xs ago`

🤖 Generated with [Claude Code](https://claude.com/claude-code)