### PR TITLE
fix(auth): auto-trust private network origins for login (#97)

### DIFF
--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,10 +1,17 @@
 import { betterAuth }     from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { getDb, user, session, account, verification } from '@backupos/db'
+import { isPrivateOrigin } from './private-origin'
+
+const explicitTrusted = process.env['BETTER_AUTH_TRUSTED_ORIGINS']
+  ?.split(',').map(s => s.trim()).filter(Boolean) ?? []
 
 export const auth = betterAuth({
   baseURL: process.env['BETTER_AUTH_URL'],
-  trustedOrigins: process.env['BETTER_AUTH_TRUSTED_ORIGINS']?.split(',').map(s => s.trim()) ?? [],
+  trustedOrigins: (request?: Request) => {
+    const origin = request?.headers.get('origin') ?? ''
+    return isPrivateOrigin(origin) ? [...explicitTrusted, origin] : explicitTrusted
+  },
   database: drizzleAdapter(getDb(), {
     provider: 'sqlite',
     schema: { user, session, account, verification },

--- a/apps/web/lib/private-origin.ts
+++ b/apps/web/lib/private-origin.ts
@@ -39,6 +39,8 @@ export function isPrivateOrigin(origin: string): boolean {
   // IPv6 loopback
   if (hostname === '[::1]' || hostname === '::1') return true
 
+  if (hostname === 'localhost') return true
+
   // mDNS
   if (hostname.endsWith('.local')) return true
 

--- a/apps/web/lib/private-origin.ts
+++ b/apps/web/lib/private-origin.ts
@@ -1,0 +1,46 @@
+// RFC 1918 + CGNAT/Tailscale + localhost + mDNS origin trust helper
+
+const PRIVATE_RANGES: Array<{ base: number; mask: number }> = [
+  { base: 0x0a000000, mask: 0xff000000 }, // 10.0.0.0/8
+  { base: 0xac100000, mask: 0xfff00000 }, // 172.16.0.0/12
+  { base: 0xc0a80000, mask: 0xffff0000 }, // 192.168.0.0/16
+  { base: 0x64400000, mask: 0xffc00000 }, // 100.64.0.0/10 (CGNAT / Tailscale)
+  { base: 0x7f000000, mask: 0xff000000 }, // 127.0.0.0/8
+]
+
+function ipToInt(ip: string): number | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+  let n = 0
+  for (const p of parts) {
+    const byte = parseInt(p, 10)
+    if (isNaN(byte) || byte < 0 || byte > 255) return null
+    n = (n << 8) | byte
+  }
+  return n >>> 0
+}
+
+function isPrivateIp(hostname: string): boolean {
+  const n = ipToInt(hostname)
+  if (n === null) return false
+  return PRIVATE_RANGES.some(r => (n & r.mask) === r.base)
+}
+
+export function isPrivateOrigin(origin: string): boolean {
+  let url: URL
+  try {
+    url = new URL(origin)
+  } catch {
+    return false
+  }
+
+  const { hostname } = url
+
+  // IPv6 loopback
+  if (hostname === '[::1]' || hostname === '::1') return true
+
+  // mDNS
+  if (hostname.endsWith('.local')) return true
+
+  return isPrivateIp(hostname)
+}


### PR DESCRIPTION
## Problem

Users accessing BackupOS via a Tailscale IP, LAN IP, or any URL that differs from `BETTER_AUTH_URL` receive an **"Invalid origin"** error on login. better-auth rejects the request because the `Origin` header doesn't match the configured base URL.

## Fix

- **`apps/web/lib/private-origin.ts`** — new pure helper `isPrivateOrigin(origin: string): boolean` that recognises:
  - RFC 1918: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
  - CGNAT / Tailscale: `100.64.0.0/10`
  - Loopback: `127.0.0.0/8`, `::1`
  - mDNS: `*.local`

- **`apps/web/lib/auth.ts`** — replaces the static `trustedOrigins` array with a request-based callback (better-auth 1.x API). The callback:
  1. Always allows origins from `BETTER_AUTH_TRUSTED_ORIGINS` (existing behaviour preserved)
  2. Auto-allows the request's `Origin` header when `isPrivateOrigin()` returns `true`
  3. Public-internet origins still require explicit configuration

Public origins are unaffected — this only widens trust for private/LAN/Tailscale addresses where the operator controls the network.

Closes #97