### PR TITLE
feat(dispatch): branch compose_project jobs onto run_compose_backup

### DIFF
--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -187,20 +187,36 @@ export async function retryRun(jobId: string): Promise<void> {
     const [repo] = await db.select().from(repositories)
       .where(eq(repositories.id, job.repositoryId!)).limit(1)
     if (repo) {
-      const cfg       = JSON.parse(decryptField(repo.config)) as Record<string, string>
-      const password  = decryptField(repo.resticPassword)
+      const cfg      = JSON.parse(decryptField(repo.config)) as Record<string, string>
+      const password = decryptField(repo.resticPassword)
       if (!password) throw new Error(`dispatch: failed to decrypt repo password for repository ${repo.id}`)
-      const srcConfig = JSON.parse(job.sourceConfig) as { paths?: string[]; volumes?: string[]; exclude?: string[] }
-      const tags      = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${jobId}`]
-      const paths = job.sourceType === 'docker_volume'
-        ? (srcConfig.volumes ?? []).map(v => `/var/lib/docker/volumes/${v}/_data`)
-        : (srcConfig.paths ?? [])
-      const result = await dispatchToAgent(job.agentId, {
-        type:   'run_backup',
-        jobId,
-        runId,
-        config: { repoId: job.repositoryId!, repoUrl: cfg['repositoryUrl'] ?? '', repoPassword: password, paths, exclude: srcConfig.exclude, tags, envVars: cfg },
-      })
+      const tags = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${jobId}`]
+
+      let result: { ok: boolean; reason?: string; knownIds?: string[] }
+      if (job.sourceType === 'compose_project') {
+        const composeConfig = JSON.parse(job.sourceConfig) as import('@backupos/agent-protocol').ComposeProjectConfig
+        result = await dispatchToAgent(job.agentId, {
+          type:         'run_compose_backup',
+          jobId,
+          runId,
+          config:       composeConfig,
+          repoId:       job.repositoryId!,
+          repoUrl:      cfg['repositoryUrl'] ?? '',
+          repoPassword: password,
+          envVars:      cfg,
+        })
+      } else {
+        const srcConfig = JSON.parse(job.sourceConfig) as { paths?: string[]; volumes?: string[]; exclude?: string[] }
+        const paths = job.sourceType === 'docker_volume'
+          ? (srcConfig.volumes ?? []).map(v => `/var/lib/docker/volumes/${v}/_data`)
+          : (srcConfig.paths ?? [])
+        result = await dispatchToAgent(job.agentId, {
+          type:   'run_backup',
+          jobId,
+          runId,
+          config: { repoId: job.repositoryId!, repoUrl: cfg['repositoryUrl'] ?? '', repoPassword: password, paths, exclude: srcConfig.exclude, tags, envVars: cfg },
+        })
+      }
       if (!result.ok) {
         console.error('[retryRun] dispatch failed reason=%s knownIds=%j', result.reason, result.knownIds)
       }

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -5,7 +5,7 @@ import { decryptField } from './repo-crypto'
 import { ResticEngine } from '@backupos/engine'
 import { sendAlert } from './alerts'
 import { dispatch, connectedAgentIds } from './ws-state'
-import type { ServerMessage, MountConfig } from '@backupos/agent-protocol'
+import type { ServerMessage, MountConfig, ComposeProjectConfig } from '@backupos/agent-protocol'
 
 interface RepoConfig {
   repositoryUrl: string
@@ -96,12 +96,9 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
     .where(eq(repositories.id, job.repositoryId)).limit(1)
   if (!repo) return false
 
-  const cfg       = JSON.parse(decryptField(repo.config)) as Record<string, string>
-  const password  = decryptField(repo.resticPassword)
+  const cfg      = JSON.parse(decryptField(repo.config)) as Record<string, string>
+  const password = decryptField(repo.resticPassword)
   if (!password) throw new Error(`dispatch: failed to decrypt repo password for repository ${repo.id}`)
-  const srcConfig = JSON.parse(job.sourceConfig) as SourceConfig
-  const paths     = resolveBackupPaths(job.sourceType, srcConfig)
-  if (paths.length === 0) return false
 
   const runId = crypto.randomUUID()
   const now   = new Date()
@@ -110,26 +107,45 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
     id: runId, jobId: job.id, repositoryId: job.repositoryId,
     agentId: job.agentId, status: 'running', trigger, startedAt: now,
   })
-
   await db.update(backupJobs).set({ lastRunAt: now }).where(eq(backupJobs.id, job.id))
 
-  const tags = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${job.id}`]
-  const mountConfig = cfg['mountConfig'] ? (JSON.parse(cfg['mountConfig']) as MountConfig) : undefined
-
-  const msg: ServerMessage = {
-    type:   'run_backup',
-    jobId:  job.id,
-    runId,
-    config: {
+  let msg: ServerMessage
+  if (job.sourceType === 'compose_project') {
+    const composeConfig = JSON.parse(job.sourceConfig) as ComposeProjectConfig
+    msg = {
+      type:         'run_compose_backup',
+      jobId:        job.id,
+      runId,
+      config:       composeConfig,
       repoId:       job.repositoryId ?? '',
       repoUrl:      cfg['repositoryUrl'] ?? '',
       repoPassword: password,
-      paths,
-      exclude:  srcConfig.exclude,
-      tags,
-      envVars:  cfg,
-      mountConfig,
-    },
+      envVars:      cfg,
+    }
+  } else {
+    const srcConfig   = JSON.parse(job.sourceConfig) as SourceConfig
+    const paths       = resolveBackupPaths(job.sourceType, srcConfig)
+    if (paths.length === 0) {
+      await db.update(backupRuns).set({ status: 'failed', completedAt: now, errorMessage: 'No backup paths resolved' }).where(eq(backupRuns.id, runId))
+      return false
+    }
+    const tags        = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${job.id}`]
+    const mountConfig = cfg['mountConfig'] ? (JSON.parse(cfg['mountConfig']) as MountConfig) : undefined
+    msg = {
+      type:   'run_backup',
+      jobId:  job.id,
+      runId,
+      config: {
+        repoId:       job.repositoryId ?? '',
+        repoUrl:      cfg['repositoryUrl'] ?? '',
+        repoPassword: password,
+        paths,
+        exclude:      srcConfig.exclude,
+        tags,
+        envVars:      cfg,
+        mountConfig,
+      },
+    }
   }
 
   const sent = dispatch(job.agentId, msg)
@@ -143,7 +159,7 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
 
   // Reset nextRunAt so the trigger tick doesn't re-fire this job
   await stampNextRun(db, job.id, job.schedule)
-  console.log(`[scheduler] Dispatched job "${job.name}" to agent ${job.agentId}`)
+  console.log(`[scheduler] Dispatched job "${job.name}" (${job.sourceType}) to agent ${job.agentId}`)
   return true
 }
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -227,6 +227,9 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
   } else if (msg.type === 'verify_repo') {
     void verifyRepo(msg.repoId, msg.repoUrl, msg.repoPassword, msg.readData, msg.envVars)
 
+  } else if (msg.type === 'run_compose_backup') {
+    send({ type: 'backup_failed', jobId: msg.jobId, error: 'compose backup execution not implemented yet (Task 7)', detail: '' })
+
   } else if (msg.type === 'list_compose_project') {
     void (async () => {
       try {


### PR DESCRIPTION
## Summary
- `scheduler.ts` `dispatchToAgent` branches on `compose_project` → sends `run_compose_backup` with `ComposeProjectConfig`; non-compose path still calls `resolveBackupPaths` as before
- `jobs.ts` `retryRun` gets the same branch — compose sends `run_compose_backup`, everything else sends `run_backup`
- Agent stub handler for `run_compose_backup` returns `backup_failed` with a clear "not implemented yet (Task 7)" message so existing installs don't crash on unknown message type

## Test plan
- [ ] Trigger a filesystem job with an agent → still dispatches `run_backup`, backup completes normally
- [ ] Trigger a compose_project job with an agent → dispatches `run_compose_backup`, run row gets `failed` status with "not implemented" error message
- [ ] Trigger a compose_project job without an agent → falls through to local scheduler path (no-op until Task 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)