### PR TITLE
fix(retryRun): remove local execution fallback, add clear agent error states

### DIFF
--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -208,46 +208,77 @@ export async function retryRun(jobId: string): Promise<void> {
   })
   await db.update(backupJobs).set({ lastRunAt: now }).where(eq(backupJobs.id, jobId))
 
-  if (job.agentId) {
-    const [repo] = await db.select().from(repositories)
-      .where(eq(repositories.id, job.repositoryId!)).limit(1)
-    if (repo) {
-      const cfg      = JSON.parse(decryptField(repo.config)) as Record<string, string>
-      const password = decryptField(repo.resticPassword)
-      if (!password) throw new Error(`dispatch: failed to decrypt repo password for repository ${repo.id}`)
-      const tags = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${jobId}`]
+  if (!job.agentId) {
+    await db.update(backupRuns).set({
+      status:       'failed',
+      completedAt:  now,
+      errorMessage: 'job has no agent assigned — set an agent on this job',
+    }).where(eq(backupRuns.id, runId))
+    await db.update(backupJobs).set({ lastRunStatus: 'failed' }).where(eq(backupJobs.id, jobId))
+    redirect(`/jobs/${jobId}`)
+  }
 
-      let result: { ok: boolean; reason?: string; knownIds?: string[] }
-      if (job.sourceType === 'compose_project') {
-        const composeConfig = JSON.parse(job.sourceConfig) as import('@backupos/agent-protocol').ComposeProjectConfig
-        result = await dispatchToAgent(job.agentId, {
-          type:         'run_compose_backup',
-          jobId,
-          runId,
-          config:       composeConfig,
-          repoId:       job.repositoryId!,
-          repoUrl:      cfg['repositoryUrl'] ?? '',
-          repoPassword: password,
-          envVars:      cfg,
-        })
-      } else {
-        const srcConfig = JSON.parse(job.sourceConfig) as { paths?: string[]; volumes?: string[]; exclude?: string[] }
-        const paths = job.sourceType === 'docker_volume'
-          ? (srcConfig.volumes ?? []).map(v => `/var/lib/docker/volumes/${v}/_data`)
-          : (srcConfig.paths ?? [])
-        result = await dispatchToAgent(job.agentId, {
-          type:   'run_backup',
-          jobId,
-          runId,
-          config: { repoId: job.repositoryId!, repoUrl: cfg['repositoryUrl'] ?? '', repoPassword: password, paths, exclude: srcConfig.exclude, tags, envVars: cfg },
-        })
-      }
-      if (!result.ok) {
-        console.error('[retryRun] dispatch failed reason=%s knownIds=%j', result.reason, result.knownIds)
-      }
-    }
+  const { connectedAgentIds } = await import('@/lib/ws-state')
+  if (!connectedAgentIds().includes(job.agentId)) {
+    await db.update(backupRuns).set({
+      status:       'failed',
+      completedAt:  now,
+      errorMessage: `agent ${job.agentId} is not connected — backup deferred until agent reconnects`,
+    }).where(eq(backupRuns.id, runId))
+    await db.update(backupJobs).set({ lastRunStatus: 'failed' }).where(eq(backupJobs.id, jobId))
+    redirect(`/jobs/${jobId}`)
+  }
+
+  const [repo] = await db.select().from(repositories)
+    .where(eq(repositories.id, job.repositoryId!)).limit(1)
+  if (!repo) {
+    await db.update(backupRuns).set({
+      status:       'failed',
+      completedAt:  now,
+      errorMessage: `repository ${job.repositoryId} not found`,
+    }).where(eq(backupRuns.id, runId))
+    redirect(`/jobs/${jobId}`)
+  }
+
+  const cfg      = JSON.parse(decryptField(repo.config)) as Record<string, string>
+  const password = decryptField(repo.resticPassword)
+  if (!password) throw new Error(`dispatch: failed to decrypt repo password for repository ${repo.id}`)
+  const tags = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${jobId}`]
+
+  let result: { ok: boolean; reason?: string; knownIds?: string[] }
+  if (job.sourceType === 'compose_project') {
+    const composeConfig = JSON.parse(job.sourceConfig) as import('@backupos/agent-protocol').ComposeProjectConfig
+    result = await dispatchToAgent(job.agentId, {
+      type:         'run_compose_backup',
+      jobId,
+      runId,
+      config:       composeConfig,
+      repoId:       job.repositoryId!,
+      repoUrl:      cfg['repositoryUrl'] ?? '',
+      repoPassword: password,
+      envVars:      cfg,
+    })
   } else {
-    void import('@/lib/scheduler').then(({ executeRun }) => executeRun(jobId, runId))
+    const srcConfig = JSON.parse(job.sourceConfig) as { paths?: string[]; volumes?: string[]; exclude?: string[] }
+    const paths = job.sourceType === 'docker_volume'
+      ? (srcConfig.volumes ?? []).map(v => `/var/lib/docker/volumes/${v}/_data`)
+      : (srcConfig.paths ?? [])
+    result = await dispatchToAgent(job.agentId, {
+      type:   'run_backup',
+      jobId,
+      runId,
+      config: { repoId: job.repositoryId!, repoUrl: cfg['repositoryUrl'] ?? '', repoPassword: password, paths, exclude: srcConfig.exclude, tags, envVars: cfg },
+    })
+  }
+
+  if (!result.ok) {
+    await db.update(backupRuns).set({
+      status:       'failed',
+      completedAt:  now,
+      errorMessage: `dispatch failed: ${result.reason ?? 'unknown'}`,
+    }).where(eq(backupRuns.id, runId))
+    await db.update(backupJobs).set({ lastRunStatus: 'failed' }).where(eq(backupJobs.id, jobId))
+    console.error('[retryRun] dispatch failed reason=%s knownIds=%j', result.reason, result.knownIds)
   }
 
   redirect(`/jobs/${jobId}`)

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -1,32 +1,15 @@
 import * as cron from 'node-cron'
 import { parseExpression } from 'cron-parser'
-import { getDb, backupJobs, backupRuns, repositories, agents, backupDefaults, eq, and, or, lt, lte, isNotNull, isNull } from '@backupos/db'
+import { getDb, backupJobs, backupRuns, repositories, agents, eq, and, or, lt, lte, isNotNull, isNull } from '@backupos/db'
 import { decryptField } from './repo-crypto'
-import { ResticEngine } from '@backupos/engine'
 import { sendAlert } from './alerts'
 import { dispatch, connectedAgentIds } from './ws-state'
 import type { ServerMessage, MountConfig, ComposeProjectConfig } from '@backupos/agent-protocol'
-
-interface RepoConfig {
-  repositoryUrl: string
-  password: string
-  envVars?: Record<string, string>
-}
 
 interface SourceConfig {
   paths?:    string[]
   volumes?:  string[]
   exclude?:  string[]
-}
-
-function resolveBackupPaths(sourceType: string, srcConfig: SourceConfig): string[] {
-  if (sourceType === 'filesystem' || sourceType === 'windows_system') {
-    return srcConfig.paths ?? []
-  }
-  if (sourceType === 'docker_volume') {
-    return (srcConfig.volumes ?? []).map(v => `/var/lib/docker/volumes/${v}/_data`)
-  }
-  return []
 }
 
 export async function initScheduler(): Promise<void> {
@@ -80,15 +63,6 @@ async function stampNextRun(db: Db, jobId: string, schedule: string): Promise<vo
   }
 }
 
-// executeRun performs local restic execution for an already-inserted backupRun row.
-// Called only for no-agent manual retries (retryRun in jobs.ts when job.agentId is null).
-export async function executeRun(jobId: string, runId: string): Promise<void> {
-  const db = getDb()
-  const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, jobId)).limit(1)
-  if (!job || !job.repositoryId) return
-  await runJobCore(db, job, runId)
-}
-
 async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Promise<boolean> {
   if (!job.agentId || !job.repositoryId) return false
 
@@ -124,7 +98,9 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
     }
   } else {
     const srcConfig   = JSON.parse(job.sourceConfig) as SourceConfig
-    const paths       = resolveBackupPaths(job.sourceType, srcConfig)
+    const paths       = job.sourceType === 'docker_volume'
+      ? (srcConfig.volumes ?? []).map(v => `/var/lib/docker/volumes/${v}/_data`)
+      : (srcConfig.paths ?? [])
     if (paths.length === 0) {
       await db.update(backupRuns).set({ status: 'failed', completedAt: now, errorMessage: 'No backup paths resolved' }).where(eq(backupRuns.id, runId))
       return false
@@ -237,138 +213,6 @@ async function triggerTick(db: Db): Promise<void> {
     await db.update(backupJobs).set({ nextRunAt: next ?? null }).where(eq(backupJobs.id, job.id))
 
     await runJob(db, job, 'manual')
-  }
-}
-
-function fmtBytes(b: number): string {
-  if (b < 1024 ** 2) return `${(b / 1024).toFixed(1)} KB`
-  if (b < 1024 ** 3) return `${(b / 1024 ** 2).toFixed(1)} MB`
-  return `${(b / 1024 ** 3).toFixed(2)} GB`
-}
-
-// Core local backup execution — updates an existing backupRun row identified by runId.
-async function runJobCore(db: Db, job: Job, runId: string): Promise<void> {
-  if (!job.repositoryId) {
-    await db.update(backupRuns).set({ status: 'failed', completedAt: new Date(), errorMessage: 'Job has no repository configured' }).where(eq(backupRuns.id, runId))
-    return
-  }
-
-  const [repo] = await db.select().from(repositories).where(eq(repositories.id, job.repositoryId)).limit(1)
-  if (!repo) {
-    await db.update(backupRuns).set({ status: 'failed', completedAt: new Date(), errorMessage: 'Repository not found' }).where(eq(backupRuns.id, runId))
-    return
-  }
-
-  const cfg       = JSON.parse(decryptField(repo.config)) as Record<string, string>
-  const srcConfig = JSON.parse(job.sourceConfig) as SourceConfig
-  const paths     = resolveBackupPaths(job.sourceType, srcConfig)
-  if (paths.length === 0) {
-    await db.update(backupRuns).set({ status: 'failed', completedAt: new Date(), errorMessage: 'No backup paths configured' }).where(eq(backupRuns.id, runId))
-    return
-  }
-
-  // Accumulate log lines + latest progress for periodic DB flush
-  const logLines: string[] = []
-  let lastProgress: { pct: number; bytesDone: number; bytesTotal: number; filesDone: number; filesTotal: number } | null = null
-
-  const flushToDB = async () => {
-    const update: Record<string, unknown> = { log: logLines.join('\n') }
-    if (lastProgress) {
-      update['progressPct']  = lastProgress.pct
-      update['bytesDone']    = lastProgress.bytesDone
-      update['bytesTotal']   = lastProgress.bytesTotal
-      update['filesDone']    = lastProgress.filesDone
-      update['filesTotal']   = lastProgress.filesTotal
-    }
-    await db.update(backupRuns).set(update).where(eq(backupRuns.id, runId))
-  }
-
-  const flushInterval = setInterval(() => { void flushToDB() }, 2000)
-
-  try {
-    const engine = new ResticEngine({
-      repositoryUrl: cfg['repositoryUrl'] ?? '',
-      password:      decryptField(repo.resticPassword),
-      envVars:       cfg,
-      binaryPath:    process.env['RESTIC_BINARY_PATH'],
-    })
-
-    const tags   = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${job.id}`]
-    const result = await engine.backup({
-      paths,
-      exclude: srcConfig.exclude,
-      tags,
-      onProgress: (s) => {
-        lastProgress = s
-        const pctStr  = (s.pct * 100).toFixed(1)
-        const eta     = s.secondsRemaining != null ? ` ETA ${s.secondsRemaining}s` : ''
-        logLines.push(`[${new Date().toISOString().slice(11, 19)}] ${pctStr}% — ${fmtBytes(s.bytesDone)} / ${fmtBytes(s.bytesTotal)} · ${s.filesDone}/${s.filesTotal} files${eta}`)
-      },
-    })
-
-    clearInterval(flushInterval)
-
-    await db.update(backupRuns).set({
-      status:          'success',
-      completedAt:     new Date(),
-      snapshotId:      result.snapshotId,
-      filesNew:        result.filesNew,
-      filesChanged:    result.filesChanged,
-      filesUnmodified: result.filesUnmodified,
-      dataAdded:       result.dataAdded,
-      totalSize:       result.totalSize,
-      duration:        result.duration,
-      log:             logLines.join('\n'),
-      progressPct:     1,
-      bytesDone:       result.totalSize,
-      bytesTotal:      result.totalSize,
-    }).where(eq(backupRuns.id, runId))
-
-    const jobHasRetention = job.keepLast || job.keepDaily || job.keepWeekly || job.keepMonthly || job.keepYearly
-    const retentionPolicy = jobHasRetention
-      ? {
-          keepLast:    job.keepLast    ?? undefined,
-          keepDaily:   job.keepDaily   ?? undefined,
-          keepWeekly:  job.keepWeekly  ?? undefined,
-          keepMonthly: job.keepMonthly ?? undefined,
-          keepYearly:  job.keepYearly  ?? undefined,
-        }
-      : await (async () => {
-          const [defaults] = await db.select().from(backupDefaults).limit(1).all()
-          if (!defaults) return null
-          const hasAny = defaults.keepLast || defaults.keepDaily || defaults.keepWeekly || defaults.keepMonthly || defaults.keepYearly
-          if (!hasAny) return null
-          return {
-            keepLast:    defaults.keepLast    ?? undefined,
-            keepDaily:   defaults.keepDaily   ?? undefined,
-            keepWeekly:  defaults.keepWeekly  ?? undefined,
-            keepMonthly: defaults.keepMonthly ?? undefined,
-            keepYearly:  defaults.keepYearly  ?? undefined,
-          }
-        })()
-
-    if (retentionPolicy) {
-      const tags2  = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${job.id}`]
-      const forget = await engine.forget({ ...retentionPolicy, keepTags: tags2 })
-      await db.update(backupRuns).set({
-        snapshotsRemoved: forget.removed,
-        snapshotsKept:    forget.kept,
-      }).where(eq(backupRuns.id, runId))
-    }
-
-    const nextRun = nextRunDate(job.schedule)
-    await db.update(backupJobs).set({ lastRunAt: new Date(), lastRunStatus: 'success', ...(nextRun ? { nextRunAt: nextRun } : {}) })
-      .where(eq(backupJobs.id, job.id))
-
-  } catch (err) {
-    clearInterval(flushInterval)
-    const errorMessage = String(err)
-    await db.update(backupRuns).set({ status: 'failed', completedAt: new Date(), errorMessage, log: logLines.join('\n') || null })
-      .where(eq(backupRuns.id, runId))
-    const nextRun = nextRunDate(job.schedule)
-    await db.update(backupJobs).set({ lastRunAt: new Date(), lastRunStatus: 'failed', ...(nextRun ? { nextRunAt: nextRun } : {}) })
-      .where(eq(backupJobs.id, job.id))
-    await sendAlert('backup_failed', { jobId: job.id, jobName: job.name, error: errorMessage })
   }
 }
 


### PR DESCRIPTION
## Summary
- Replaces the `if (job.agentId) { ... } else { executeRun(...) }` pattern in `retryRun` with three explicit states: no agent assigned → fail, agent offline → fail, agent connected → dispatch
- Dispatch failures now mark the run as `failed` with an error message instead of silently logging to console (no more eternal spinners)
- Deletes now-dead code: `executeRun`, `runJobCore`, `resolveBackupPaths`, `fmtBytes` from `scheduler.ts` — no callers remain
- Removes unused `ResticEngine` and `backupDefaults` imports from `scheduler.ts`

Mirrors the fix from PR #22 which applied the same pattern to `runJob`.

Fixes #23.

## Test plan
- [ ] Retry on a compose_project job with connected agent → run completes successfully via dispatch path
- [ ] Retry on a job with no agent assigned → run immediately shows `failed` with "job has no agent assigned" message
- [ ] Retry on a job whose agent is offline → run immediately shows `failed` with "agent X is not connected" message
- [ ] `grep -rn "executeRun\|runJobCore\|resolveBackupPaths" apps/web/ --include="*.ts"` → only internal references within scheduler.ts (none after this PR)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)