### PR TITLE
fix(docs): add MDX components (Note, Tip, FeatureComparison, GlossaryTable)

### DIFF
--- a/apps/docs/app/[...slug]/page.tsx
+++ b/apps/docs/app/[...slug]/page.tsx
@@ -4,6 +4,12 @@ import { notFound }      from 'next/navigation'
 import { MDXRemote }     from 'next-mdx-remote/rsc'
 import { nav }           from '@backupos/docs-content'
 import type { Metadata } from 'next'
+import { Note }              from '@/components/mdx/note'
+import { Tip }               from '@/components/mdx/tip'
+import { FeatureComparison } from '@/components/mdx/feature-comparison'
+import { GlossaryTable }     from '@/components/mdx/glossary-table'
+
+const mdxComponents = { Note, Tip, FeatureComparison, GlossaryTable }
 
 const DOCS_ROOT = resolve(process.cwd(), '../../packages/docs-content/content')
 
@@ -58,5 +64,5 @@ export default async function DocsPage({
   const source = readDocSource(filePath)
   if (!source) notFound()
 
-  return <MDXRemote source={source} />
+  return <MDXRemote source={source} components={mdxComponents} />
 }

--- a/apps/docs/components/mdx/feature-comparison.tsx
+++ b/apps/docs/components/mdx/feature-comparison.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react'
+import { featureComparison, type FeatureComparisonRow } from '@backupos/docs-content'
+
+export function FeatureComparison() {
+  const { columns, rows } = featureComparison
+
+  function renderCell(value: boolean | string | undefined): ReactNode {
+    if (value === true) return <span style={{ color: 'var(--success)' }}>✓</span>
+    if (value === false || value === undefined) return <span style={{ color: 'var(--fg-dim)' }}>—</span>
+    return <span style={{ fontSize: 12, color: 'var(--fg-mute)' }}>{value}</span>
+  }
+
+  return (
+    <div style={{ overflowX: 'auto', margin: '20px 0' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left', padding: '10px 12px', borderBottom: '1px solid var(--border)', fontSize: 13, fontWeight: 600 }}>Feature</th>
+            {columns.map(col => (
+              <th key={col.key} style={{ textAlign: 'center', padding: '10px 12px', borderBottom: '1px solid var(--border)', fontSize: 13, fontWeight: 600 }}>
+                {col.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {(rows as FeatureComparisonRow[]).map((row, i) => (
+            <tr key={i} style={{ borderBottom: '1px solid var(--border-subtle, var(--border))' }}>
+              <td style={{ padding: '10px 12px', color: 'var(--fg)' }}>{row.feature}</td>
+              {columns.map(col => (
+                <td key={col.key} style={{ padding: '10px 12px', textAlign: 'center' }}>
+                  {renderCell(row[col.key] as boolean | string | undefined)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/apps/docs/components/mdx/glossary-table.tsx
+++ b/apps/docs/components/mdx/glossary-table.tsx
@@ -1,0 +1,20 @@
+import { glossary } from '@backupos/docs-content'
+
+export function GlossaryTable() {
+  return (
+    <dl style={{ margin: '20px 0' }}>
+      {glossary.terms.map(({ term, definition }) => (
+        <div key={term} style={{
+          padding: '12px 0',
+          borderBottom: '1px solid var(--border-subtle, var(--border))',
+          display: 'grid',
+          gridTemplateColumns: 'minmax(140px, 200px) 1fr',
+          gap: 16,
+        }}>
+          <dt style={{ fontWeight: 600, color: 'var(--fg)', fontSize: 14 }}>{term}</dt>
+          <dd style={{ margin: 0, color: 'var(--fg-mute)', fontSize: 14, lineHeight: 1.6 }}>{definition}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/apps/docs/components/mdx/note.tsx
+++ b/apps/docs/components/mdx/note.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+
+export function Note({ children }: { children: ReactNode }) {
+  return (
+    <div style={{
+      backgroundColor: 'color-mix(in srgb, var(--accent) 6%, var(--surf))',
+      border: '1px solid color-mix(in srgb, var(--accent) 25%, var(--border))',
+      borderRadius: 'var(--radius)',
+      padding: '12px 18px',
+      margin: '16px 0',
+      fontSize: 14,
+      color: 'var(--fg)',
+      lineHeight: 1.6,
+    }}>
+      <strong style={{ display: 'block', marginBottom: 4, fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5, color: 'var(--accent)' }}>Note</strong>
+      {children}
+    </div>
+  )
+}

--- a/apps/docs/components/mdx/tip.tsx
+++ b/apps/docs/components/mdx/tip.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+
+export function Tip({ children }: { children: ReactNode }) {
+  return (
+    <div style={{
+      backgroundColor: 'color-mix(in srgb, var(--success) 6%, var(--surf))',
+      border: '1px solid color-mix(in srgb, var(--success) 25%, var(--border))',
+      borderRadius: 'var(--radius)',
+      padding: '12px 18px',
+      margin: '16px 0',
+      fontSize: 14,
+      color: 'var(--fg)',
+      lineHeight: 1.6,
+    }}>
+      <strong style={{ display: 'block', marginBottom: 4, fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5, color: 'var(--success)' }}>Tip</strong>
+      {children}
+    </div>
+  )
+}

--- a/packages/docs-content/content/feature-comparison.json
+++ b/packages/docs-content/content/feature-comparison.json
@@ -1,0 +1,18 @@
+{
+  "columns": [
+    { "key": "backupos", "label": "BackupOS" },
+    { "key": "restic_alone", "label": "restic alone" },
+    { "key": "borg", "label": "Borg" },
+    { "key": "rsnapshot", "label": "rsnapshot" }
+  ],
+  "rows": [
+    { "feature": "Multi-host backup", "backupos": true, "restic_alone": false, "borg": false, "rsnapshot": false },
+    { "feature": "Web UI", "backupos": true, "restic_alone": false, "borg": false, "rsnapshot": false },
+    { "feature": "Scheduled backups", "backupos": true, "restic_alone": "via cron", "borg": "via cron", "rsnapshot": true },
+    { "feature": "Application-aware quiescence", "backupos": true, "restic_alone": false, "borg": false, "rsnapshot": false },
+    { "feature": "Docker / Compose project support", "backupos": true, "restic_alone": false, "borg": false, "rsnapshot": false },
+    { "feature": "Container deployment", "backupos": true, "restic_alone": "manual", "borg": "manual", "rsnapshot": "manual" },
+    { "feature": "Self-hosted", "backupos": true, "restic_alone": true, "borg": true, "rsnapshot": true },
+    { "feature": "Open source", "backupos": true, "restic_alone": true, "borg": true, "rsnapshot": true }
+  ]
+}

--- a/packages/docs-content/content/glossary.json
+++ b/packages/docs-content/content/glossary.json
@@ -1,0 +1,14 @@
+{
+  "terms": [
+    { "term": "Snapshot", "definition": "A point-in-time backup of data, stored as deduplicated chunks in a repository." },
+    { "term": "Repository", "definition": "The destination where snapshots are stored — local disk, NFS mount, S3 bucket, or restic-rest server." },
+    { "term": "Job", "definition": "A configured backup task: a source (what to back up), a destination (which repository), a schedule, and a retention policy." },
+    { "term": "Run", "definition": "A single execution of a job. Records start/end time, status, files backed up, and any errors." },
+    { "term": "Source", "definition": "The data being backed up. Source types include filesystem paths, Docker volumes, compose projects, and Proxmox VMs." },
+    { "term": "Agent", "definition": "A small program running on a host that executes backup and restore commands. Can run as a host process (systemd) or in a container." },
+    { "term": "Quiescence", "definition": "Putting an application into a consistent state before backup. Strategies include 'stop' (halt the container), 'pause' (suspend), and 'apphook' (database-aware dump)." },
+    { "term": "Apphook", "definition": "An application-aware backup hook that produces a consistent dump of a database (postgres, mysql, redis, sqlite) without stopping the container." },
+    { "term": "Snapshot retention", "definition": "Rules for how many snapshots to keep over time — typically expressed as N daily, N weekly, N monthly. Older snapshots are pruned." },
+    { "term": "Restic", "definition": "The deduplicating, encrypting backup engine BackupOS uses under the hood. BackupOS provides scheduling, multi-host coordination, and a UI on top of restic." }
+  ]
+}

--- a/packages/docs-content/src/index.ts
+++ b/packages/docs-content/src/index.ts
@@ -1,5 +1,7 @@
 import { join } from 'path'
-import navData  from '../content/nav.json'
+import navData              from '../content/nav.json'
+import featureComparisonData from '../content/feature-comparison.json'
+import glossaryData          from '../content/glossary.json'
 
 export const DOCS_ROOT = join(__dirname, '..', 'content')
 
@@ -8,3 +10,13 @@ export interface NavSection { title: string; slug: string; pages: NavPage[] }
 export interface Nav        { sections: NavSection[] }
 
 export const nav = navData satisfies Nav
+
+export interface FeatureComparisonColumn { key: string; label: string }
+export interface FeatureComparisonRow { feature: string; [key: string]: boolean | string }
+export interface FeatureComparison { columns: FeatureComparisonColumn[]; rows: FeatureComparisonRow[] }
+
+export interface GlossaryTerm { term: string; definition: string }
+export interface Glossary { terms: GlossaryTerm[] }
+
+export const featureComparison = featureComparisonData satisfies FeatureComparison
+export const glossary          = glossaryData satisfies Glossary


### PR DESCRIPTION
## Summary
- Creates four MDX components in `apps/docs/components/mdx/`: `Note`, `Tip`, `FeatureComparison`, `GlossaryTable`
- Adds `feature-comparison.json` and `glossary.json` data files to `packages/docs-content/content/`
- Exports the new data + interfaces from `@backupos/docs-content`
- Wires all four components into `<MDXRemote components={...}>` in the docs `[...slug]/page.tsx`

Fixes #43 — `pnpm -r build` failed at prerender because MDX pages reference these components but they were never defined.

## Test plan
- [ ] `pnpm --filter "@backupos/docs..." build` completes without prerender errors
- [ ] `/introduction/why-backupos` — `FeatureComparison` table renders with ✓ / — cells
- [ ] `/introduction/terminology` — `GlossaryTable` renders as definition list
- [ ] Any page using `<Note>` — info-blue bordered callout renders
- [ ] Any page using `<Tip>` — green bordered callout renders

🤖 Generated with [Claude Code](https://claude.ai/claude-code)