### PR TITLE
feat(web): Restore button on compose_project jobs + jobId pre-selection

### DIFF
--- a/apps/web/app/(dashboard)/jobs/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/[id]/page.tsx
@@ -117,6 +117,19 @@ export default async function JobDetailPage({ params }: { params: Promise<{ id: 
         >
           Edit
         </Link>
+        {job.sourceType === 'compose_project' && (
+          <Link
+            href={`/restore/compose/new?jobId=${job.id}`}
+            style={{
+              padding: '6px 16px', fontSize: 13,
+              borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+              background: 'var(--surf2)', color: 'var(--fg)',
+              textDecoration: 'none', display: 'inline-flex', alignItems: 'center',
+            }}
+          >
+            Restore
+          </Link>
+        )}
       </div>
 
       {/* Deprecation banner for legacy docker_volume jobs */}

--- a/apps/web/app/(dashboard)/restore/compose/new/compose-restore-wizard.tsx
+++ b/apps/web/app/(dashboard)/restore/compose/new/compose-restore-wizard.tsx
@@ -22,12 +22,13 @@ function fmt(iso: string): string {
   return new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
 }
 
-export function ComposeRestoreWizard({ jobs, initialError }: { jobs: JobOption[]; initialError?: string }) {
-  const [selectedJobId, setSelectedJobId]   = useState(jobs[0]?.id ?? '')
-  const [selectedRunId, setSelectedRunId]   = useState(jobs[0]?.runs[0]?.id ?? '')
+export function ComposeRestoreWizard({ jobs, initialError, initialJobId }: { jobs: JobOption[]; initialError?: string; initialJobId?: string }) {
+  const initialJob = (initialJobId ? jobs.find(j => j.id === initialJobId) : undefined) ?? jobs[0]
+  const [selectedJobId, setSelectedJobId]   = useState(initialJob?.id ?? '')
+  const [selectedRunId, setSelectedRunId]   = useState(initialJob?.runs[0]?.id ?? '')
   const [mode, setMode]                     = useState<'in_place' | 'side_by_side'>('side_by_side')
   const [newProjectName, setNewProjectName] = useState(() => {
-    const proj = jobs[0]?.projectName ?? ''
+    const proj = initialJob?.projectName ?? ''
     return proj ? `${proj}-restored` : ''
   })
   const [restoreComposeFile, setRestoreComposeFile] = useState(true)

--- a/apps/web/app/(dashboard)/restore/compose/new/page.tsx
+++ b/apps/web/app/(dashboard)/restore/compose/new/page.tsx
@@ -4,8 +4,8 @@ import type { ComposeProjectConfig } from '@backupos/agent-protocol'
 
 export const dynamic = 'force-dynamic'
 
-export default async function ComposeRestoreNewPage({ searchParams }: { searchParams: Promise<{ confirmError?: string }> }) {
-  const { confirmError } = await searchParams
+export default async function ComposeRestoreNewPage({ searchParams }: { searchParams: Promise<{ confirmError?: string; jobId?: string }> }) {
+  const { confirmError, jobId } = await searchParams
   const db = getDb()
 
   const jobs = await db
@@ -49,7 +49,7 @@ export default async function ComposeRestoreNewPage({ searchParams }: { searchPa
         Restore a previously backed-up compose project from a snapshot.
         Default mode is side-by-side (safe). In-place requires explicit confirmation.
       </p>
-      <ComposeRestoreWizard jobs={jobData} initialError={confirmError} />
+      <ComposeRestoreWizard jobs={jobData} initialError={confirmError} initialJobId={jobId} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds a **Restore** link to the action cluster on `/jobs/[id]` for `compose_project` jobs only (neutral border/surf2 style, consistent with Edit)
- Navigates to `/restore/compose/new?jobId=<job.id>`
- The restore page now accepts `jobId` as a search param and passes it to the wizard
- The wizard uses `initialJobId` to pre-select the matching job; falls back to `jobs[0]` if the param is absent or stale (deleted job)

## Test plan
- [ ] `/jobs/<compose-project-job>` → Restore button visible in action cluster
- [ ] `/jobs/<filesystem-job>` or `/jobs/<docker-volume-job>` → Restore button NOT visible
- [ ] Click Restore → URL is `/restore/compose/new?jobId=<correct-id>`, wizard pre-selects that job
- [ ] `/restore/compose/new?jobId=invalid-uuid` → page renders with first job selected, no crash

🤖 Generated with [Claude Code](https://claude.ai/claude-code)