### PR TITLE
fix(bandwidth): wire bandwidth limits into restic CLI flags (#103)

### DIFF
--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -261,14 +261,15 @@ export async function retryRun(jobId: string): Promise<void> {
   if (job.sourceType === 'compose_project') {
     const composeConfig = JSON.parse(job.sourceConfig) as import('@backupos/agent-protocol').ComposeProjectConfig
     result = await dispatchToAgent(job.agentId, {
-      type:         'run_compose_backup',
+      type:               'run_compose_backup',
       jobId,
       runId,
-      config:       composeConfig,
-      repoId:       job.repositoryId!,
-      repoUrl:      cfg['repositoryUrl'] ?? '',
-      repoPassword: password,
-      envVars:      cfg,
+      config:             composeConfig,
+      repoId:             job.repositoryId!,
+      repoUrl:            cfg['repositoryUrl'] ?? '',
+      repoPassword:       password,
+      envVars:            cfg,
+      bandwidthLimitKbps,
     })
   } else {
     const srcConfig = JSON.parse(job.sourceConfig) as { paths?: string[]; volumes?: string[]; exclude?: string[] }
@@ -276,10 +277,11 @@ export async function retryRun(jobId: string): Promise<void> {
       ? (srcConfig.volumes ?? []).map(v => `/var/lib/docker/volumes/${v}/_data`)
       : (srcConfig.paths ?? [])
     result = await dispatchToAgent(job.agentId, {
-      type:   'run_backup',
+      type:               'run_backup',
       jobId,
       runId,
-      config: { repoId: job.repositoryId!, repoUrl: cfg['repositoryUrl'] ?? '', repoPassword: password, paths, exclude: srcConfig.exclude, tags, envVars: cfg },
+      config:             { repoId: job.repositoryId!, repoUrl: cfg['repositoryUrl'] ?? '', repoPassword: password, paths, exclude: srcConfig.exclude, tags, envVars: cfg },
+      bandwidthLimitKbps,
     })
   }
 

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -1,6 +1,6 @@
 import * as cron from 'node-cron'
 import { parseExpression } from 'cron-parser'
-import { getDb, backupJobs, backupRuns, repositories, agents, eq, and, or, lt, lte, isNotNull, isNull } from '@backupos/db'
+import { getDb, backupJobs, backupRuns, repositories, agents, bandwidthProfiles, bandwidthRules, eq, and, or, lt, lte, gte, isNotNull, isNull } from '@backupos/db'
 import { decryptField } from './repo-crypto'
 import { sendAlert } from './alerts'
 import { dispatch, connectedAgentIds } from './ws-state'
@@ -88,9 +88,33 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
   const runId = crypto.randomUUID()
   const now   = new Date()
 
+  // Resolve bandwidth limit: per-job profile first, then global fallback
+  let bandwidthLimitKbps: number | null = null
+  {
+    let profileId = job.bandwidthProfileId ?? null
+    if (!profileId) {
+      const [globalProfile] = await db.select().from(bandwidthProfiles).where(eq(bandwidthProfiles.isGlobal, true)).limit(1)
+      profileId = globalProfile?.id ?? null
+    }
+    if (profileId) {
+      const currentHour = new Date().getHours()
+      const [rule] = await db
+        .select()
+        .from(bandwidthRules)
+        .where(and(
+          eq(bandwidthRules.profileId, profileId),
+          lte(bandwidthRules.startHour, currentHour),
+          gte(bandwidthRules.endHour,   currentHour),
+        ))
+        .limit(1)
+      bandwidthLimitKbps = rule?.limitKbps ?? null
+    }
+  }
+
   await db.insert(backupRuns).values({
     id: runId, jobId: job.id, repositoryId: job.repositoryId,
     agentId: job.agentId, status: 'running', trigger, startedAt: now,
+    bandwidthLimitKbps,
   })
   await db.update(backupJobs).set({ lastRunAt: now }).where(eq(backupJobs.id, job.id))
 
@@ -98,14 +122,15 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
   if (job.sourceType === 'compose_project') {
     const composeConfig = JSON.parse(job.sourceConfig) as ComposeProjectConfig
     msg = {
-      type:         'run_compose_backup',
-      jobId:        job.id,
+      type:               'run_compose_backup',
+      jobId:              job.id,
       runId,
-      config:       composeConfig,
-      repoId:       job.repositoryId ?? '',
-      repoUrl:      cfg['repositoryUrl'] ?? '',
-      repoPassword: password,
-      envVars:      cfg,
+      config:             composeConfig,
+      repoId:             job.repositoryId ?? '',
+      repoUrl:            cfg['repositoryUrl'] ?? '',
+      repoPassword:       password,
+      envVars:            cfg,
+      bandwidthLimitKbps,
     }
   } else {
     const srcConfig   = JSON.parse(job.sourceConfig) as SourceConfig
@@ -119,8 +144,8 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
     const tags        = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${job.id}`]
     const mountConfig = cfg['mountConfig'] ? (JSON.parse(cfg['mountConfig']) as MountConfig) : undefined
     msg = {
-      type:   'run_backup',
-      jobId:  job.id,
+      type:               'run_backup',
+      jobId:              job.id,
       runId,
       config: {
         repoId:       job.repositoryId ?? '',
@@ -132,6 +157,7 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
         envVars:      cfg,
         mountConfig,
       },
+      bandwidthLimitKbps,
     }
   }
 

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -155,8 +155,8 @@ export interface DetectedResources {
 export type ServerMessage =
   | { type: 'welcome'; agentId: string; serverVersion: string; bundleHash?: string }
   | { type: 'pong' }
-  | { type: 'run_backup'; jobId: string; runId: string; config: BackupJobConfig }
-  | { type: 'run_restore'; restoreId: string; specYaml: string; snapshotId: string }
+  | { type: 'run_backup'; jobId: string; runId: string; config: BackupJobConfig; bandwidthLimitKbps?: number | null }
+  | { type: 'run_restore'; restoreId: string; specYaml: string; snapshotId: string; bandwidthLimitKbps?: number | null }
   | { type: 'cancel_backup'; jobId: string; runId: string }
   | { type: 'verify_repo'; repoId: string; repoUrl: string; repoPassword: string; readData: boolean; envVars?: Record<string, string> }
   | { type: 'list_resources'; requestId: string }
@@ -164,6 +164,6 @@ export type ServerMessage =
   | { type: 'test_mount'; requestId: string; mountConfig: MountConfig }
   | { type: 'force_update' }
   | { type: 'list_compose_project'; requestId: string; projectName: string }
-  | { type: 'run_compose_backup'; jobId: string; runId: string; config: ComposeProjectConfig; repoId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
+  | { type: 'run_compose_backup'; jobId: string; runId: string; config: ComposeProjectConfig; repoId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; bandwidthLimitKbps?: number | null }
   | { type: 'run_compose_restore'; jobId: string; runId: string; repoId: string; config: ComposeRestoreConfig; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
   | { type: 'mount_repository'; requestId: string; repoId: string; nfsServer: string; nfsExport: string; nfsOptions: string }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -218,7 +218,7 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
     // heartbeat acknowledged
 
   } else if (msg.type === 'run_backup') {
-    void runBackup(msg.jobId, msg.runId, msg.config)
+    void runBackup(msg.jobId, msg.runId, msg.config, msg.bandwidthLimitKbps)
 
   } else if (msg.type === 'cancel_backup') {
     const job = activeJobs.get(msg.jobId)
@@ -265,7 +265,7 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
   }
 }
 
-async function runBackup(jobId: string, runId: string, config: BackupJobConfig): Promise<void> {
+async function runBackup(jobId: string, runId: string, config: BackupJobConfig, bandwidthLimitKbps?: number | null): Promise<void> {
   if (activeJobs.has(jobId)) {
     console.warn(`[agent] Job ${jobId} already running — ignoring duplicate dispatch`)
     return
@@ -288,10 +288,11 @@ async function runBackup(jobId: string, runId: string, config: BackupJobConfig):
     }
 
     const engine = new ResticEngine({
-      repositoryUrl: config.repoUrl,
-      password:      config.repoPassword,
-      envVars:       config.envVars ?? {},
-      binaryPath:    BINARY,
+      repositoryUrl:      config.repoUrl,
+      password:           config.repoPassword,
+      envVars:            config.envVars ?? {},
+      binaryPath:         BINARY,
+      bandwidthLimitKbps: bandwidthLimitKbps ?? undefined,
     })
 
     await ensureRepoInitialized(engine, config.repoId)

--- a/packages/agent/src/handlers/composeBackup.ts
+++ b/packages/agent/src/handlers/composeBackup.ts
@@ -50,7 +50,7 @@ export async function runComposeBackup(
   binaryPath: string | undefined,
   ensureRepo: EnsureRepoFn,
 ): Promise<void> {
-  const { jobId, runId, config, repoId, repoUrl, repoPassword, envVars } = msg
+  const { jobId, runId, config, repoId, repoUrl, repoPassword, envVars, bandwidthLimitKbps } = msg
   const ctrl = new AbortController()
 
   activeJobs.set(jobId, { ctrl, runId, phase: 'starting', lastResticEventAt: Date.now(), cancelled: false })
@@ -65,10 +65,11 @@ export async function runComposeBackup(
   }
 
   const makeEngine = () => new ResticEngine({
-    repositoryUrl: repoUrl,
-    password:      repoPassword,
-    envVars:       envVars ?? {},
+    repositoryUrl:      repoUrl,
+    password:           repoPassword,
+    envVars:            envVars ?? {},
     binaryPath,
+    bandwidthLimitKbps: bandwidthLimitKbps ?? undefined,
   })
 
   const tmpDir = path.join(os.tmpdir(), 'backupos-apphooks', jobId)

--- a/packages/engine/src/restic.ts
+++ b/packages/engine/src/restic.ts
@@ -73,6 +73,10 @@ export class ResticEngine {
       if (opts.excludeFile)   args.push('--exclude-file', opts.excludeFile)
       if (opts.oneFileSystem) args.push('--one-file-system')
       if (opts.useVSS)        args.push('--use-fs-snapshot')
+      if (this.config.bandwidthLimitKbps && this.config.bandwidthLimitKbps > 0) {
+        args.push('--limit-upload',   String(this.config.bandwidthLimitKbps))
+        args.push('--limit-download', String(this.config.bandwidthLimitKbps))
+      }
 
       const result = await this.runStreaming(
         args,
@@ -164,6 +168,10 @@ export class ResticEngine {
   async check(readData = false): Promise<CheckResult> {
     const args = ['check']
     if (readData) args.push('--read-data')
+    if (this.config.bandwidthLimitKbps && this.config.bandwidthLimitKbps > 0) {
+      args.push('--limit-upload',   String(this.config.bandwidthLimitKbps))
+      args.push('--limit-download', String(this.config.bandwidthLimitKbps))
+    }
 
     const result = await this.run(args, undefined, 1_800_000)
     const ok = result.exitCode === 0
@@ -184,6 +192,10 @@ export class ResticEngine {
   ): Promise<RestoreResult> {
     const args = ['restore', snapshotId, '--target', target]
     if (include) for (const p of include) args.push('--include', p)
+    if (this.config.bandwidthLimitKbps && this.config.bandwidthLimitKbps > 0) {
+      args.push('--limit-upload',   String(this.config.bandwidthLimitKbps))
+      args.push('--limit-download', String(this.config.bandwidthLimitKbps))
+    }
 
     const before = Date.now()
     const result = await this.run(args, undefined, 14_400_000, signal)

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -3,6 +3,7 @@ export interface ResticConfig {
   password: string
   envVars: Record<string, string>  // backend credentials (AWS_*, etc.)
   binaryPath?: string              // defaults to 'restic' in PATH
+  bandwidthLimitKbps?: number | null
 }
 
 export interface BackupProgressStatus {


### PR DESCRIPTION
## Summary

Bandwidth limits were saved per-run in \`backup_runs.bandwidth_limit_kbps\` but the value never reached restic. Backups ran at full speed regardless of the profile.

## Pipeline added

```
server (scheduler.ts / retryRun)
  → resolves bandwidthLimitKbps (per-job profile → global fallback → current hour rule)
  → stored in backup_runs.bandwidth_limit_kbps
  → included in run_backup / run_compose_backup WebSocket message
agent handler (agent.ts / composeBackup.ts)
  → extracts bandwidthLimitKbps from message
  → passes to ResticEngine constructor
engine (restic.ts)
  → adds --limit-upload <kbps> --limit-download <kbps> to restic backup / restore / check args
  → skipped when value is null, undefined, or <= 0 (no flags = unlimited)
```

## Changes by package

| Package | Change |
|---------|--------|
| `@backupos/agent-protocol` | Added `bandwidthLimitKbps?: number \| null` to `run_backup`, `run_compose_backup`, `run_restore` message types |
| `@backupos/engine` | Added `bandwidthLimitKbps` to `ResticConfig`; flags applied in `backup`, `restore`, `check` (not `forget`/`prune`) |
| `@backupos/agent` | `runBackup` and `composeBackup` extract limit from message and pass to engine constructor |
| `apps/web` | `scheduler.ts` resolves limit before dispatch; `retryRun` in `jobs.ts` includes limit in both message types |

## Verification

1. Configure a bandwidth profile (e.g. 100 KB/s) at `/settings/bandwidth`
2. Set it as global default or assign to a job
3. Trigger a backup
4. Check agent logs — the restic invocation should include:
   ```
   restic backup --json --no-scan ... --limit-upload 100 --limit-download 100
   ```
5. Network throughput should be capped

Closes #103