### PR TITLE
fix(scheduler): preserve manual trigger nextRunAt across server restarts

### DIFF
--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -28,7 +28,7 @@ export async function initScheduler(): Promise<void> {
     }
 
     cron.schedule(job.schedule, () => { void runJob(db, job, 'cron') }, { timezone: 'UTC' })
-    void stampNextRun(db, job.id, job.schedule)
+    void stampNextRunIfMissing(db, job.id, job.schedule)
     console.log(`[scheduler] Scheduled "${job.name}" (${job.schedule})`)
   }
 
@@ -57,6 +57,16 @@ function nextRunDate(schedule: string): Date | null {
 }
 
 async function stampNextRun(db: Db, jobId: string, schedule: string): Promise<void> {
+  const next = nextRunDate(schedule)
+  if (next) {
+    await db.update(backupJobs).set({ nextRunAt: next }).where(eq(backupJobs.id, jobId))
+  }
+}
+
+async function stampNextRunIfMissing(db: Db, jobId: string, schedule: string): Promise<void> {
+  const [row] = await db.select({ nextRunAt: backupJobs.nextRunAt })
+    .from(backupJobs).where(eq(backupJobs.id, jobId)).limit(1)
+  if (row && row.nextRunAt !== null) return
   const next = nextRunDate(schedule)
   if (next) {
     await db.update(backupJobs).set({ nextRunAt: next }).where(eq(backupJobs.id, jobId))


### PR DESCRIPTION
## Summary
- Adds `stampNextRunIfMissing()` — a conditional variant that only writes `nextRunAt` when the current value is `null`
- Replaces the unconditional `stampNextRun()` call in `initScheduler()` with `stampNextRunIfMissing()`
- `stampNextRun()` is unchanged — post-backup callers that want unconditional overwrite are unaffected

**Root cause:** `triggerJob` sets `nextRunAt = now()` so `triggerTick` fires within 5 seconds. On restart, `initScheduler` overwrote this with the next cron time, silently dropping the manual trigger.

Fixes #26.

## Test plan
- [ ] Click "Run now" → immediately restart the service → within 10s a new run row appears with `trigger='manual'`
- [ ] New job with no `nextRunAt` → restart → `nextRunAt` is stamped with the next cron time (null path still works)
- [ ] Existing job with valid `nextRunAt` → restart → `nextRunAt` is unchanged (no unnecessary write)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)