### PR TITLE
fix(db): seed backup_defaults so retention runs by default (#101)

### DIFF
--- a/packages/db/migrations/0030_seed_backup_defaults.sql
+++ b/packages/db/migrations/0030_seed_backup_defaults.sql
@@ -1,0 +1,3 @@
+INSERT INTO backup_defaults (id, keep_last, keep_daily, keep_weekly, keep_monthly, keep_yearly, schedule_start, schedule_end)
+VALUES ('singleton', 10, 7, 4, 12, 0, 0, 23)
+ON CONFLICT(id) DO NOTHING;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1777334400000,
       "tag": "0029_two_factor_plugin",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "6",
+      "when": 1745884800001,
+      "tag": "0030_seed_backup_defaults",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Jobs without per-job retention settings fall back to `backup_defaults`. The `backup_defaults` table was empty on fresh installs, so `defaults` was `undefined` in `server.ts`, the forget call was skipped entirely, and snapshots accumulated forever.

This migration inserts the singleton defaults row on first run.

## Migration

```sql
INSERT INTO backup_defaults (id, keep_last, keep_daily, keep_weekly, keep_monthly, keep_yearly, schedule_start, schedule_end)
VALUES ('singleton', 10, 7, 4, 12, 0, 0, 23)
ON CONFLICT(id) DO NOTHING;
```

Defaults seeded: keep-last=10, daily=7, weekly=4, monthly=12, yearly=0, schedule window 00:00–23:00.

## Migration impact

Idempotent — `ON CONFLICT(id) DO NOTHING` means it is safe to run against installs that already have a row. Existing customised defaults are left untouched.

## Verification

After deploy:

```sql
SELECT * FROM backup_defaults;
-- id         | keep_last | keep_daily | keep_weekly | keep_monthly | keep_yearly | schedule_start | schedule_end
-- singleton  | 10        | 7          | 4           | 12           | 0           | 0              | 23
```

Closes #101