### PR TITLE
fix(auth): wire API token validation into middleware (#99)

### DIFF
--- a/apps/web/app/api/trpc/[...trpc]/route.ts
+++ b/apps/web/app/api/trpc/[...trpc]/route.ts
@@ -6,14 +6,23 @@ import { getDb } from '@backupos/db'
 import type { Context } from '@backupos/api'
 import { dispatch } from '../../../../lib/ws-state'
 import { auth } from '@/lib/auth'
+import { validateApiToken } from '@/lib/api-token-auth'
 
 async function createContext({ req }: { req: Request }): Promise<Context> {
   const session = await auth.api.getSession({ headers: req.headers })
-  return {
-    db:       getDb(),
-    user:     session?.user ?? null,
-    dispatch,
+  if (session) {
+    return { db: getDb(), user: session.user, dispatch }
   }
+
+  const authHeader = req.headers.get('authorization')
+  if (authHeader?.startsWith('Bearer ')) {
+    const tokenUser = await validateApiToken(authHeader.slice(7))
+    if (tokenUser) {
+      return { db: getDb(), user: tokenUser, dispatch }
+    }
+  }
+
+  return { db: getDb(), user: null, dispatch }
 }
 
 const handler = (req: Request) =>

--- a/apps/web/lib/api-token-auth.ts
+++ b/apps/web/lib/api-token-auth.ts
@@ -1,0 +1,35 @@
+import { createHash } from 'crypto'
+import { getDb, apiTokens, user, eq } from '@backupos/db'
+import type { AuthUser } from '@backupos/api'
+
+export async function validateApiToken(raw: string): Promise<AuthUser | null> {
+  const hash = createHash('sha256').update(raw).digest('hex')
+  const db = getDb()
+  const now = new Date()
+
+  const rows = await db
+    .select({ token: apiTokens, usr: user })
+    .from(apiTokens)
+    .innerJoin(user, eq(apiTokens.userId, user.id))
+    .where(eq(apiTokens.tokenHash, hash))
+    .limit(1)
+    .all()
+
+  if (rows.length === 0) return null
+
+  const row = rows[0]!
+
+  if (row.token.expiresAt !== null && row.token.expiresAt <= now) return null
+
+  try {
+    await db.update(apiTokens).set({ lastUsedAt: now }).where(eq(apiTokens.id, row.token.id))
+  } catch {
+    // best-effort — don't fail validation if the update fails
+  }
+
+  return {
+    id:    row.usr.id,
+    email: row.usr.email,
+    name:  row.usr.name ?? undefined,
+  }
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -35,6 +35,9 @@ export function middleware(request: NextRequest) {
 
   // API routes: accept Bearer token OR session cookie; never redirect to /login
   if (pathname.startsWith('/api/')) {
+    // Edge runtime has no DB access, so Bearer presence bypasses the /login redirect
+    // but does NOT constitute validation. Route handlers must call validateApiToken
+    // from @/lib/api-token-auth themselves before treating the request as authenticated.
     const authHeader = request.headers.get('authorization')
     if (authHeader?.startsWith('Bearer ') || request.cookies.get(SESSION_COOKIE)) {
       return NextResponse.next()

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -33,8 +33,16 @@ export function middleware(request: NextRequest) {
     return NextResponse.next()
   }
 
-  const token = request.cookies.get(SESSION_COOKIE)
-  if (!token) {
+  // API routes: accept Bearer token OR session cookie; never redirect to /login
+  if (pathname.startsWith('/api/')) {
+    const authHeader = request.headers.get('authorization')
+    if (authHeader?.startsWith('Bearer ') || request.cookies.get(SESSION_COOKIE)) {
+      return NextResponse.next()
+    }
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (!request.cookies.get(SESSION_COOKIE)) {
     const loginUrl = new URL('/login', request.url)
     loginUrl.searchParams.set('next', pathname)
     return NextResponse.redirect(loginUrl)


### PR DESCRIPTION
## Summary

API tokens existed in the DB but were never validated — any `Authorization: Bearer` header was ignored. This PR wires real token validation into the request pipeline.

## Validation flow

1. Request arrives at `/api/*` (excluding `/api/auth/*`, `/api/health`)
2. Middleware checks: Bearer header present OR session cookie → allow through; neither → **401 JSON** (never `/login` redirect)
3. For tRPC requests carrying `Authorization: Bearer <token>`, the route handler's `createContext` calls `validateApiToken(token)`:
   - SHA-256 hashes the token and looks it up in `api_tokens` by `token_hash`
   - Rejects if `expires_at` is set and in the past
   - Updates `last_used_at` (best-effort — doesn't fail auth on write error)
   - Returns `{ id, email, name }` matching `AuthUser`, or `null` on no match / expired
4. If token is valid, `ctx.user` is set — the request proceeds identically to a session-cookie request
5. If token is invalid (Bearer present but doesn't validate), `ctx.user` is null → tRPC procedures that require auth return their normal unauthorized error (JSON, not redirect)

## Edge runtime note

`api-token-auth.ts` uses `node:crypto` and drizzle/SQLite — it is only imported inside the tRPC route handler (Node.js runtime). The Next.js Edge middleware never imports it, so the 32.7 kB middleware bundle stays clean.

## Verification

```bash
# No token → 401 JSON
curl -s http://localhost:3000/api/trpc/jobs.list | jq .
# → {"error":"Unauthorized"}

# Invalid token → tRPC unauthorized (JSON, not redirect)
curl -s -H "Authorization: Bearer bkp_fake" http://localhost:3000/api/trpc/jobs.list | jq .

# Valid token → normal response
curl -s -H "Authorization: Bearer bkp_<real_token>" http://localhost:3000/api/trpc/jobs.list | jq .
```

Closes #99