### PR TITLE
fix(compose-wizard): hydrate edit-mode from saved config, guard empty compose on save

### DIFF
--- a/apps/web/app/(dashboard)/jobs/[id]/edit/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/[id]/edit/page.tsx
@@ -11,10 +11,10 @@ export default async function EditJobPage({
   searchParams,
 }: {
   params: Promise<{ id: string }>
-  searchParams: Promise<{ cronError?: string }>
+  searchParams: Promise<{ cronError?: string; composeError?: string }>
 }) {
   const { id }      = await params
-  const { cronError } = await searchParams
+  const { cronError, composeError } = await searchParams
   const db = getDb()
 
   const [[job], repos, agentList] = await Promise.all([
@@ -59,6 +59,7 @@ export default async function EditJobPage({
           <SourceConfigSection
             defaultSourceType={job.sourceType}
             initialConfig={job.sourceConfig}
+            composeError={composeError}
           />
 
           <div style={{ marginBottom: 20 }}>

--- a/apps/web/app/(dashboard)/jobs/new/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/new/page.tsx
@@ -7,13 +7,14 @@ import { CronInput } from '@/components/cron-input'
 export default async function NewJobPage({
   searchParams,
 }: {
-  searchParams: Promise<{ name?: string; sourceType?: string; infraServiceId?: string; cronError?: string }>
+  searchParams: Promise<{ name?: string; sourceType?: string; infraServiceId?: string; cronError?: string; composeError?: string }>
 }) {
   const params              = await searchParams
   const prefillName         = params.name           ?? ''
   const prefillSourceType   = params.sourceType     ?? ''
   const prefillInfraService = params.infraServiceId ?? ''
   const cronError           = params.cronError
+  const composeError        = params.composeError
 
   const db      = getDb()
   const [repos, agentList] = await Promise.all([
@@ -62,7 +63,10 @@ export default async function NewJobPage({
             />
           </div>
 
-          <SourceConfigSection defaultSourceType={prefillSourceType || 'filesystem'} />
+          <SourceConfigSection
+            defaultSourceType={prefillSourceType || 'filesystem'}
+            composeError={composeError}
+          />
 
           <div style={{ marginBottom: 20 }}>
             <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6, fontWeight: 500 }}>

--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -68,6 +68,13 @@ export async function createJob(formData: FormData): Promise<void> {
     redirect(`/jobs/new?cronError=${encodeURIComponent(`Invalid cron expression "${schedule}". ${cronCheck.error}. Examples: "0 2 * * *" (daily 2am), "*/15 * * * *" (every 15min).`)}`)
   }
 
+  if (sourceType === 'compose_project') {
+    const raw = (formData.get('composeConfig') as string | null)?.trim() ?? ''
+    let ok = false
+    try { const p = JSON.parse(raw) as { services?: unknown }; ok = Array.isArray(p.services) && (p.services as unknown[]).length > 0 } catch { /* ok stays false */ }
+    if (!ok) redirect(`/jobs/new?composeError=${encodeURIComponent('Discover and configure at least one service before saving.')}`)
+  }
+
   const db = getDb()
   const id = crypto.randomUUID()
   await db.insert(backupJobs).values({
@@ -156,6 +163,13 @@ export async function updateJob(id: string, formData: FormData): Promise<void> {
   const cronCheck = validateCron(schedule)
   if (!cronCheck.valid) {
     redirect(`/jobs/${id}/edit?cronError=${encodeURIComponent(`Invalid cron expression "${schedule}". ${cronCheck.error}. Examples: "0 2 * * *" (daily 2am), "*/15 * * * *" (every 15min).`)}`)
+  }
+
+  if (sourceType === 'compose_project') {
+    const raw = (formData.get('composeConfig') as string | null)?.trim() ?? ''
+    let ok = false
+    try { const p = JSON.parse(raw) as { services?: unknown }; ok = Array.isArray(p.services) && (p.services as unknown[]).length > 0 } catch { /* ok stays false */ }
+    if (!ok) redirect(`/jobs/${id}/edit?composeError=${encodeURIComponent('Discover and configure at least one service before saving.')}`)
   }
 
   const db = getDb()

--- a/apps/web/components/compose-project-fields.tsx
+++ b/apps/web/components/compose-project-fields.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import type { ComposeProjectConfig, ComposeServiceConfig } from '@backupos/agent-protocol'
 
 type QuiescenceType = 'none' | 'pause' | 'stop' | 'apphook'
 type ApphookType = 'postgres' | 'mysql' | 'redis' | 'sqlite'
@@ -75,6 +76,43 @@ function buildConfig(projectName: string, listing: Listing, services: ServiceSta
   }
 }
 
+function synthesizeListing(config: ComposeProjectConfig): Listing {
+  return {
+    name: config.projectName,
+    composeFilePath: config.composeFilePath,
+    services: config.services.map(s => ({
+      name: s.serviceName,
+      image: '',
+      containerStatus: '(saved)',
+      volumes: s.includedVolumes.map(v => ({ type: 'volume' as const, name: v, target: '' })),
+      binds: s.includedBindMounts ?? [],
+      defaultQuiescence: s.quiescence,
+      defaultApphookType: s.apphookType,
+    })),
+  }
+}
+
+function hydrateService(s: ComposeServiceConfig): ServiceState {
+  const q = s.quiescence
+  const at = (s.apphookType ?? 'postgres') as ApphookType
+  const d = APPHOOK_DEFAULTS[at] ?? APPHOOK_DEFAULTS.postgres!
+  return {
+    name: s.serviceName,
+    image: '',
+    containerStatus: '(saved)',
+    quiescence: q,
+    apphookType: at,
+    apphookUsername:    s.apphookConfig?.username    ?? '',
+    apphookPasswordEnv: s.apphookConfig?.passwordEnv ?? '',
+    apphookDatabase:    s.apphookConfig?.database    ?? d.database,
+    apphookHost:        s.apphookConfig?.host        ?? '',
+    apphookPort:        s.apphookConfig?.port ? String(s.apphookConfig.port) : (d.port > 0 ? String(d.port) : ''),
+    includedVolumes: s.includedVolumes,
+    allVolumes: s.includedVolumes.map(v => ({ name: v, target: '' })),
+    binds: s.includedBindMounts ?? [],
+  }
+}
+
 function initService(s: ListingService): ServiceState {
   const q = (s.defaultQuiescence ?? 'stop') as QuiescenceType
   const at = (s.defaultApphookType ?? 'postgres') as ApphookType
@@ -91,12 +129,21 @@ function initService(s: ListingService): ServiceState {
   }
 }
 
-export function ComposeProjectFields() {
-  const [projectName, setProjectName] = useState('')
+export function ComposeProjectFields({
+  initialConfig,
+  serverError,
+}: {
+  initialConfig?: ComposeProjectConfig
+  serverError?: string
+} = {}) {
+  const initialListing = initialConfig?.services?.length ? synthesizeListing(initialConfig) : undefined
+  const [projectName, setProjectName] = useState(initialConfig?.projectName ?? '')
   const [discovering, setDiscovering] = useState(false)
   const [discoverError, setDiscoverError] = useState<string | undefined>()
-  const [listing, setListing] = useState<Listing | undefined>()
-  const [services, setServices] = useState<ServiceState[]>([])
+  const [listing, setListing] = useState<Listing | undefined>(initialListing)
+  const [services, setServices] = useState<ServiceState[]>(
+    initialConfig?.services?.length ? initialConfig.services.map(hydrateService) : [],
+  )
 
   const discover = async () => {
     const agentId = document.querySelector<HTMLSelectElement>('select[name="agentId"]')?.value
@@ -112,7 +159,19 @@ export function ComposeProjectFields() {
       if (!res.ok) { setDiscoverError((body as { error?: string }).error ?? 'Discovery failed'); return }
       const l = body as Listing
       setListing(l)
-      setServices(l.services.map(initService))
+      setServices(prev => l.services.map(newSvc => {
+        const existing = prev.find(s => s.name === newSvc.name)
+        if (existing) {
+          return {
+            ...existing,
+            image: newSvc.image,
+            containerStatus: newSvc.containerStatus,
+            allVolumes: newSvc.volumes.filter(v => v.type === 'volume').map(v => ({ name: v.name, target: v.target })),
+            binds: newSvc.binds,
+          }
+        }
+        return initService(newSvc)
+      }))
     } catch { setDiscoverError('Network error — check the agent is connected') }
     finally { setDiscovering(false) }
   }
@@ -148,6 +207,20 @@ export function ComposeProjectFields() {
         <div style={{ fontSize: 12, color: 'var(--err)', marginBottom: 8, padding: '6px 10px',
           background: 'color-mix(in srgb, var(--err) 10%, transparent)', borderRadius: 'var(--radius-sm)' }}>
           {discoverError}
+        </div>
+      )}
+
+      {serverError && (
+        <div style={{ fontSize: 12, color: 'var(--err)', marginBottom: 8, padding: '6px 10px',
+          background: 'color-mix(in srgb, var(--err) 10%, transparent)', borderRadius: 'var(--radius-sm)' }}>
+          {serverError}
+        </div>
+      )}
+
+      {!listing && (
+        <div style={{ fontSize: 12, color: 'var(--fg-mute)', marginBottom: 8, padding: '6px 10px',
+          background: 'var(--surf3)', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)' }}>
+          No services discovered yet. Enter the project name above and click "Discover services".
         </div>
       )}
 

--- a/apps/web/components/source-config-section.tsx
+++ b/apps/web/components/source-config-section.tsx
@@ -27,7 +27,7 @@ const hintStyle: React.CSSProperties = {
   fontSize: 11, color: 'var(--fg-dim)', marginTop: 4,
 }
 
-import type { DetectedResources } from '@backupos/agent-protocol'
+import type { DetectedResources, ComposeProjectConfig } from '@backupos/agent-protocol'
 import { ComposeProjectFields } from './compose-project-fields'
 
 type Cfg = Record<string, unknown>
@@ -317,12 +317,22 @@ const DETECTABLE = new Set(['filesystem', 'docker_volume', 'database'])
 export function SourceConfigSection({
   defaultSourceType,
   initialConfig,
+  composeError,
 }: {
   defaultSourceType?: string
   initialConfig?: string
+  composeError?: string
 }) {
   const cfg: Cfg = (() => {
     try { return JSON.parse(initialConfig ?? '{}') as Cfg } catch { return {} }
+  })()
+
+  const composeInitialConfig: ComposeProjectConfig | undefined = (() => {
+    if (defaultSourceType !== 'compose_project') return undefined
+    try {
+      const p = JSON.parse(initialConfig ?? '{}') as ComposeProjectConfig
+      return Array.isArray(p.services) ? p : undefined
+    } catch { return undefined }
   })()
   const [selected, setSelected] = useState(defaultSourceType ?? 'filesystem')
   const [detecting, setDetecting] = useState(false)
@@ -404,7 +414,9 @@ export function SourceConfigSection({
           <div style={{ fontSize: 11, color: 'var(--err)', marginTop: 4 }}>{detectError}</div>
         )}
         {selected === 'filesystem'      && <FilesystemFields cfg={cfg} detected={detected} />}
-        {selected === 'compose_project' && <ComposeProjectFields />}
+        {selected === 'compose_project' && (
+          <ComposeProjectFields initialConfig={composeInitialConfig} serverError={composeError} />
+        )}
         {selected === 'docker_volume'   && <DockerVolumeFields cfg={cfg} detected={detected} />}
         {selected === 'database'       && <DatabaseFields cfg={cfg} detected={detected} />}
         {selected === 'proxmox_vm'     && <ProxmoxFields label="VM" cfg={cfg} />}


### PR DESCRIPTION
## Summary

- **Edit-mode hydration**: `ComposeProjectFields` now accepts `initialConfig?: ComposeProjectConfig` and synthesizes a listing from the saved config, so the edit page loads with services pre-filled instead of blank
- **Merge on re-discover**: clicking "Re-discover services" preserves existing quiescence/apphook selections for services that still exist, only resetting them for new services
- **Server-side guard**: `createJob` and `updateJob` redirect with `?composeError=` when `composeConfig` is empty (no discovery done), preventing the `Cannot read properties of undefined (reading 'filter')` crash in `composeBackup.ts`
- **Error threading**: `composeError` flows from searchParams → `SourceConfigSection` → `ComposeProjectFields` and displays inline

## Test plan

- [ ] Open edit page for a compose_project job with a saved config — services should render pre-filled
- [ ] Change quiescence setting on a service, then click "Re-discover" — setting should be preserved
- [ ] Create a new compose_project job without clicking "Discover" and submit — should redirect back with error banner "Discover and configure at least one service before saving."
- [ ] Verify a normal compose_project job (with discovered services) still saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)