### PR TITLE
fix(container): document filesystem repo mount requirement in docker-compose.yml

### DIFF
--- a/apps/web/public/agent/docker-compose.yml
+++ b/apps/web/public/agent/docker-compose.yml
@@ -6,9 +6,12 @@
 #   3. Run: docker compose -f docker-compose.yml up -d
 #
 # Mounts control what this agent can do:
-#   - Docker socket     enables: docker capability + compose backup/restore
-#   - docker/volumes    enables: reading volume data for compose source type
-#   - /host             enables: filesystem source backups of host paths
+#   - Docker socket          enables: docker capability + compose backup/restore
+#   - docker/volumes         enables: reading volume data for compose source type
+#   - /host                  enables: filesystem source backups of host paths
+#   - Repository path(s)     REQUIRED if your repository is filesystem-based
+#                            (e.g. /mnt/backupos, /srv/restic, /var/restic)
+#                            S3/SFTP/restic-rest repositories don't need a mount.
 #
 # Comment out mounts you don't want — capability detection adapts at startup.
 #
@@ -44,6 +47,18 @@ services:
 
       # Docker volumes — required to read volume data during compose backups.
       - /var/lib/docker/volumes:/var/lib/docker/volumes:rw
+
+      # Restic repository (REQUIRED for filesystem-path repos):
+      # If your BackupOS repository is configured with a filesystem path like
+      # /mnt/backupos or /srv/restic, you MUST mount that path here. The agent
+      # writes snapshots to this exact path inside the container, so the path
+      # inside and outside the container must match.
+      #
+      # Example for a repository at /mnt/backupos on the host:
+      # - /mnt/backupos:/mnt/backupos:rw
+      #
+      # For S3/SFTP/restic-rest repositories, no mount is needed — these are
+      # accessed over the network using credentials in the BackupOS repository config.
 
       # Host filesystem — uncomment to enable filesystem source backups.
       # Backup paths configured in BackupOS should use /host/<path> as the


### PR DESCRIPTION
## Problem

The container agent compose template had no guidance about mounting filesystem-path repositories. Any user with a repo configured at a path like `/mnt/backupos/<id>` or `/srv/restic` would hit `Fatal: repository does not exist` on first backup with no hint as to why.

## Fix

Documentation-only change to `apps/web/public/agent/docker-compose.yml`:

1. Updated header mount guide to include repo paths as a fourth category (alongside Docker socket, docker/volumes, and /host), with a note that S3/SFTP/restic-rest repos don't need a mount
2. Added a clearly-marked `# Restic repository (REQUIRED for filesystem-path repos)` block in the volumes section with an example mount and explanation of the path-matching requirement

## Verification

```bash
curl -fsSL http://192.168.69.52:3093/agent/docker-compose.yml | grep -A3 "Repository"
```

Should show the new `Restic repository (REQUIRED...` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)