### PR TITLE
chore: clean up stale lockfile + gitignore docs build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist
 data/
 .DS_Store
 *.log
+apps/docs/out/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,18 +22,7 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
-  apps/agent-linux:
-    dependencies:
-      '@backupos/agent-protocol':
-        specifier: workspace:*
-        version: link:../../packages/agent-protocol
-    devDependencies:
-      '@types/node':
-        specifier: ^22.0.0
-        version: 22.19.17
-      typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+  apps/agent-container: {}
 
   apps/agent-windows:
     dependencies:


### PR DESCRIPTION
Trivial cleanup. apps/agent-linux directory was removed in yesterday's reorganization PRs but the lockfile entry remained. Also adding apps/docs/out/ to .gitignore so it stops showing as untracked.