### PR TITLE
fix(middleware): allow /login/two-factor without session

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -5,6 +5,7 @@ const SESSION_COOKIE = 'better-auth.session_token'
 
 const PUBLIC_PATHS = [
   '/login',
+  '/login/two-factor',
   '/signup',
   '/install.sh',
   '/install.ps1',


### PR DESCRIPTION
## Summary
- Adds `/login/two-factor` to `PUBLIC_PATHS` in `apps/web/middleware.ts` so the 2FA challenge page is not redirected to `/login` when no session cookie is present

Closes #98

## Test plan
- [ ] Sign in with an account that has 2FA enabled — should land on `/login/two-factor` instead of being bounced back to `/login`
- [ ] Unauthenticated direct navigation to `/login/two-factor` should render the page, not redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)