### PR TITLE
fix(jobs): validate cron expressions on save and surface invalid state in UI

### DIFF
--- a/apps/web/app/(dashboard)/jobs/[id]/edit/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/[id]/edit/page.tsx
@@ -4,9 +4,17 @@ import { getDb, backupJobs, repositories, agents, eq } from '@backupos/db'
 import { Button } from '@/components/ui/button'
 import { SourceConfigSection } from '@/components/source-config-section'
 import { updateJob } from '@/app/actions/jobs'
+import { CronInput } from '@/components/cron-input'
 
-export default async function EditJobPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params
+export default async function EditJobPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>
+  searchParams: Promise<{ cronError?: string }>
+}) {
+  const { id }      = await params
+  const { cronError } = await searchParams
   const db = getDb()
 
   const [[job], repos, agentList] = await Promise.all([
@@ -81,16 +89,13 @@ export default async function EditJobPage({ params }: { params: Promise<{ id: st
             <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6, fontWeight: 500 }}>
               Schedule (cron)
             </label>
-            <input
+            <CronInput
               name="schedule"
-              type="text"
               required
               defaultValue={job.schedule}
+              serverError={cronError}
               style={{ ...inputStyle, fontFamily: 'var(--font-mono)' }}
             />
-            <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginTop: 4 }}>
-              e.g. <code>0 2 * * *</code> = daily at 02:00
-            </div>
           </div>
 
           <div style={{ display: 'flex', gap: 10 }}>

--- a/apps/web/app/(dashboard)/jobs/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/[id]/page.tsx
@@ -11,6 +11,7 @@ import { PreflightButton } from '@/components/preflight-modal'
 import { togglePreflight } from '@/app/actions/preflight'
 import { PreflightToggle } from '@/components/preflight-toggle'
 import { triggerJob, saveJobRetention, cancelJob, retryRun } from '@/app/actions/jobs'
+import { validateCron } from '@/lib/cron-validate'
 
 type BadgeStatus = ComponentProps<typeof Badge>['status']
 
@@ -166,7 +167,17 @@ export default async function JobDetailPage({ params }: { params: Promise<{ id: 
         </div>
         <div style={fieldStyle}>
           <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginBottom: 6 }}>Schedule</div>
-          <div style={{ fontSize: 14, color: 'var(--fg)', fontFamily: 'var(--font-mono)' }}>{job.schedule}</div>
+          {(() => {
+            const check = validateCron(job.schedule)
+            return check.valid ? (
+              <div style={{ fontSize: 14, color: 'var(--fg)', fontFamily: 'var(--font-mono)' }}>{job.schedule}</div>
+            ) : (
+              <div>
+                <div style={{ fontSize: 14, fontFamily: 'var(--font-mono)', color: 'var(--err)' }}>⚠ {job.schedule}</div>
+                <div style={{ fontSize: 11, color: 'var(--err)', marginTop: 4 }}>{check.error} — <Link href={`/jobs/${id}/edit`} style={{ color: 'var(--err)' }}>Fix schedule</Link></div>
+              </div>
+            )
+          })()}
         </div>
         <div style={fieldStyle}>
           <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginBottom: 8 }}>Status</div>

--- a/apps/web/app/(dashboard)/jobs/jobs-table.tsx
+++ b/apps/web/app/(dashboard)/jobs/jobs-table.tsx
@@ -6,6 +6,7 @@ import type { ComponentProps }         from 'react'
 import { Badge }                       from '@/components/ui/badge'
 import { PageHeader }                  from '@/components/ui/page-header'
 import { pauseJobs, resumeJobs, deleteJobs } from '@/app/actions/jobs'
+import { validateCron }                from '@/lib/cron-validate'
 import type { RunDot }                 from './page'
 
 type BadgeStatus = ComponentProps<typeof Badge>['status']
@@ -155,8 +156,15 @@ export function JobsTable({
                       {job.name}
                     </Link>
                   </td>
-                  <td style={{ ...td, fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg-mute)' }}>
-                    {job.schedule}
+                  <td style={{ ...td, fontSize: 12 }}>
+                    {(() => {
+                      const check = validateCron(job.schedule)
+                      return check.valid ? (
+                        <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--fg-mute)' }}>{job.schedule}</span>
+                      ) : (
+                        <span style={{ color: 'var(--err)' }} title={check.error}>⚠ {job.schedule}</span>
+                      )
+                    })()}
                   </td>
                   <td style={td}>
                     <Badge status={job.enabled === true ? 'healthy' : 'paused'} label={job.enabled === true ? 'Enabled' : 'Disabled'} />

--- a/apps/web/app/(dashboard)/jobs/new/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/new/page.tsx
@@ -2,16 +2,18 @@ import { getDb, repositories, agents } from '@backupos/db'
 import { Button } from '@/components/ui/button'
 import { createJob } from '@/app/actions/jobs'
 import { SourceConfigSection } from '@/components/source-config-section'
+import { CronInput } from '@/components/cron-input'
 
 export default async function NewJobPage({
   searchParams,
 }: {
-  searchParams: Promise<{ name?: string; sourceType?: string; infraServiceId?: string }>
+  searchParams: Promise<{ name?: string; sourceType?: string; infraServiceId?: string; cronError?: string }>
 }) {
   const params              = await searchParams
   const prefillName         = params.name           ?? ''
   const prefillSourceType   = params.sourceType     ?? ''
   const prefillInfraService = params.infraServiceId ?? ''
+  const cronError           = params.cronError
 
   const db      = getDb()
   const [repos, agentList] = await Promise.all([
@@ -98,11 +100,11 @@ export default async function NewJobPage({
             <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6, fontWeight: 500 }}>
               Schedule (cron)
             </label>
-            <input
+            <CronInput
               name="schedule"
-              type="text"
               required
-              placeholder="0 2 * * *"
+              defaultValue=""
+              serverError={cronError}
               style={{
                 width: '100%', padding: '8px 12px',
                 backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
@@ -110,9 +112,6 @@ export default async function NewJobPage({
                 fontFamily: 'var(--font-mono)', outline: 'none', boxSizing: 'border-box',
               }}
             />
-            <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginTop: 4 }}>
-              Standard cron expression. e.g. <code>0 2 * * *</code> = daily at 02:00
-            </div>
           </div>
 
           {prefillInfraService && (

--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation'
 import { getDb, backupJobs, backupRuns, repositories, bandwidthProfiles, bandwidthRules, eq, inArray, and, lte, gte } from '@backupos/db'
 import { decryptField } from '@/lib/repo-crypto'
 import { dispatchToAgent } from '@/lib/internal-dispatch'
+import { validateCron } from '@/lib/cron-validate'
 
 function parseSourceConfig(sourceType: string, fd: FormData): string {
   const str = (k: string) => (fd.get(k) as string | null)?.trim() || undefined
@@ -61,6 +62,11 @@ export async function createJob(formData: FormData): Promise<void> {
   const infraServiceId = (formData.get('infraServiceId') as string) || null
 
   if (!name || !sourceType || !schedule) return
+
+  const cronCheck = validateCron(schedule)
+  if (!cronCheck.valid) {
+    redirect(`/jobs/new?cronError=${encodeURIComponent(`Invalid cron expression "${schedule}". ${cronCheck.error}. Examples: "0 2 * * *" (daily 2am), "*/15 * * * *" (every 15min).`)}`)
+  }
 
   const db = getDb()
   const id = crypto.randomUUID()
@@ -146,6 +152,11 @@ export async function updateJob(id: string, formData: FormData): Promise<void> {
   const schedule     = (formData.get('schedule')     as string)?.trim()
 
   if (!name || !sourceType || !schedule) return
+
+  const cronCheck = validateCron(schedule)
+  if (!cronCheck.valid) {
+    redirect(`/jobs/${id}/edit?cronError=${encodeURIComponent(`Invalid cron expression "${schedule}". ${cronCheck.error}. Examples: "0 2 * * *" (daily 2am), "*/15 * * * *" (every 15min).`)}`)
+  }
 
   const db = getDb()
   await db.update(backupJobs).set({

--- a/apps/web/components/cron-input.tsx
+++ b/apps/web/components/cron-input.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState } from 'react'
+import { validateCron } from '@/lib/cron-validate'
+
+interface Props {
+  name: string
+  defaultValue?: string
+  required?: boolean
+  style?: React.CSSProperties
+  serverError?: string
+}
+
+const HINT = 'Standard cron. e.g. 0 2 * * * = daily at 02:00'
+const EXAMPLES = '"0 2 * * *" (daily 2am), "*/15 * * * *" (every 15min).'
+
+export function CronInput({ name, defaultValue = '', required, style, serverError }: Props) {
+  const initError = serverError ?? (() => {
+    if (!defaultValue) return null
+    const r = validateCron(defaultValue)
+    return r.valid ? null : r.error
+  })()
+
+  const [error, setError] = useState<string | null>(initError)
+
+  return (
+    <>
+      <input
+        name={name}
+        type="text"
+        required={required}
+        defaultValue={defaultValue}
+        onChange={e => {
+          const v = e.target.value.trim()
+          if (!v) { setError(null); return }
+          const r = validateCron(v)
+          setError(r.valid ? null : r.error)
+        }}
+        style={{ ...style, ...(error ? { borderColor: 'var(--err)' } : {}) }}
+      />
+      {error ? (
+        <div style={{ fontSize: 11, color: 'var(--err)', marginTop: 4 }}>
+          {error}. Examples: {EXAMPLES}
+        </div>
+      ) : (
+        <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginTop: 4 }}>{HINT}</div>
+      )}
+    </>
+  )
+}

--- a/apps/web/lib/cron-validate.ts
+++ b/apps/web/lib/cron-validate.ts
@@ -1,0 +1,10 @@
+import { parseExpression } from 'cron-parser'
+
+export function validateCron(expression: string): { valid: true } | { valid: false; error: string } {
+  try {
+    parseExpression(expression)
+    return { valid: true }
+  } catch (err) {
+    return { valid: false, error: err instanceof Error ? err.message : 'Invalid cron expression' }
+  }
+}


### PR DESCRIPTION
## Summary
- New `apps/web/lib/cron-validate.ts` — pure `validateCron()` using the same `cron-parser` library as the scheduler
- New `apps/web/components/cron-input.tsx` — client component that validates on-change and shows inline error (or hint when valid)
- `createJob` / `updateJob` server actions validate the cron string before persisting; invalid expressions redirect back to the form with a `?cronError=` message
- Jobs list (`jobs-table.tsx`) and job detail page show a red `⚠ Invalid: <schedule>` indicator for rows with bad crons — covers the existing `dockee01` (`02**`) and `proxyos-app-test` (`02***`) jobs without touching DB rows

## Test plan
- [ ] Type `02**` in the schedule field on job-create → inline error appears immediately; hitting Save redirects back with the error still visible
- [ ] Type `0 2 * * *` → error clears; Save succeeds
- [ ] Open job-list with `dockee01` and `proxyos-app-test` in DB → both show `⚠ Invalid: 02**` / `⚠ Invalid: 02***` with tooltip
- [ ] Open edit page for `proxyos-app-test` → cron field renders with inline error already shown; fix to `0 0 1 1 *` → error clears; Save → warning gone from list/detail
- [ ] After fixing all bad-cron jobs: restart server → no `[scheduler] Invalid cron` log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)