### PR TITLE
fix(ci): build all workspace packages in dep order before agent bundle stage

### DIFF
--- a/.github/workflows/release-container-agent.yml
+++ b/.github/workflows/release-container-agent.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build agent bundle
-        run: pnpm --filter @backupos/agent build
+      - name: Build all packages (dep-ordered)
+        run: pnpm -r build
 
       - name: Stage bundle for image build
         run: cp apps/web/public/agent/bundle.js apps/agent-container/bundle.js


### PR DESCRIPTION
## Problem

`pnpm --filter @backupos/agent build` fails with `Cannot find module` because `@backupos/engine` and `@backupos/agent-protocol` haven't been built yet — their `dist/` outputs don't exist.

Failing run: https://github.com/dariusvorster/backupos/actions/runs/25009273046

## Fix

One-line change: replace the filtered build with `pnpm -r build`, which runs every workspace package's build script in topological dependency order.

## Diff

```diff
-      - name: Build agent bundle
-        run: pnpm --filter @backupos/agent build
+      - name: Build all packages (dep-ordered)
+        run: pnpm -r build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)