### PR TITLE
feat(db): add NFS config columns to repositories (PR-A)

### DIFF
--- a/packages/db/migrations/0028_repo_nfs_config.sql
+++ b/packages/db/migrations/0028_repo_nfs_config.sql
@@ -1,0 +1,5 @@
+ALTER TABLE repositories ADD COLUMN nfs_server TEXT;
+--> statement-breakpoint
+ALTER TABLE repositories ADD COLUMN nfs_export TEXT;
+--> statement-breakpoint
+ALTER TABLE repositories ADD COLUMN nfs_options TEXT;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1777161600000,
       "tag": "0027_run_type",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1777248000000,
+      "tag": "0028_repo_nfs_config",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -39,6 +39,10 @@ export const repositories = sqliteTable('repositories', {
   backend:         text('backend').notNull(),   // 's3'|'r2'|'b2'|'sftp'|'local'|'rclone'
   config:          text('config').notNull(),    // JSON, encrypted — backend-specific details
   resticPassword:  text('restic_password').notNull(), // encrypted with ENCRYPTION_KEY
+  // ── NFS agent-mount config (used when backend='nfs' and mode is agent-side) ──
+  nfsServer:       text('nfs_server'),
+  nfsExport:       text('nfs_export'),
+  nfsOptions:      text('nfs_options'),
   sizeBytes:       integer('size_bytes'),
   snapshotCount:   integer('snapshot_count'),
   initializedAt:   integer('initialized_at',    { mode: 'timestamp_ms' }),


### PR DESCRIPTION
## Summary
- Adds three nullable columns to the `repositories` table: `nfs_server`, `nfs_export`, `nfs_options`
- Migration file: `packages/db/migrations/0028_repo_nfs_config.sql`
- Drizzle schema updated in `packages/db/src/schema.ts` — new fields placed after `resticPassword`, before `sizeBytes`
- Journal entry added for migration 0028
- No behavior changes — columns are added but unused until PR-B wires the agent-side mounting
- Presence of `nfs_server` will be the auto-detect signal in PR-B for agent-mounted mode

## Test plan
- [ ] Deploy and verify `sqlite3 .schema repositories` shows all three new columns
- [ ] Verify existing repository rows show NULL in the new columns
- [ ] Verify a manual SQL UPDATE to set NFS values on an existing row succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)