### PR TITLE
fix(ci): scope build to agent and its workspace deps only

### DIFF
--- a/.github/workflows/release-container-agent.yml
+++ b/.github/workflows/release-container-agent.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build all packages (dep-ordered)
-        run: pnpm -r build
+      - name: Build agent and its workspace deps
+        run: pnpm --filter "@backupos/agent..." build
 
       - name: Stage bundle for image build
         run: cp apps/web/public/agent/bundle.js apps/agent-container/bundle.js


### PR DESCRIPTION
## Problem

PR #41 changed the build step to `pnpm -r build` (build everything). This hit unrelated prerender errors in `apps/docs` — MDX components like `Note`, `Tip`, `FeatureComparison`, `GlossaryTable` not defined during static generation — causing the workflow to abort before reaching the Docker build step.

Failing run: https://github.com/dariusvorster/backupos/actions/runs/25009794382

## Fix

```diff
-      - name: Build all packages (dep-ordered)
-        run: pnpm -r build
+      - name: Build agent and its workspace deps
+        run: pnpm --filter "@backupos/agent..." build
```

The `...` ancestor filter builds `@backupos/agent` plus all its transitive workspace dependencies (`@backupos/agent-protocol`, `@backupos/engine`) in topological order — nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)