### PR TITLE
feat(agent): auto-prefix /host onto filesystem paths for container agents

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -7,6 +7,7 @@ import { ResticEngine } from '@backupos/engine'
 import type { AgentMessage, ServerMessage, BackupJobConfig } from '@backupos/agent-protocol'
 import { getSystemUptimeSeconds } from './system-uptime'
 import { detectCapabilities } from './capabilities'
+import { resolveHostPrefix, applyHostPrefixAll } from './lib/host-prefix'
 
 function requireEnv(name: string): string {
   const v = process.env[name]
@@ -89,6 +90,12 @@ async function ensureRepoInitialized(engine: ResticEngine, repoId: string): Prom
   }
 }
 const BINARY          = process.env['RESTIC_BINARY_PATH']
+const HOST_PREFIX     = resolveHostPrefix()
+if (HOST_PREFIX) {
+  console.log(`[agent] host prefix active: ${HOST_PREFIX} (filesystem paths will be rewritten)`)
+} else {
+  console.log('[agent] host prefix inactive (running as host agent or opted out)')
+}
 const VERSION         = '0.1.0'
 const PROTOCOL_VERSION = '1'
 
@@ -263,8 +270,11 @@ async function runBackup(jobId: string, runId: string, config: BackupJobConfig):
   const ctrl = new AbortController()
   activeJobs.set(jobId, { ctrl, runId, phase: 'starting', lastResticEventAt: Date.now(), cancelled: false })
 
+  const paths   = applyHostPrefixAll(config.paths,   HOST_PREFIX)
+  const exclude = config.exclude ? applyHostPrefixAll(config.exclude, HOST_PREFIX) : config.exclude
+
   send({ type: 'backup_start', jobId, config })
-  console.log(`[agent] Starting backup for job ${jobId} — paths: ${config.paths.join(', ')}`)
+  console.log(`[agent] Starting backup for job ${jobId} — paths: ${paths.join(', ')}`)
 
   let runLog = ''
 
@@ -283,8 +293,8 @@ async function runBackup(jobId: string, runId: string, config: BackupJobConfig):
     await ensureRepoInitialized(engine, config.repoId)
 
     const result = await engine.backup({
-      paths:   config.paths,
-      exclude: config.exclude,
+      paths,
+      exclude,
       tags:    config.tags,
       signal:  ctrl.signal,
       onProgress: (s) => {

--- a/packages/agent/src/lib/host-prefix.ts
+++ b/packages/agent/src/lib/host-prefix.ts
@@ -1,0 +1,48 @@
+import { existsSync, statSync } from 'fs'
+
+const DEFAULT_HOST_PREFIX = '/host'
+
+/**
+ * Resolves the host path prefix for this agent based on environment.
+ * Returns '' if no prefix should be applied (host agent or explicit opt-out).
+ * Returns a normalized prefix (no trailing slash) if prefix should be applied.
+ *
+ * Known limitation: container-agent backups produce snapshot paths beginning
+ * with the prefix (e.g. /host/etc/...). The server sees these verbatim.
+ * Stripping the prefix from snapshot metadata is a future concern (v0.3.0).
+ */
+export function resolveHostPrefix(): string {
+  if ('BACKUPOS_HOST_PREFIX' in process.env) {
+    const explicit = process.env['BACKUPOS_HOST_PREFIX']
+    if (explicit === '' || explicit === undefined) return ''
+    return explicit.replace(/\/+$/, '')
+  }
+
+  try {
+    if (existsSync(DEFAULT_HOST_PREFIX) && statSync(`${DEFAULT_HOST_PREFIX}/etc`).isDirectory()) {
+      return DEFAULT_HOST_PREFIX
+    }
+  } catch {
+    // /host/etc doesn't exist — host agent
+  }
+
+  return ''
+}
+
+/**
+ * Rewrites a single absolute path with the host prefix if applicable.
+ * Idempotent: a path already prefixed is returned unchanged.
+ */
+export function applyHostPrefix(p: string, prefix: string): string {
+  if (!prefix) return p
+  if (!p.startsWith('/')) return p
+  if (p === prefix || p.startsWith(`${prefix}/`)) return p
+  return `${prefix}${p}`
+}
+
+/**
+ * Applies prefix to an array of paths.
+ */
+export function applyHostPrefixAll(paths: string[], prefix: string): string[] {
+  return paths.map(p => applyHostPrefix(p, prefix))
+}


### PR DESCRIPTION
## Summary
- Adds `packages/agent/src/lib/host-prefix.ts` with `resolveHostPrefix()`, `applyHostPrefix()`, and `applyHostPrefixAll()`
- `resolveHostPrefix()` detects container context via `existsSync('/host') && statSync('/host/etc').isDirectory()`, with `BACKUPOS_HOST_PREFIX` env override (empty string = opt-out)
- Prefix is resolved once at startup and logged: `[agent] host prefix active: /host` or `inactive`
- Applied idempotently to `config.paths` and `config.exclude` in `runBackup` — paths already starting with `/host` are unchanged

**No standalone filesystem restore handler exists** — the only restore path is `run_compose_restore` (composeRestore.ts) which operates via Docker socket, not filesystem paths. No restore-side changes needed.

**Snapshot path asymmetry:** Container-agent snapshots will have paths beginning `/host/...`. This is a known limitation; stripping the prefix from snapshot metadata is out of scope for this PR.

**Post-deploy migration (manual):** The `dockee01-container-etc-test` job currently has `source_config='{"paths":["/host/etc"]}'`. The idempotent rewrite means it continues to work as-is. For cleanliness, update to `{"paths":["/etc"]}` after deploy:
```sql
UPDATE backup_jobs SET source_config='{"paths":["/etc"]}' WHERE name='dockee01-container-etc-test';
```

## Test plan
- [ ] `sudo docker logs backupos-agent 2>&1 | grep "host prefix"` → `host prefix active: /host`
- [ ] Host agent logs show `host prefix inactive`
- [ ] Edit test job path to `/etc` (no prefix) → trigger run → `status=success`, `files_new > 0`
- [ ] Edit test job path back to `/host/etc` → trigger run → still works (idempotent)
- [ ] Existing host-agent jobs unaffected (no regression)
- [ ] Compose project backups unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)