### PR TITLE
feat(agent): mount_repository protocol + NFS pre-mount for agent-mounted repos (PR-B)

### DIFF
--- a/apps/agent-container/Dockerfile
+++ b/apps/agent-container/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine
 # restic  — required for backup/restore
 # tini    — proper PID 1 / signal handling (ensures Docker stop/restart works correctly)
 # curl    — used by the agent's bundle self-update download
-RUN apk add --no-cache restic tini curl ca-certificates
+RUN apk add --no-cache restic tini curl ca-certificates nfs-utils
 
 # The agent runs as root inside the container so it can read mounted Docker volumes
 # (which are root-owned) and so docker-cli operations against /var/run/docker.sock work.

--- a/apps/agent-container/docker-compose.example.yml
+++ b/apps/agent-container/docker-compose.example.yml
@@ -1,0 +1,26 @@
+services:
+  backupos-agent:
+    image: ghcr.io/dariusvorster/backupos-agent:latest
+    restart: unless-stopped
+    environment:
+      BACKUPOS_URL: wss://backupos.example.com/ws/agent
+      BACKUPOS_TOKEN: <your-api-token>
+    volumes:
+      # Docker socket — required for compose backup/restore and docker_volume source types
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Docker named volumes — required for docker_volume backups
+      - /var/lib/docker/volumes:/var/lib/docker/volumes:ro
+      # Host filesystem — required for filesystem source types in container mode
+      # The agent detects this mount and automatically prefixes /host onto all backup paths
+      - /:/host:ro
+      # Persistent state: enrollment token, bundle hash, restic cache
+      - backupos-agent-state:/var/lib/backupos
+      - backupos-restic-cache:/var/cache/restic
+    cap_add:
+      - SYS_ADMIN  # Required for NFS mount syscall when using agent-mounted repositories
+    security_opt:
+      - apparmor=unconfined  # Some distros (Ubuntu with AppArmor) need this alongside SYS_ADMIN for NFS
+
+volumes:
+  backupos-agent-state:
+  backupos-restic-cache:

--- a/apps/web/app/actions/compose-restore.ts
+++ b/apps/web/app/actions/compose-restore.ts
@@ -5,6 +5,7 @@ import { getDb, backupJobs, backupRuns, repositories, eq } from '@backupos/db'
 import { decryptField } from '@/lib/repo-crypto'
 import { dispatchToAgent } from '@/lib/internal-dispatch'
 import { connectedAgentIds } from '@/lib/ws-state'
+import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 import type { ComposeProjectConfig } from '@backupos/agent-protocol'
 
 export async function triggerComposeRestore(formData: FormData): Promise<void> {
@@ -62,6 +63,18 @@ export async function triggerComposeRestore(formData: FormData): Promise<void> {
   const cfg      = JSON.parse(decryptField(repo.config)) as Record<string, string>
   const password = decryptField(repo.resticPassword)
   if (!password) throw new Error(`triggerComposeRestore: failed to decrypt repo password for ${repo.id}`)
+
+  try {
+    await ensureRepoMountedOnAgent(job.agentId!, job.repositoryId!)
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    await db.insert(backupRuns).values({
+      id: crypto.randomUUID(), jobId, repositoryId: job.repositoryId!, agentId: job.agentId!,
+      status: 'failed', trigger: 'manual', startedAt: now, completedAt: now,
+      runType: 'restore', errorMessage: `NFS mount failed: ${errorMessage}`,
+    })
+    redirect(`/jobs/${jobId}`)
+  }
 
   const runId = crypto.randomUUID()
   await db.insert(backupRuns).values({

--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -6,6 +6,7 @@ import { getDb, backupJobs, backupRuns, repositories, bandwidthProfiles, bandwid
 import { decryptField } from '@/lib/repo-crypto'
 import { dispatchToAgent } from '@/lib/internal-dispatch'
 import { validateCron } from '@/lib/cron-validate'
+import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 
 function parseSourceConfig(sourceType: string, fd: FormData): string {
   const str = (k: string) => (fd.get(k) as string | null)?.trim() || undefined
@@ -244,6 +245,17 @@ export async function retryRun(jobId: string): Promise<void> {
   const password = decryptField(repo.resticPassword)
   if (!password) throw new Error(`dispatch: failed to decrypt repo password for repository ${repo.id}`)
   const tags = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${jobId}`]
+
+  try {
+    await ensureRepoMountedOnAgent(job.agentId, job.repositoryId!)
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    await db.update(backupRuns).set({
+      status: 'failed', completedAt: now, errorMessage: `NFS mount failed: ${errorMessage}`,
+    }).where(eq(backupRuns.id, runId))
+    await db.update(backupJobs).set({ lastRunStatus: 'failed' }).where(eq(backupJobs.id, jobId))
+    redirect(`/jobs/${jobId}`)
+  }
 
   let result: { ok: boolean; reason?: string; knownIds?: string[] }
   if (job.sourceType === 'compose_project') {

--- a/apps/web/lib/repo-mount.ts
+++ b/apps/web/lib/repo-mount.ts
@@ -1,0 +1,22 @@
+import { repositories, getDb, eq } from '@backupos/db'
+import { requestMountRepository } from './ws-state'
+
+/**
+ * If the repo has agent-mount config (nfs_server set), instructs the agent
+ * to mount it before the job runs. No-op for host-mounted repos.
+ */
+export async function ensureRepoMountedOnAgent(agentId: string, repoId: string): Promise<void> {
+  const db = getDb()
+  const [repo] = await db.select().from(repositories).where(eq(repositories.id, repoId)).limit(1)
+  if (!repo) throw new Error(`repository ${repoId} not found`)
+
+  if (!repo.nfsServer) return
+
+  await requestMountRepository(
+    agentId,
+    repoId,
+    repo.nfsServer,
+    repo.nfsExport ?? '',
+    repo.nfsOptions ?? 'vers=3,soft,timeo=50',
+  )
+}

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -4,6 +4,7 @@ import { getDb, backupJobs, backupRuns, repositories, agents, eq, and, or, lt, l
 import { decryptField } from './repo-crypto'
 import { sendAlert } from './alerts'
 import { dispatch, connectedAgentIds } from './ws-state'
+import { ensureRepoMountedOnAgent } from './repo-mount'
 import type { ServerMessage, MountConfig, ComposeProjectConfig } from '@backupos/agent-protocol'
 
 interface SourceConfig {
@@ -132,6 +133,16 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
         mountConfig,
       },
     }
+  }
+
+  try {
+    await ensureRepoMountedOnAgent(job.agentId, job.repositoryId)
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    await db.update(backupRuns).set({
+      status: 'failed', completedAt: now, errorMessage: `NFS mount failed: ${errorMessage}`,
+    }).where(eq(backupRuns.id, runId))
+    return false
   }
 
   const sent = dispatch(job.agentId, msg)

--- a/apps/web/lib/ws-state.ts
+++ b/apps/web/lib/ws-state.ts
@@ -135,6 +135,50 @@ export function resolveTestMount(requestId: string, result: MountTestResult): vo
 
 declare global {
   // eslint-disable-next-line no-var
+  var __bkp_pending_mount_repos: Map<string, { resolve: () => void; reject: (err: Error) => void }> | undefined
+}
+
+const pendingMountRepos: Map<string, { resolve: () => void; reject: (err: Error) => void }> =
+  (globalThis.__bkp_pending_mount_repos ??= new Map())
+
+export function requestMountRepository(
+  agentId: string,
+  repoId: string,
+  nfsServer: string,
+  nfsExport: string,
+  nfsOptions: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const requestId = crypto.randomUUID()
+    pendingMountRepos.set(requestId, { resolve, reject })
+    const sent = dispatch(agentId, {
+      type: 'mount_repository', requestId, repoId, nfsServer, nfsExport, nfsOptions,
+    })
+    if (!sent) {
+      pendingMountRepos.delete(requestId)
+      reject(new Error(`agent ${agentId} not connected`))
+      return
+    }
+    // NFS mount can be slow — allow 60s
+    setTimeout(() => {
+      if (pendingMountRepos.has(requestId)) {
+        pendingMountRepos.delete(requestId)
+        reject(new Error('mount request timed out after 60s'))
+      }
+    }, 60_000)
+  })
+}
+
+export function resolveMountRepository(requestId: string, error?: string): void {
+  const pending = pendingMountRepos.get(requestId)
+  if (!pending) return
+  pendingMountRepos.delete(requestId)
+  if (error) pending.reject(new Error(error))
+  else pending.resolve()
+}
+
+declare global {
+  // eslint-disable-next-line no-var
   var __bkp_pending_compose_lists: Map<string, (r: ComposeProjectListing) => void> | undefined
 }
 

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -10,7 +10,7 @@ import type { WebSocket } from 'ws'
 import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, eq, and, desc } from '@backupos/db'
 import { ResticEngine } from '@backupos/engine'
 import { parseExpression } from 'cron-parser'
-import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, connectedAgentIds, dispatch, requestListCompose, resolveListCompose } from './lib/ws-state'
+import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository } from './lib/ws-state'
 import { loadOrCreateInternalToken } from './lib/internal-token'
 import { decryptField } from './lib/repo-crypto'
 import { sendAlert } from './lib/alerts'
@@ -605,6 +605,12 @@ void app.prepare().then(() => {
 
         } else if (msg.type === 'test_mount_result') {
           resolveTestMount(msg.requestId, { ok: msg.ok, error: msg.error })
+
+        } else if (msg.type === 'mount_complete') {
+          resolveMountRepository(msg.requestId)
+
+        } else if (msg.type === 'mount_failed') {
+          resolveMountRepository(msg.requestId, msg.error)
 
         } else if (msg.type === 'compose_project_listing') {
           resolveListCompose(msg.requestId, msg.project)

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -143,6 +143,8 @@ export type AgentMessage =
   | { type: 'test_repo_result'; requestId: string; ok: boolean; error?: string; snapshotCount?: number }
   | { type: 'test_mount_result'; requestId: string; ok: boolean; error?: string }
   | { type: 'compose_project_listing'; requestId: string; project: ComposeProjectListing }
+  | { type: 'mount_complete'; requestId: string; repoId: string }
+  | { type: 'mount_failed'; requestId: string; repoId: string; error: string }
 
 export interface DetectedResources {
   dockerVolumes?: string[]
@@ -164,3 +166,4 @@ export type ServerMessage =
   | { type: 'list_compose_project'; requestId: string; projectName: string }
   | { type: 'run_compose_backup'; jobId: string; runId: string; config: ComposeProjectConfig; repoId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
   | { type: 'run_compose_restore'; jobId: string; runId: string; repoId: string; config: ComposeRestoreConfig; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
+  | { type: 'mount_repository'; requestId: string; repoId: string; nfsServer: string; nfsExport: string; nfsOptions: string }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -8,6 +8,7 @@ import type { AgentMessage, ServerMessage, BackupJobConfig } from '@backupos/age
 import { getSystemUptimeSeconds } from './system-uptime'
 import { detectCapabilities } from './capabilities'
 import { resolveHostPrefix, applyHostPrefixAll } from './lib/host-prefix'
+import { runMountRepository } from './handlers/mountRepository'
 
 function requireEnv(name: string): string {
   const v = process.env[name]
@@ -245,6 +246,9 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
       const { runComposeRestore } = await import('./handlers/composeRestore')
       await runComposeRestore(msg, send, activeJobs, BINARY)
     })()
+
+  } else if (msg.type === 'mount_repository') {
+    void runMountRepository(msg, send)
 
   } else if (msg.type === 'list_compose_project') {
     void (async () => {

--- a/packages/agent/src/handlers/mountRepository.ts
+++ b/packages/agent/src/handlers/mountRepository.ts
@@ -1,0 +1,49 @@
+import { execFile } from 'child_process'
+import { mkdirSync } from 'fs'
+import { promisify } from 'util'
+import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
+
+const execFileAsync = promisify(execFile)
+type MountMsg = Extract<ServerMessage, { type: 'mount_repository' }>
+
+async function isMountpoint(path: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync('cat', ['/proc/self/mountinfo'])
+    return stdout.split('\n').some(line => {
+      const parts = line.split(' ')
+      return parts[4] === path
+    })
+  } catch {
+    return false
+  }
+}
+
+export async function runMountRepository(
+  msg: MountMsg,
+  send: (out: AgentMessage) => void,
+): Promise<void> {
+  const { requestId, repoId, nfsServer, nfsExport, nfsOptions } = msg
+  const target = `/mnt/backupos/${repoId}`
+
+  try {
+    if (await isMountpoint(target)) {
+      send({ type: 'mount_complete', requestId, repoId })
+      return
+    }
+
+    mkdirSync(target, { recursive: true })
+
+    const source = `${nfsServer}:${nfsExport}`
+    const args = ['-t', 'nfs', '-o', nfsOptions, source, target]
+    await execFileAsync('mount', args, { timeout: 30_000 })
+
+    if (!(await isMountpoint(target))) {
+      throw new Error('mount command succeeded but target is not a mountpoint')
+    }
+
+    send({ type: 'mount_complete', requestId, repoId })
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    send({ type: 'mount_failed', requestId, repoId, error })
+  }
+}

--- a/packages/db/migrations/0028_repo_nfs_config.sql
+++ b/packages/db/migrations/0028_repo_nfs_config.sql
@@ -1,0 +1,5 @@
+ALTER TABLE repositories ADD COLUMN nfs_server TEXT;
+--> statement-breakpoint
+ALTER TABLE repositories ADD COLUMN nfs_export TEXT;
+--> statement-breakpoint
+ALTER TABLE repositories ADD COLUMN nfs_options TEXT;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1777161600000,
       "tag": "0027_run_type",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1777248000000,
+      "tag": "0028_repo_nfs_config",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -39,6 +39,10 @@ export const repositories = sqliteTable('repositories', {
   backend:         text('backend').notNull(),   // 's3'|'r2'|'b2'|'sftp'|'local'|'rclone'
   config:          text('config').notNull(),    // JSON, encrypted — backend-specific details
   resticPassword:  text('restic_password').notNull(), // encrypted with ENCRYPTION_KEY
+  // ── NFS agent-mount config (used when backend='nfs' and mode is agent-side) ──
+  nfsServer:       text('nfs_server'),
+  nfsExport:       text('nfs_export'),
+  nfsOptions:      text('nfs_options'),
   sizeBytes:       integer('size_bytes'),
   snapshotCount:   integer('snapshot_count'),
   initializedAt:   integer('initialized_at',    { mode: 'timestamp_ms' }),


### PR DESCRIPTION
## Summary
- Adds `mount_repository` (server→agent) and `mount_complete`/`mount_failed` (agent→server) protocol messages to `@backupos/agent-protocol`
- New agent handler `mountRepository.ts`: mounts `nfsServer:nfsExport` at `/mnt/backupos/<repoId>` using `mount -t nfs`, idempotent via `/proc/self/mountinfo`
- Agent routes `mount_repository` to the new handler
- `ws-state.ts`: adds `requestMountRepository` / `resolveMountRepository` request-response helpers (60s timeout)
- `server.ts`: routes `mount_complete` / `mount_failed` to `resolveMountRepository`
- New `lib/repo-mount.ts`: `ensureRepoMountedOnAgent` — no-op for repos without `nfs_server`, mounts before dispatch for NFS repos
- Pre-mount injected into all 3 dispatch sites: `scheduler.ts dispatchToAgent`, `jobs.ts retryRun`, `compose-restore.ts triggerComposeRestore`
- Mount failures fail the run with a clear error message; dispatch is skipped
- `apps/agent-container/Dockerfile`: adds `nfs-utils` to Alpine apk install
- Backwards compat: repos without `nfs_server` are unchanged — `ensureRepoMountedOnAgent` returns immediately

## Test plan
- [ ] Trigger a backup on a host-agent job — no regression, no mount step
- [ ] Set `nfs_server` on a repo and trigger a backup — verify `mount_repository` is dispatched and mount appears inside container
- [ ] Disconnect agent and trigger — verify mount failure produces a `failed` run with clear error
- [ ] Docker image builds with `nfs-utils` installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)