### PR TITLE
chore(ci): bump actions to Node 24 versions

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -18,7 +18,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/release-container-agent.yml
+++ b/.github/workflows/release-container-agent.yml
@@ -40,15 +40,15 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v5
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -78,7 +78,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: apps/agent-container
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary
- GitHub Actions will remove Node 20 support on Sep 16, 2026 (forced from Jun 2, 2026)
- Bumps three actions in `release-container-agent.yml` to their first Node 24 releases: `actions/checkout@v5`, `pnpm/action-setup@v5`, `actions/setup-node@v5`, `docker/build-push-action@v6`
- Bumps `actions/checkout@v4` → `v5` in `docker-release.yml`
- `docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/login-action` left unchanged — no Node 24 versions released as of April 2026
- `node-version: 20` input in `setup-node` is untouched — that controls the runtime, not the action runner

## Test plan
- [ ] Verify next workflow run completes without the Node 20 deprecation warning annotation
- [ ] Verify multi-arch image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)