### PR TITLE
feat(agent): implement compose backup handler (Task 7 — smoke test gate)

### DIFF
--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -408,6 +408,7 @@ void app.prepare().then(() => {
             status: 'success', completedAt: new Date(),
             log:             msg.log ?? null,
             snapshotId:      msg.snapshotId,
+            snapshotIds:     msg.snapshotIds ? JSON.stringify(msg.snapshotIds) : null,
             filesNew:        msg.stats.filesNew,
             filesChanged:    msg.stats.filesChanged,
             filesUnmodified: msg.stats.filesUnmodified,

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -129,9 +129,9 @@ export type AgentMessage =
   | { type: 'ping' }
   | { type: 'metrics'; metrics: AgentMetrics }
   | { type: 'backup_start'; jobId: string; config: BackupJobConfig }
-  | { type: 'backup_heartbeat'; jobId: string; runId: string; phase: 'starting' | 'scanning' | 'uploading' | 'finalizing'; lastResticEventAt: number }
+  | { type: 'backup_heartbeat'; jobId: string; runId: string; phase: 'starting' | 'scanning' | 'uploading' | 'finalizing' | 'quiescing' | 'resuming'; lastResticEventAt: number }
   | { type: 'backup_progress'; jobId: string; pct: number; filesProcessed: number; bytesProcessed: number; filesTotal: number; bytesTotal: number; secondsRemaining?: number }
-  | { type: 'backup_complete'; jobId: string; snapshotId: string; stats: BackupStats; log?: string }
+  | { type: 'backup_complete'; jobId: string; snapshotId: string; snapshotIds?: string[]; stats: BackupStats; log?: string }
   | { type: 'backup_failed'; jobId: string; error: string; detail: string; log?: string }
   | { type: 'backup_cancelled'; jobId: string; runId: string; reason: 'user_requested' | 'not_running' | 'agent_disconnect' }
   | { type: 'restore_start'; restoreId: string; specId: string }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -132,8 +132,8 @@ let ws: WebSocket | null = null
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null
 let shuttingDown = false
 
-type BackupPhase = 'starting' | 'scanning' | 'uploading' | 'finalizing'
-interface ActiveJob { ctrl: AbortController; runId: string; phase: BackupPhase; lastResticEventAt: number; cancelled: boolean }
+type BackupPhase = 'starting' | 'scanning' | 'uploading' | 'finalizing' | 'quiescing' | 'resuming'
+interface ActiveJob { ctrl: AbortController; runId: string; phase: string; lastResticEventAt: number; cancelled: boolean }
 
 // Active jobs — keyed by jobId
 const activeJobs = new Map<string, ActiveJob>()
@@ -145,7 +145,7 @@ setInterval(() => {
       type:              'backup_heartbeat',
       jobId,
       runId:             job.runId,
-      phase:             job.phase,
+      phase:             (job.phase as BackupPhase) ?? 'starting',
       lastResticEventAt: job.lastResticEventAt,
     })
   }
@@ -228,7 +228,10 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
     void verifyRepo(msg.repoId, msg.repoUrl, msg.repoPassword, msg.readData, msg.envVars)
 
   } else if (msg.type === 'run_compose_backup') {
-    send({ type: 'backup_failed', jobId: msg.jobId, error: 'compose backup execution not implemented yet (Task 7)', detail: '' })
+    void (async () => {
+      const { runComposeBackup } = await import('./handlers/composeBackup')
+      await runComposeBackup(msg, send, activeJobs, BINARY, ensureRepoInitialized)
+    })()
 
   } else if (msg.type === 'list_compose_project') {
     void (async () => {

--- a/packages/agent/src/handlers/composeBackup.ts
+++ b/packages/agent/src/handlers/composeBackup.ts
@@ -1,0 +1,195 @@
+import { ResticEngine } from '@backupos/engine'
+import type { AgentMessage, ServerMessage, ComposeServiceConfig } from '@backupos/agent-protocol'
+import {
+  listComposeContainers,
+  pauseContainer, unpauseContainer,
+  stopContainer, startContainer, waitForRunning,
+} from '../docker-client'
+
+type SendFn = (msg: AgentMessage) => void
+type RunMsg = Extract<ServerMessage, { type: 'run_compose_backup' }>
+type EnsureRepoFn = (engine: ResticEngine, repoId: string) => Promise<void>
+
+interface ActiveJobRef {
+  ctrl: AbortController
+  runId: string
+  phase: string
+  lastResticEventAt: number
+  cancelled: boolean
+}
+
+async function quiesce(containerId: string, strategy: ComposeServiceConfig['quiescence']): Promise<void> {
+  switch (strategy) {
+    case 'none':    return
+    case 'pause':   await pauseContainer(containerId); return
+    case 'stop':    await stopContainer(containerId); return
+    case 'apphook': throw new Error('apphook quiescence not implemented yet (Task 8)')
+  }
+}
+
+async function resumeService(containerId: string, strategy: ComposeServiceConfig['quiescence']): Promise<void> {
+  switch (strategy) {
+    case 'none':   return
+    case 'pause':  await unpauseContainer(containerId); return
+    case 'stop':
+      await startContainer(containerId)
+      await waitForRunning(containerId, 30_000)
+      return
+    case 'apphook': return
+  }
+}
+
+export async function runComposeBackup(
+  msg: RunMsg,
+  send: SendFn,
+  activeJobs: Map<string, ActiveJobRef>,
+  binaryPath: string | undefined,
+  ensureRepo: EnsureRepoFn,
+): Promise<void> {
+  const { jobId, runId, config, repoId, repoUrl, repoPassword, envVars } = msg
+  const ctrl = new AbortController()
+
+  activeJobs.set(jobId, { ctrl, runId, phase: 'starting', lastResticEventAt: Date.now(), cancelled: false })
+
+  const logLines: string[] = []
+  const snapshotIds: string[] = []
+  const agg = { filesNew: 0, filesChanged: 0, filesUnmodified: 0, dataAdded: 0, totalSize: 0, durationMs: 0 }
+
+  function setPhase(phase: string): void {
+    const j = activeJobs.get(jobId)
+    if (j) { j.phase = phase; j.lastResticEventAt = Date.now() }
+  }
+
+  const makeEngine = () => new ResticEngine({
+    repositoryUrl: repoUrl,
+    password:      repoPassword,
+    envVars:       envVars ?? {},
+    binaryPath,
+  })
+
+  try {
+    await ensureRepo(makeEngine(), repoId)
+
+    const services = config.services.filter(s => s.included)
+
+    for (const service of services) {
+      if (service.includedVolumes.length === 0) {
+        logLines.push(`[compose] SKIP: "${service.serviceName}" — no included volumes`)
+        continue
+      }
+
+      const containers = await listComposeContainers(config.projectName)
+      const target = containers.find(
+        c => (c.Labels['com.docker.compose.service'] ?? '') === service.serviceName,
+      )
+      if (!target) {
+        logLines.push(`[compose] WARN: "${service.serviceName}" not found in Docker — skipping`)
+        continue
+      }
+
+      // Quiesce
+      setPhase('quiescing')
+      try {
+        await quiesce(target.Id, service.quiescence)
+        if (service.quiescence !== 'none') {
+          logLines.push(`[compose] quiesced "${service.serviceName}" (${service.quiescence})`)
+        }
+      } catch (err) {
+        const e = err instanceof Error ? err.message : String(err)
+        logLines.push(`[compose] FAIL: quiesce "${service.serviceName}" → ${e}`)
+        throw new Error(`quiesce failed for "${service.serviceName}": ${e}`)
+      }
+
+      // Back up volumes
+      setPhase('uploading')
+      let volumeBackupOk = false
+      try {
+        const paths = service.includedVolumes.map(v => `/var/lib/docker/volumes/${v}/_data`)
+        const result = await makeEngine().backup({
+          paths,
+          tags: [
+            `job:${jobId}`,
+            `compose:${config.projectName}`,
+            `service:${service.serviceName}`,
+          ],
+          signal: ctrl.signal,
+        })
+        snapshotIds.push(result.snapshotId)
+        agg.filesNew        += result.filesNew
+        agg.filesChanged    += result.filesChanged
+        agg.filesUnmodified += result.filesUnmodified
+        agg.dataAdded       += result.dataAdded
+        agg.totalSize       += result.totalSize
+        agg.durationMs      += result.duration
+        logLines.push(result.log)
+        volumeBackupOk = true
+      } catch (err) {
+        const e = err instanceof Error ? err.message : String(err)
+        logLines.push(`[compose] FAIL: restic backup "${service.serviceName}" → ${e}`)
+        setPhase('resuming')
+        await resumeService(target.Id, service.quiescence).catch(re => {
+          logLines.push(`[compose] WARN: resume "${service.serviceName}" after backup failure → ${re instanceof Error ? re.message : String(re)}`)
+        })
+        throw new Error(`backup failed for "${service.serviceName}": ${e}`)
+      }
+
+      // Resume
+      if (volumeBackupOk) {
+        setPhase('resuming')
+        try {
+          await resumeService(target.Id, service.quiescence)
+          if (service.quiescence !== 'none') {
+            logLines.push(`[compose] resumed "${service.serviceName}"`)
+          }
+        } catch (err) {
+          logLines.push(`[compose] WARN: resume "${service.serviceName}" failed → ${err instanceof Error ? err.message : String(err)}`)
+        }
+      }
+    }
+
+    // Optionally back up the compose file itself
+    if (config.includeComposeFile && config.composeFilePath) {
+      setPhase('uploading')
+      try {
+        const result = await makeEngine().backup({
+          paths: [config.composeFilePath],
+          tags:  [`job:${jobId}`, `compose:${config.projectName}`, 'meta:compose-file'],
+          signal: ctrl.signal,
+        })
+        snapshotIds.push(result.snapshotId)
+        logLines.push(result.log)
+      } catch (err) {
+        logLines.push(`[compose] WARN: backup of compose file failed → ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }
+
+    setPhase('finalizing')
+    send({
+      type:       'backup_complete',
+      jobId,
+      snapshotId: snapshotIds[0] ?? 'multi',
+      snapshotIds,
+      stats: {
+        filesNew:            agg.filesNew,
+        filesChanged:        agg.filesChanged,
+        filesUnmodified:     agg.filesUnmodified,
+        dataAdded:           agg.dataAdded,
+        totalFilesProcessed: agg.filesNew + agg.filesChanged + agg.filesUnmodified,
+        totalBytesProcessed: agg.totalSize,
+        durationMs:          agg.durationMs,
+      },
+      log: logLines.join('\n').slice(0, 1_000_000) || undefined,
+    })
+
+  } catch (err) {
+    send({
+      type:   'backup_failed',
+      jobId,
+      error:  err instanceof Error ? err.message : String(err),
+      detail: err instanceof Error && err.stack ? err.stack : '',
+      log:    logLines.join('\n').slice(0, 1_000_000) || undefined,
+    })
+  } finally {
+    activeJobs.delete(jobId)
+  }
+}

--- a/packages/db/migrations/0026_snapshot_ids.sql
+++ b/packages/db/migrations/0026_snapshot_ids.sql
@@ -1,0 +1,1 @@
+ALTER TABLE backup_runs ADD COLUMN snapshot_ids TEXT;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1745971200000,
       "tag": "0025_run_heartbeat",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1746057600000,
+      "tag": "0026_snapshot_ids",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -123,7 +123,8 @@ export const backupRuns = sqliteTable('backup_runs', {
 
   status:  text('status').notNull(), // 'running'|'success'|'failed'|'cancelled'
   trigger: text('trigger').notNull(), // 'scheduled'|'manual'|'api'
-  snapshotId: text('snapshot_id'),  // Restic snapshot ID on success
+  snapshotId:  text('snapshot_id'),   // Restic snapshot ID on success (single-snapshot jobs)
+  snapshotIds: text('snapshot_ids'),  // JSON string[] for compose backups (multiple snapshots)
 
   // Stats
   filesNew:        integer('files_new'),


### PR DESCRIPTION
## Summary
- New `packages/agent/src/handlers/composeBackup.ts` — `runComposeBackup()` handles the full per-service lifecycle: quiesce → restic backup → resume
- `quiescence: 'none' | 'pause' | 'stop'` fully supported; `'apphook'` throws "not implemented yet (Task 8)"
- Resume is always attempted after a backup failure so services aren't left stopped; resume failures are warnings, not errors
- `backup_heartbeat` gains `'quiescing'` and `'resuming'` phases in agent-protocol
- `backup_complete` gains optional `snapshotIds?: string[]` for the per-service snapshot array
- DB migration `0026_snapshot_ids` adds `snapshot_ids TEXT` to `backup_runs`
- `server.ts` stores `snapshotIds` as a JSON string on `backup_complete`

## Smoke test gate
This is the gate PR. Deploy to Dockee01, then trigger `proxyos-app-test` with `quiescence: stop`:

```bash
sudo sqlite3 /var/lib/backupos/backupos.db \
  "UPDATE backup_jobs SET next_run_at = cast(strftime('%s','now') as integer) * 1000 WHERE name='proxyos-app-test';"
```

Pass conditions:
- [ ] Run row: `status=success`, `files_new > 0`, `total_size > 0`, `snapshot_ids` is a non-empty JSON array
- [ ] proxyos-app containers show `Up` after the run (stop → start round-trip completed)
- [ ] Agent journal shows `quiesced → resumed` log lines with no errors

## Test plan
- [ ] Deploy `apps/web` and `packages/agent` bundle to Dockee01
- [ ] Run smoke test above and verify all pass conditions
- [ ] Trigger a normal filesystem job — confirm `run_backup` path still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)