### PR TITLE
fix(web): strip redundant prefix and Examples from cron error redirects

### DIFF
--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -65,7 +65,7 @@ export async function createJob(formData: FormData): Promise<void> {
 
   const cronCheck = validateCron(schedule)
   if (!cronCheck.valid) {
-    redirect(`/jobs/new?cronError=${encodeURIComponent(`Invalid cron expression "${schedule}". ${cronCheck.error}. Examples: "0 2 * * *" (daily 2am), "*/15 * * * *" (every 15min).`)}`)
+    redirect(`/jobs/new?cronError=${encodeURIComponent(cronCheck.error)}`)
   }
 
   if (sourceType === 'compose_project') {
@@ -162,7 +162,7 @@ export async function updateJob(id: string, formData: FormData): Promise<void> {
 
   const cronCheck = validateCron(schedule)
   if (!cronCheck.valid) {
-    redirect(`/jobs/${id}/edit?cronError=${encodeURIComponent(`Invalid cron expression "${schedule}". ${cronCheck.error}. Examples: "0 2 * * *" (daily 2am), "*/15 * * * *" (every 15min).`)}`)
+    redirect(`/jobs/${id}/edit?cronError=${encodeURIComponent(cronCheck.error)}`)
   }
 
   if (sourceType === 'compose_project') {


### PR DESCRIPTION
## Summary
- `createJob` and `updateJob` server actions previously wrapped `cronCheck.error` in a verbose string that duplicated the expression value and appended hardcoded Examples
- `validateCron` now returns clean, user-friendly messages from `translateCronError` — the wrapper is redundant and causes double-prefixing
- Both redirect calls now pass `cronCheck.error` directly

## Test plan
- [ ] Submit a job form with an invalid cron expression (e.g. `0 2 * *`) and verify the error shown matches the translated message only, with no duplicate prefix or Examples suffix
- [ ] Verify valid cron expressions still save successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)