### PR TITLE
fix(web): translate cron-parser errors into plain-English messages

### DIFF
--- a/apps/web/lib/cron-validate.ts
+++ b/apps/web/lib/cron-validate.ts
@@ -1,10 +1,33 @@
 import { parseExpression } from 'cron-parser'
 
+function translateCronError(rawMessage: string): string {
+  if (/Expected\s+\d+(-\d+)?\s+fields/i.test(rawMessage)) {
+    return 'Cron expression must have 5 fields: minute hour day-of-month month day-of-week'
+  }
+
+  const constraintMatch = rawMessage.match(/Constraint error.*got\s+value\s+(-?\d+).*expected\s+range\s+(-?\d+)-(-?\d+)/i)
+  if (constraintMatch) {
+    const [, value, min, max] = constraintMatch
+    return `Value ${value} is out of range — must be between ${min} and ${max}`
+  }
+
+  if (/Invalid range/i.test(rawMessage)) {
+    return 'Range is malformed — use the form START-END (e.g. 9-17 for 9am to 5pm)'
+  }
+
+  if (/Unexpected character/i.test(rawMessage) || /unknown alias/i.test(rawMessage)) {
+    return 'Contains an invalid character — only digits, *, -, /, and , are allowed in each field'
+  }
+
+  return 'Invalid cron expression — check the format and try again'
+}
+
 export function validateCron(expression: string): { valid: true } | { valid: false; error: string } {
   try {
     parseExpression(expression)
     return { valid: true }
   } catch (err) {
-    return { valid: false, error: err instanceof Error ? err.message : 'Invalid cron expression' }
+    const raw = err instanceof Error ? err.message : ''
+    return { valid: false, error: translateCronError(raw) }
   }
 }


### PR DESCRIPTION
## Summary
Adds `translateCronError()` to `cron-validate.ts` that maps common cron-parser error patterns to user-friendly messages:

| Pattern | Before | After |
|---------|--------|-------|
| Wrong field count | `Expected 5 fields, got 3` | `Cron expression must have 5 fields: minute hour day-of-month month day-of-week` |
| Out-of-range value | `Constraint error, got value 25...` | `Value 25 is out of range — must be between 0 and 23` |
| Malformed range | `Invalid range: 00110-7` | `Range is malformed — use the form START-END (e.g. 9-17 for 9am to 5pm)` |
| Invalid character | `Unexpected character ...` | `Contains an invalid character — only digits, *, -, /, and , are allowed in each field` |
| Unknown | *(raw parser internals)* | `Invalid cron expression — check the format and try again` |

No changes to `cron-input.tsx` or any other file.

Fixes #27.

## Test plan
- [ ] `0 2 *` → "Cron expression must have 5 fields..."
- [ ] `0 25 * * *` → "Value 25 is out of range..."
- [ ] `0 0 1 1 00110-7` → "Range is malformed..."
- [ ] `0 2 * * *` → no error shown
- [ ] Obscure parser error → generic fallback message (never raw parser text)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)