### PR TITLE
feat(container): agent Dockerfile + docker-compose.yml template

### DIFF
--- a/apps/agent-container/.dockerignore
+++ b/apps/agent-container/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!bundle.js

--- a/apps/agent-container/Dockerfile
+++ b/apps/agent-container/Dockerfile
@@ -27,4 +27,4 @@ RUN mkdir -p /var/lib/backupos
 # sees the child exit and Docker's restart: unless-stopped policy brings the container
 # back up with the updated bundle.
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["/usr/local/bin/node", "/app/agent.js"]
+CMD ["/usr/local/bin/node", "/app/agent.js", "run"]

--- a/apps/agent-container/Dockerfile
+++ b/apps/agent-container/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:20-alpine
+
+# restic  — required for backup/restore
+# tini    — proper PID 1 / signal handling (ensures Docker stop/restart works correctly)
+# curl    — used by the agent's bundle self-update download
+RUN apk add --no-cache restic tini curl ca-certificates
+
+# The agent runs as root inside the container so it can read mounted Docker volumes
+# (which are root-owned) and so docker-cli operations against /var/run/docker.sock work.
+# The container itself is the security boundary, not the process user.
+WORKDIR /app
+
+# bundle.js is copied into the build context by the build:container script
+# (cp ../web/public/agent/bundle.js ./bundle.js before docker build)
+COPY bundle.js /app/agent.js
+
+# Restic cache — persist across restarts via a named volume mounted at this path
+ENV XDG_CACHE_HOME=/var/cache/restic
+ENV HOME=/root
+RUN mkdir -p /var/cache/restic
+
+# Agent state (enrollment token, bundle hash) — persist via named volume at this path
+RUN mkdir -p /var/lib/backupos
+
+# tini as PID 1 handles SIGTERM/SIGCHLD correctly and reaps zombie processes.
+# When the agent self-updates (controlled exit + re-spawn via process.argv), tini
+# sees the child exit and Docker's restart: unless-stopped policy brings the container
+# back up with the updated bundle.
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/usr/local/bin/node", "/app/agent.js"]

--- a/apps/agent-container/package.json
+++ b/apps/agent-container/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@backupos/agent-container",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "build:container": "cp ../web/public/agent/bundle.js ./bundle.js && docker build -t backupos/agent:dev .",
+    "build:container:clean": "cp ../web/public/agent/bundle.js ./bundle.js && docker build --no-cache -t backupos/agent:dev ."
+  }
+}

--- a/apps/web/public/agent/docker-compose.yml
+++ b/apps/web/public/agent/docker-compose.yml
@@ -1,0 +1,61 @@
+# BackupOS Agent — Docker Compose template
+#
+# Usage:
+#   1. Copy this file to your host
+#   2. Set BACKUPOS_URL and BACKUPOS_TOKEN below (or export them as env vars)
+#   3. Run: docker compose -f docker-compose.yml up -d
+#
+# Mounts control what this agent can do:
+#   - Docker socket     enables: docker capability + compose backup/restore
+#   - docker/volumes    enables: reading volume data for compose source type
+#   - /host             enables: filesystem source backups of host paths
+#
+# Comment out mounts you don't want — capability detection adapts at startup.
+#
+# Extending with apphook binaries (pg_dump, mysqldump, redis-cli, sqlite3):
+#   The base image does not include database client tools. To enable apphook
+#   quiescence (dump-based backup), extend the image:
+#
+#     FROM backupos/agent:latest
+#     RUN apk add postgresql-client mysql-client redis sqlite
+#
+#   Then set image: your-custom-image below.
+
+services:
+  backupos-agent:
+    image: backupos/agent:latest
+    container_name: backupos-agent
+    restart: unless-stopped
+
+    environment:
+      # REQUIRED: WebSocket URL of the BackupOS server (no trailing slash).
+      # Use ws:// for plain or wss:// for TLS.
+      BACKUPOS_URL: ws://your-backupos-server:3093/ws/agent
+
+      # REQUIRED: enrollment token from the BackupOS UI (Agents → New Agent).
+      BACKUPOS_TOKEN: your-enrollment-token-here
+
+      # Optional: override Docker socket path if not using the default unix socket.
+      # DOCKER_HOST: tcp://docker-host:2375
+
+    volumes:
+      # Docker socket — required for compose source type and docker capability.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+      # Docker volumes — required to read volume data during compose backups.
+      - /var/lib/docker/volumes:/var/lib/docker/volumes:rw
+
+      # Host filesystem — uncomment to enable filesystem source backups.
+      # Backup paths configured in BackupOS should use /host/<path> as the
+      # agent-side path (e.g. /host/etc for the host's /etc).
+      # - /:/host:ro
+
+      # Persistent agent state: enrollment token, bundle hash for self-update.
+      - backupos-agent-state:/var/lib/backupos
+
+      # Restic cache: speeds up subsequent backup operations.
+      - backupos-agent-cache:/var/cache/restic
+
+volumes:
+  backupos-agent-state:
+  backupos-agent-cache:


### PR DESCRIPTION
## Summary

- `apps/agent-container/Dockerfile` — node:20-alpine image with restic, tini, curl; copies bundled `agent.js`; tini as PID 1
- `apps/agent-container/.dockerignore` — minimal build context (Dockerfile + bundle.js only)
- `apps/agent-container/package.json` — `build:container` script: `cp ../web/public/agent/bundle.js ./bundle.js && docker build -t backupos/agent:dev .`
- `apps/web/public/agent/docker-compose.yml` — served at `/agent/docker-compose.yml`; users curl + edit two env vars + `docker compose up -d`

## Architecture notes

**Mounts control capabilities** — no image variants. User mounts determine what the agent reports:
- `/var/run/docker.sock` → `docker` capability + compose backup/restore
- `/var/lib/docker/volumes` → volume data access for compose source type
- `/:/host:ro` (optional) → filesystem source backups
- No apphook binaries in base image — users extend the image if needed (documented in the compose file)

**Self-update + tini**: when the agent self-updates (controlled exit → re-spawn via `process.argv`), tini reaps the child and Docker's `restart: unless-stopped` brings the container back. Smoke test (Test 5) verifies convergence.

**Persistent volumes**: `backupos-agent-state` (enrollment token + bundle hash) and `backupos-agent-cache` (restic cache) survive container restarts.

## Known follow-up

`capabilities.ts:canReadFilesystem()` probes `/`, which is always readable inside the container regardless of whether `/host` is mounted. A container agent therefore always reports `filesystem` capability even with no host filesystem mount. This is a pre-existing behaviour; fixing it (probe `/host` in container context) is out of scope for this PR.

## Not included (per spec scope)

- Registry publish / multi-arch buildx — Task 11
- Helm chart / Kubernetes deployment
- Wizard UI for deploying a container agent
- Apphook binaries baked into the base image

## Test plan

- [ ] `cd apps/agent-container && npm run build:container` builds successfully
- [ ] `docker run --rm -e BACKUPOS_URL=... -e BACKUPOS_TOKEN=... backupos/agent:dev` connects, enrolls, reports capabilities
- [ ] Named volumes persist enrollment token across `docker compose restart`
- [ ] Self-update: deploy new bundle on server → container logs show hash mismatch → container restarts → reconnects with new hash
- [ ] `curl http://<server>:3093/agent/docker-compose.yml` returns the compose file

🤖 Generated with [Claude Code](https://claude.com/claude-code)