### PR TITLE
fix(auth): require password input when enabling 2FA

### DIFF
--- a/apps/web/components/totp-setup-modal.tsx
+++ b/apps/web/components/totp-setup-modal.tsx
@@ -8,6 +8,7 @@ interface Props { onClose: () => void; onEnabled: () => void }
 
 export function TotpSetupModal({ onClose, onEnabled }: Props) {
   const [step, setStep]               = useState<1 | 2 | 3>(1)
+  const [password, setPassword]       = useState('')
   const [uri, setUri]                 = useState('')
   const [code, setCode]               = useState('')
   const [backupCodes, setBackupCodes] = useState<string[]>([])
@@ -17,7 +18,8 @@ export function TotpSetupModal({ onClose, onEnabled }: Props) {
   async function handleInit() {
     setError('')
     setLoading(true)
-    const result = await authClient.twoFactor.enable()
+    const result = await authClient.twoFactor.enable({ password })
+    setPassword('')
     setLoading(false)
     if (result.error) { setError(result.error.message ?? 'Failed to initialise 2FA'); return }
     if (!result.data) { setError('Unexpected empty response'); return }
@@ -65,9 +67,29 @@ export function TotpSetupModal({ onClose, onEnabled }: Props) {
             <p style={{ fontSize: 14, color: 'var(--fg-mute)', marginBottom: 20, lineHeight: 1.6 }}>
               Adding a TOTP authenticator protects your account even if your password is leaked. You will need your authenticator app every time you sign in.
             </p>
+            <div style={{ marginBottom: 20 }}>
+              <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 4 }}>
+                Confirm your password
+              </label>
+              <p style={{ fontSize: 12, color: 'var(--fg-dim)', marginBottom: 8 }}>
+                Required to enable 2FA on your account.
+              </p>
+              <input
+                type="password"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                placeholder="••••••••"
+                autoFocus
+                style={{
+                  width: '100%', padding: '8px 12px', boxSizing: 'border-box',
+                  backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)', color: 'var(--fg)', fontSize: 14,
+                }}
+              />
+            </div>
             <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
               <button onClick={onClose} style={{ padding: '7px 16px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'none', fontSize: 13, cursor: 'pointer', color: 'var(--fg)' }}>Cancel</button>
-              <button onClick={handleInit} disabled={loading} style={{ padding: '7px 16px', borderRadius: 'var(--radius-sm)', border: 'none', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
+              <button onClick={handleInit} disabled={loading || password.length === 0} style={{ padding: '7px 16px', borderRadius: 'var(--radius-sm)', border: 'none', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
                 {loading ? 'Loading…' : 'Continue →'}
               </button>
             </div>


### PR DESCRIPTION
## Summary

PR #110 missed passing the `password` parameter to `authClient.twoFactor.enable()`. better-auth's `twoFactor.enable` endpoint requires it and rejects with:

```
[body.password] Invalid input: expected string, received undefined
```

This PR adds a "Confirm your password" input field to step 1 of the `TotpSetupModal`, passes the value to `enable({ password })`, and clears it from state immediately after the API call returns.

No other changes — steps 2 (QR + verify) and 3 (backup codes) are untouched.