### PR TITLE
feat(ci): multi-arch container agent release workflow + ghcr.io image reference

### DIFF
--- a/.github/workflows/release-container-agent.yml
+++ b/.github/workflows/release-container-agent.yml
@@ -1,0 +1,105 @@
+name: Release Container Agent
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to publish (e.g., v0.1.0). Required for manual runs.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Determine version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_VAL: ${{ github.ref }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${GITHUB_REF_VAL#refs/tags/}"
+          fi
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version format: $VERSION (expected vX.Y.Z)"
+            exit 1
+          fi
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build agent bundle
+        run: pnpm --filter @backupos/agent build
+
+      - name: Stage bundle for image build
+        run: cp apps/web/public/agent/bundle.js apps/agent-container/bundle.js
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: apps/agent-container
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/dariusvorster/backupos-agent:${{ steps.version.outputs.tag }}
+            ghcr.io/dariusvorster/backupos-agent:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        env:
+          VERSION_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          echo "## Published Container Agent" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version:** $VERSION_TAG" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Latest tag:** also updated" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Platforms:** linux/amd64, linux/arm64" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Pull with:" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "docker pull ghcr.io/dariusvorster/backupos-agent:$VERSION_TAG" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/apps/web/public/agent/docker-compose.yml
+++ b/apps/web/public/agent/docker-compose.yml
@@ -26,7 +26,8 @@
 
 services:
   backupos-agent:
-    image: backupos/agent:latest
+    # To pin to a specific version, replace 'latest' with e.g. 'v0.1.0'.
+    image: ghcr.io/dariusvorster/backupos-agent:latest
     container_name: backupos-agent
     restart: unless-stopped
 


### PR DESCRIPTION
## Summary

- `.github/workflows/release-container-agent.yml` — builds and pushes `linux/amd64` + `linux/arm64` to `ghcr.io/dariusvorster/backupos-agent` on `v*.*.*` tag push or `workflow_dispatch`
- `apps/web/public/agent/docker-compose.yml` — image reference updated from `backupos/agent:latest` (placeholder) to `ghcr.io/dariusvorster/backupos-agent:latest`

## Workflow design

| Concern | Decision |
|---------|----------|
| Trigger | `push: tags: v*.*.*` + `workflow_dispatch` — no push-to-main noise |
| Auth | `GITHUB_TOKEN` only — no secrets management needed |
| Permissions | `contents: read` + `packages: write` — declared in workflow, not repo settings |
| Multi-arch | buildx + QEMU emulation — no arm64 hardware needed in CI |
| Cache | `type=gha` layer cache — speeds up repeat builds |
| Version validation | Regex `^v[0-9]+\.[0-9]+\.[0-9]+$` rejects malformed input before any docker step |

## Security

All user-controlled inputs (`inputs.version`, `github.ref`) are passed through `env:` variables before use in `run:` steps — no direct expression interpolation in shell commands.

## Tags published per run

- `ghcr.io/dariusvorster/backupos-agent:vX.Y.Z` — immutable
- `ghcr.io/dariusvorster/backupos-agent:latest` — updated on every publish

## Test plan

- [ ] Workflow appears in Actions tab after merge (syntax valid)
- [ ] `gh workflow run release-container-agent.yml -f version=v0.0.0-test` completes green
- [ ] Image visible at https://github.com/dariusvorster/backupos/pkgs/container/backupos-agent
- [ ] `docker buildx imagetools inspect ghcr.io/dariusvorster/backupos-agent:v0.0.0-test` shows both amd64 and arm64 manifests
- [ ] `docker pull ghcr.io/dariusvorster/backupos-agent:v0.0.0-test` succeeds without auth (public image)
- [ ] Tag `v0.1.0` → workflow fires automatically, image updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)