### PR TITLE
feat(agent): Item 4 — cancel_backup kills restic via AbortSignal

### DIFF
--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -219,12 +219,23 @@ export async function cancelJob(jobId: string): Promise<void> {
 
   if (!run) { revalidatePath(`/jobs/${jobId}`); return }
 
-  await db.update(backupRuns).set({ status: 'cancelled', completedAt: new Date() }).where(eq(backupRuns.id, run.id))
-  await db.update(backupJobs).set({ lastRunStatus: 'cancelled' }).where(eq(backupJobs.id, jobId))
+  if (!run.agentId) {
+    // Local run (no agent) — cancel directly
+    await db.update(backupRuns).set({ status: 'cancelled', completedAt: new Date() }).where(eq(backupRuns.id, run.id))
+    await db.update(backupJobs).set({ lastRunStatus: 'cancelled' }).where(eq(backupJobs.id, jobId))
+    revalidatePath(`/jobs/${jobId}`)
+    return
+  }
 
-  const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, jobId)).limit(1)
-  if (job?.agentId) {
-    void dispatchToAgent(job.agentId, { type: 'cancel_backup', jobId })
+  // Agent run: dispatch cancel and let the agent's backup_cancelled response update the DB
+  const result = await dispatchToAgent(run.agentId, { type: 'cancel_backup', jobId, runId: run.id })
+  if (!result.ok) {
+    // Agent unreachable — honour the cancel immediately
+    await db.update(backupRuns).set({
+      status: 'cancelled', completedAt: new Date(),
+      errorMessage: `cancel: agent unreachable (${result.reason ?? 'unknown'})`,
+    }).where(eq(backupRuns.id, run.id))
+    await db.update(backupJobs).set({ lastRunStatus: 'cancelled' }).where(eq(backupJobs.id, jobId))
   }
 
   revalidatePath(`/jobs/${jobId}`)

--- a/apps/web/public/agent/bundle.js
+++ b/apps/web/public/agent/bundle.js
@@ -3738,7 +3738,7 @@ var ResticEngine = class {
           }
         } catch {
         }
-      } : void 0, void 0, 144e5);
+      } : void 0, void 0, 144e5, opts.signal);
       if (result.exitCode !== 0)
         throw new ResticError("backup", result);
       const summary = this.parseSummaryLine(result.stdout);
@@ -3892,13 +3892,24 @@ var ResticEngine = class {
   run(args, extraEnv, timeoutMs) {
     return this.runStreaming(args, void 0, extraEnv, timeoutMs);
   }
-  runStreaming(args, onLine, extraEnv, timeoutMs) {
+  runStreaming(args, onLine, extraEnv, timeoutMs, signal) {
     return new Promise((resolve, reject) => {
       const proc = (0, import_child_process.spawn)(this.binary, args, {
         env: this.buildEnv(extraEnv),
         stdio: ["ignore", "pipe", "pipe"]
       });
       let settled = false;
+      if (signal) {
+        signal.addEventListener("abort", () => {
+          if (settled)
+            return;
+          proc.kill("SIGTERM");
+          setTimeout(() => {
+            if (!proc.killed && proc.exitCode === null)
+              proc.kill("SIGKILL");
+          }, 1e4);
+        }, { once: true });
+      }
       const outLines = [];
       const err = [];
       let partial = "";
@@ -4182,9 +4193,14 @@ async function handleMessage(raw) {
     void runBackup(msg.jobId, msg.runId, msg.config);
   } else if (msg.type === "cancel_backup") {
     const job = activeJobs.get(msg.jobId);
-    if (job) {
+    if (!job) {
+      console.warn(`[agent] cancel_backup: no active backup for jobId=${msg.jobId}`);
+      send({ type: "backup_cancelled", jobId: msg.jobId, runId: msg.runId, reason: "not_running" });
+    } else {
+      console.log(`[agent] cancel_backup jobId=${msg.jobId} runId=${job.runId} \u2014 aborting`);
+      job.cancelled = true;
       job.ctrl.abort();
-      console.log(`[agent] Cancelled job ${msg.jobId}`);
+      send({ type: "backup_cancelled", jobId: msg.jobId, runId: job.runId, reason: "user_requested" });
     }
   } else if (msg.type === "verify_repo") {
     void verifyRepo(msg.repoId, msg.repoUrl, msg.repoPassword, msg.readData, msg.envVars);
@@ -4196,7 +4212,7 @@ async function runBackup(jobId, runId, config) {
     return;
   }
   const ctrl = new AbortController();
-  activeJobs.set(jobId, { ctrl, runId, phase: "starting", lastResticEventAt: Date.now() });
+  activeJobs.set(jobId, { ctrl, runId, phase: "starting", lastResticEventAt: Date.now(), cancelled: false });
   send({ type: "backup_start", jobId, config });
   console.log(`[agent] Starting backup for job ${jobId} \u2014 paths: ${config.paths.join(", ")}`);
   let runLog = "";
@@ -4215,6 +4231,7 @@ async function runBackup(jobId, runId, config) {
       paths: config.paths,
       exclude: config.exclude,
       tags: config.tags,
+      signal: ctrl.signal,
       onProgress: (s) => {
         const active = activeJobs.get(jobId);
         if (active) {
@@ -4251,10 +4268,14 @@ async function runBackup(jobId, runId, config) {
     });
     console.log(`[agent] Backup complete \u2014 snapshot ${result.snapshotId}`);
   } catch (err) {
-    const error = err instanceof Error ? err.message : String(err);
-    const detail = err instanceof Error && err.stack ? err.stack : "";
-    send({ type: "backup_failed", jobId, error, detail, log: runLog || void 0 });
-    console.error(`[agent] Backup failed for job ${jobId}:`, error);
+    if (ctrl.signal.aborted) {
+      console.log(`[agent] Backup for job ${jobId} exited due to cancel signal \u2014 skipping backup_failed`);
+    } else {
+      const error = err instanceof Error ? err.message : String(err);
+      const detail = err instanceof Error && err.stack ? err.stack : "";
+      send({ type: "backup_failed", jobId, error, detail, log: runLog || void 0 });
+      console.error(`[agent] Backup failed for job ${jobId}:`, error);
+    }
   } finally {
     activeJobs.delete(jobId);
   }

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -183,6 +183,38 @@ void app.prepare().then(() => {
       return
     }
 
+    // Cancel a run by runId — testing / admin use
+    const cancelRunMatch = parsed.pathname?.match(/^\/internal\/cancel-run\/([^/]+)$/)
+    if (req.method === 'POST' && cancelRunMatch) {
+      void (async () => {
+        const auth = req.headers['x-internal-token']
+        if (auth !== process.env['BACKUPOS_INTERNAL_TOKEN']) {
+          res.writeHead(401, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ ok: false, reason: 'unauthorized' }))
+          return
+        }
+        const runId = cancelRunMatch[1]!
+        const db2   = getDb()
+        const [run] = await db2.select().from(backupRuns).where(eq(backupRuns.id, runId)).limit(1)
+        if (!run || run.status !== 'running') {
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ ok: true, note: 'run not active' }))
+          return
+        }
+        if (run.agentId) {
+          const sent = dispatch(run.agentId, { type: 'cancel_backup', jobId: run.jobId!, runId: run.id })
+          if (!sent) {
+            await db2.update(backupRuns).set({ status: 'cancelled', completedAt: new Date(), errorMessage: 'cancel: agent unreachable' }).where(eq(backupRuns.id, runId))
+          }
+        } else {
+          await db2.update(backupRuns).set({ status: 'cancelled', completedAt: new Date() }).where(eq(backupRuns.id, runId))
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: true }))
+      })()
+      return
+    }
+
     // Repository init-state — used by agent to check/set initializedAt (Fix A)
     if (req.method === 'GET' && /^\/internal\/repository\/[^/]+\/state$/.test(parsed.pathname ?? '')) {
       void (async () => {
@@ -446,6 +478,14 @@ void app.prepare().then(() => {
           const [job] = await db.select({ name: backupJobs.name }).from(backupJobs)
             .where(eq(backupJobs.id, msg.jobId)).limit(1)
           await sendAlert('backup_failed', { jobId: msg.jobId, jobName: job?.name ?? 'unknown', error: msg.error })
+
+        } else if (msg.type === 'backup_cancelled' && agentId) {
+          await db.update(backupRuns).set({
+            status:       'cancelled',
+            completedAt:  new Date(),
+            errorMessage: msg.reason === 'user_requested' ? null : `cancel: ${msg.reason}`,
+          }).where(and(eq(backupRuns.id, msg.runId), eq(backupRuns.status, 'running')))
+          console.log(`[server] backup_cancelled jobId=${msg.jobId} runId=${msg.runId} reason=${msg.reason}`)
 
         } else if (msg.type === 'backup_heartbeat' && agentId) {
           await db.update(backupRuns).set({

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -56,6 +56,7 @@ export type AgentMessage =
   | { type: 'backup_progress'; jobId: string; pct: number; filesProcessed: number; bytesProcessed: number; filesTotal: number; bytesTotal: number; secondsRemaining?: number }
   | { type: 'backup_complete'; jobId: string; snapshotId: string; stats: BackupStats; log?: string }
   | { type: 'backup_failed'; jobId: string; error: string; detail: string; log?: string }
+  | { type: 'backup_cancelled'; jobId: string; runId: string; reason: 'user_requested' | 'not_running' | 'agent_disconnect' }
   | { type: 'restore_start'; restoreId: string; specId: string }
   | { type: 'restore_progress'; restoreId: string; step: string; status: string }
   | { type: 'restore_complete'; restoreId: string; success: boolean }
@@ -74,7 +75,7 @@ export type ServerMessage =
   | { type: 'pong' }
   | { type: 'run_backup'; jobId: string; runId: string; config: BackupJobConfig }
   | { type: 'run_restore'; restoreId: string; specYaml: string; snapshotId: string }
-  | { type: 'cancel_backup'; jobId: string }
+  | { type: 'cancel_backup'; jobId: string; runId: string }
   | { type: 'verify_repo'; repoId: string; repoUrl: string; repoPassword: string; readData: boolean; envVars?: Record<string, string> }
   | { type: 'list_resources'; requestId: string }
   | { type: 'test_repo'; requestId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -131,7 +131,7 @@ let heartbeatTimer: ReturnType<typeof setInterval> | null = null
 let shuttingDown = false
 
 type BackupPhase = 'starting' | 'scanning' | 'uploading' | 'finalizing'
-interface ActiveJob { ctrl: AbortController; runId: string; phase: BackupPhase; lastResticEventAt: number }
+interface ActiveJob { ctrl: AbortController; runId: string; phase: BackupPhase; lastResticEventAt: number; cancelled: boolean }
 
 // Active jobs — keyed by jobId
 const activeJobs = new Map<string, ActiveJob>()
@@ -212,7 +212,15 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
 
   } else if (msg.type === 'cancel_backup') {
     const job = activeJobs.get(msg.jobId)
-    if (job) { job.ctrl.abort(); console.log(`[agent] Cancelled job ${msg.jobId}`) }
+    if (!job) {
+      console.warn(`[agent] cancel_backup: no active backup for jobId=${msg.jobId}`)
+      send({ type: 'backup_cancelled', jobId: msg.jobId, runId: msg.runId, reason: 'not_running' })
+    } else {
+      console.log(`[agent] cancel_backup jobId=${msg.jobId} runId=${job.runId} — aborting`)
+      job.cancelled = true
+      job.ctrl.abort()
+      send({ type: 'backup_cancelled', jobId: msg.jobId, runId: job.runId, reason: 'user_requested' })
+    }
 
   } else if (msg.type === 'verify_repo') {
     void verifyRepo(msg.repoId, msg.repoUrl, msg.repoPassword, msg.readData, msg.envVars)
@@ -226,7 +234,7 @@ async function runBackup(jobId: string, runId: string, config: BackupJobConfig):
   }
 
   const ctrl = new AbortController()
-  activeJobs.set(jobId, { ctrl, runId, phase: 'starting', lastResticEventAt: Date.now() })
+  activeJobs.set(jobId, { ctrl, runId, phase: 'starting', lastResticEventAt: Date.now(), cancelled: false })
 
   send({ type: 'backup_start', jobId, config })
   console.log(`[agent] Starting backup for job ${jobId} — paths: ${config.paths.join(', ')}`)
@@ -251,6 +259,7 @@ async function runBackup(jobId: string, runId: string, config: BackupJobConfig):
       paths:   config.paths,
       exclude: config.exclude,
       tags:    config.tags,
+      signal:  ctrl.signal,
       onProgress: (s) => {
         const active = activeJobs.get(jobId)
         if (active) {
@@ -290,10 +299,14 @@ async function runBackup(jobId: string, runId: string, config: BackupJobConfig):
     console.log(`[agent] Backup complete — snapshot ${result.snapshotId}`)
 
   } catch (err) {
-    const error  = err instanceof Error ? err.message : String(err)
-    const detail = err instanceof Error && err.stack ? err.stack : ''
-    send({ type: 'backup_failed', jobId, error, detail, log: runLog || undefined })
-    console.error(`[agent] Backup failed for job ${jobId}:`, error)
+    if (ctrl.signal.aborted) {
+      console.log(`[agent] Backup for job ${jobId} exited due to cancel signal — skipping backup_failed`)
+    } else {
+      const error  = err instanceof Error ? err.message : String(err)
+      const detail = err instanceof Error && err.stack ? err.stack : ''
+      send({ type: 'backup_failed', jobId, error, detail, log: runLog || undefined })
+      console.error(`[agent] Backup failed for job ${jobId}:`, error)
+    }
 
   } finally {
     activeJobs.delete(jobId)

--- a/packages/engine/src/restic.ts
+++ b/packages/engine/src/restic.ts
@@ -97,6 +97,7 @@ export class ResticEngine {
           : undefined,
         undefined,
         14_400_000,
+        opts.signal,
       )
       if (result.exitCode !== 0) throw new ResticError('backup', result)
 
@@ -265,6 +266,7 @@ export class ResticEngine {
     onLine?: (line: string) => void,
     extraEnv?: Record<string, string>,
     timeoutMs?: number,
+    signal?: AbortSignal,
   ): Promise<ExecResult> {
     return new Promise((resolve, reject) => {
       const proc = spawn(this.binary, args, {
@@ -273,6 +275,16 @@ export class ResticEngine {
       })
 
       let settled = false
+
+      if (signal) {
+        signal.addEventListener('abort', () => {
+          if (settled) return
+          proc.kill('SIGTERM')
+          setTimeout(() => {
+            if (!proc.killed && proc.exitCode === null) proc.kill('SIGKILL')
+          }, 10_000)
+        }, { once: true })
+      }
       const outLines: string[] = []
       const err: Buffer[] = []
       let partial = ''

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -25,6 +25,7 @@ export interface BackupOptions {
   preHook?: () => Promise<void>
   postHook?: () => Promise<void>
   onProgress?: (status: BackupProgressStatus) => void
+  signal?: AbortSignal
 }
 
 export interface ResticStatusJson {


### PR DESCRIPTION
## Summary
- `ResticEngine.backup()` now accepts `signal?: AbortSignal`; on abort it sends SIGTERM to restic, SIGKILL after 10s
- Agent `cancel_backup` handler: sets `cancelled=true`, aborts the signal, immediately sends `backup_cancelled` (non-blocking — doesn't wait for restic to exit)
- `runBackup` catch block skips `backup_failed` when signal was aborted (already cancelled)
- Server handles `backup_cancelled`: marks run `cancelled` with status guard to prevent double-write
- `cancelJob` action dispatches to agent first; falls back to direct DB update only when agent unreachable
- Adds `POST /internal/cancel-run/:runId` for acceptance testing

## Deploy note
After deploying the server, update the agent on Dockee01:
```
sudo bash /opt/backupos-agent/install.sh update
```

## Acceptance test
**Test 1 — Active cancel:**
```bash
# Trigger slow backup of /usr/share, wait for phase=uploading, then:
INTERNAL_TOKEN=$(sudo grep BACKUPOS_INTERNAL_TOKEN /opt/backupos-agent/.env | cut -d= -f2)
RUN_ID=$(sudo sqlite3 /var/lib/backupos/backupos.db \
  "SELECT id FROM backup_runs WHERE status='running' ORDER BY started_at DESC LIMIT 1;")
curl -s -X POST http://localhost:3093/internal/cancel-run/$RUN_ID \
  -H "x-internal-token: $INTERNAL_TOKEN"
# Within 15s: run=cancelled, restic gone (ps -ef | grep restic)
```

**Test 2 — Idempotent (already success):** call cancelJob on a completed run → no change

**Test 3 — Agent unreachable:** stop agent, call cancel → run immediately marked cancelled with agent unreachable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)