### PR TITLE
fix(engine): thread AbortSignal through restore() so cancel_backup kills restic

### DIFF
--- a/packages/agent/src/handlers/composeRestore.ts
+++ b/packages/agent/src/handlers/composeRestore.ts
@@ -102,7 +102,7 @@ export async function runComposeRestore(
         const sourcePath = `/var/lib/docker/volumes/${origVolName}/_data`
 
         if (mode === 'in_place') {
-          await makeEngine().restore(snapshotId, '/', [sourcePath])
+          await makeEngine().restore(snapshotId, '/', [sourcePath], ctrl.signal)
           logLines.push(`[restore] restored "${service.serviceName}" vol ${origVolName} (in-place)`)
         } else {
           // side_by_side: restore to tmpDir, create new volume, copy contents
@@ -118,7 +118,7 @@ export async function runComposeRestore(
 
           await spawnAllowed('docker', ['volume', 'create', newVolName])
 
-          await makeEngine().restore(snapshotId, tmpDir, [sourcePath])
+          await makeEngine().restore(snapshotId, tmpDir, [sourcePath], ctrl.signal)
 
           // tmpDir/<sourcePath> contains the restored files
           const restoreDest = path.join(tmpDir, 'var', 'lib', 'docker', 'volumes', origVolName, '_data')
@@ -133,7 +133,7 @@ export async function runComposeRestore(
     // Optional compose file restore
     if (composeFileSnapshotId && composeConfig.composeFilePath) {
       if (mode === 'in_place') {
-        await makeEngine().restore(composeFileSnapshotId, '/', [composeConfig.composeFilePath])
+        await makeEngine().restore(composeFileSnapshotId, '/', [composeConfig.composeFilePath], ctrl.signal)
         logLines.push(`[restore] restored compose file to ${composeConfig.composeFilePath}`)
       } else {
         logLines.push(`[restore] NOTE: compose file restore skipped for side-by-side mode — original file unchanged`)

--- a/packages/engine/src/restic.ts
+++ b/packages/engine/src/restic.ts
@@ -180,12 +180,13 @@ export class ResticEngine {
     snapshotId: string,
     target: string,
     include?: string[],
+    signal?: AbortSignal,
   ): Promise<RestoreResult> {
     const args = ['restore', snapshotId, '--target', target]
     if (include) for (const p of include) args.push('--include', p)
 
     const before = Date.now()
-    const result = await this.run(args, undefined, 14_400_000)
+    const result = await this.run(args, undefined, 14_400_000, signal)
     if (result.exitCode !== 0) throw new ResticError('restore', result)
 
     const match = result.stderr.match(/(\d+) files? restored/)
@@ -257,8 +258,9 @@ export class ResticEngine {
     args: string[],
     extraEnv?: Record<string, string>,
     timeoutMs?: number,
+    signal?: AbortSignal,
   ): Promise<ExecResult> {
-    return this.runStreaming(args, undefined, extraEnv, timeoutMs)
+    return this.runStreaming(args, undefined, extraEnv, timeoutMs, signal)
   }
 
   private runStreaming(


### PR DESCRIPTION
## Summary
- Adds `signal?: AbortSignal` to `ResticEngine.restore()` (4th positional param)
- Threads it through `private run()` → `runStreaming()`, which already implements SIGTERM-then-SIGKILL on abort
- Passes `ctrl.signal` at all three `makeEngine().restore()` call sites in `composeRestore.ts` (in-place vol restore, side-by-side vol restore, compose file restore)

The `AbortController` (`ctrl`) was already created at job start in `composeRestore.ts` and stored in `activeJobs[jobId].ctrl`. The `cancel_backup` handler in `agent.ts` already calls `ctrl.abort()`. This change closes the final gap — previously abort had no effect because `restore()` never received the signal.

**Backup side verified:** `composeBackup.ts` already passes `ctrl.signal` to `engine.backup()` correctly — no changes needed there.

Fixes #33.

## Test plan
- [ ] Side-by-side restore on a large volume → cancel mid-flight → restic process exits within ~10s (SIGTERM, then SIGKILL)
- [ ] Side-by-side restore completes normally when not cancelled (no regression from adding unused signal param)
- [ ] Run row shows `status=success` after a non-cancelled restore

🤖 Generated with [Claude Code](https://claude.ai/claude-code)