### PR TITLE
fix(docs): stub remaining 13 MDX components to unblock prerender

### DIFF
--- a/apps/docs/app/[...slug]/page.tsx
+++ b/apps/docs/app/[...slug]/page.tsx
@@ -8,8 +8,27 @@ import { Note }              from '@/components/mdx/note'
 import { Tip }               from '@/components/mdx/tip'
 import { FeatureComparison } from '@/components/mdx/feature-comparison'
 import { GlossaryTable }     from '@/components/mdx/glossary-table'
+import { Warning }           from '@/components/mdx/warning'
+import { makeStub }          from '@/components/mdx/stub'
 
-const mdxComponents = { Note, Tip, FeatureComparison, GlossaryTable }
+const AlertTriggers   = makeStub('AlertTriggers')
+const HealthFactors   = makeStub('HealthFactors')
+const HealthGrades    = makeStub('HealthGrades')
+const JobPhases       = makeStub('JobPhases')
+const OtherBackends   = makeStub('OtherBackends')
+const PlanComparison  = makeStub('PlanComparison')
+const RepoFields      = makeStub('RepoFields')
+const RetentionPolicy = makeStub('RetentionPolicy')
+const RunPhases       = makeStub('RunPhases')
+const SourceTypes     = makeStub('SourceTypes')
+const StepTypes       = makeStub('StepTypes')
+
+const mdxComponents = {
+  Note, Tip, FeatureComparison, GlossaryTable,
+  Warning,
+  AlertTriggers, HealthFactors, HealthGrades, JobPhases, OtherBackends,
+  PlanComparison, RepoFields, RetentionPolicy, RunPhases, SourceTypes, StepTypes,
+}
 
 const DOCS_ROOT = resolve(process.cwd(), '../../packages/docs-content/content')
 

--- a/apps/docs/components/mdx/stub.tsx
+++ b/apps/docs/components/mdx/stub.tsx
@@ -1,0 +1,21 @@
+export function makeStub(componentName: string) {
+  return function Stub() {
+    return (
+      <div style={{
+        margin: '20px 0',
+        padding: '14px 18px',
+        backgroundColor: 'var(--surf2)',
+        border: '1px dashed var(--border)',
+        borderRadius: 'var(--radius)',
+        fontSize: 13,
+        color: 'var(--fg-mute)',
+        textAlign: 'center',
+      }}>
+        <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.5, color: 'var(--fg-dim)', marginBottom: 4 }}>
+          Coming soon
+        </div>
+        <code style={{ fontSize: 12, color: 'var(--fg)' }}>{componentName}</code>
+      </div>
+    )
+  }
+}

--- a/apps/docs/components/mdx/warning.tsx
+++ b/apps/docs/components/mdx/warning.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react'
+
+export function Warning({ children }: { children: ReactNode }) {
+  return (
+    <div style={{
+      backgroundColor: 'color-mix(in srgb, var(--err) 6%, var(--surf))',
+      border: '1px solid color-mix(in srgb, var(--err) 25%, var(--border))',
+      borderRadius: 'var(--radius)',
+      padding: '12px 18px',
+      margin: '16px 0',
+      fontSize: 14,
+      color: 'var(--fg)',
+      lineHeight: 1.6,
+    }}>
+      <strong style={{
+        display: 'block', marginBottom: 4,
+        fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5,
+        color: 'var(--err)',
+      }}>Warning</strong>
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `Warning` — a styled error-callout component (children-based, like `Note`/`Tip`)
- Adds `makeStub` factory in `stub.tsx` — returns a placeholder component rendering a dashed "Coming soon" box labelled with the component name
- Stubs 12 parameterless components via `makeStub`: `AlertTriggers`, `HealthFactors`, `HealthGrades`, `JobPhases`, `OtherBackends`, `PlanComparison`, `RepoFields`, `RetentionPolicy`, `RunPhases`, `SourceTypes`, `StepTypes`
- Wires all 13 into `<MDXRemote components={...}>` alongside the real implementations from PR #50

Continues #43 — after this PR, `pnpm --filter "@backupos/docs..." build` completes without prerender errors.

## Test plan
- [ ] `pnpm --filter "@backupos/docs..." build` succeeds with no "Expected component X to be defined" errors
- [ ] Any page using `<Warning>` renders a red-bordered callout
- [ ] Stubbed components render a dashed placeholder box with the component name

🤖 Generated with [Claude Code](https://claude.ai/claude-code)