### PR TITLE
fix(scheduler): enforce schedule windows (#104)

### DIFF
--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -2,11 +2,12 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { getDb, backupJobs, backupRuns, repositories, bandwidthProfiles, bandwidthRules, eq, inArray, and, lte, gte } from '@backupos/db'
+import { getDb, backupJobs, backupRuns, repositories, backupDefaults, bandwidthProfiles, bandwidthRules, eq, inArray, and, lte, gte } from '@backupos/db'
 import { decryptField } from '@/lib/repo-crypto'
 import { dispatchToAgent } from '@/lib/internal-dispatch'
 import { validateCron } from '@/lib/cron-validate'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
+import { isWithinWindow } from '@/lib/schedule-window'
 
 function parseSourceConfig(sourceType: string, fd: FormData): string {
   const str = (k: string) => (fd.get(k) as string | null)?.trim() || undefined
@@ -195,6 +196,34 @@ export async function retryRun(jobId: string): Promise<void> {
   if (!job || !job.repositoryId) { redirect(`/jobs/${jobId}`) }
 
   const bandwidthLimitKbps = await resolveBandwidthLimitKbps(db, jobId)
+
+  // Resolve schedule window: per-job override → global default
+  const windowStart = job.scheduleStart
+  const windowEnd   = job.scheduleEnd
+  let effectiveStart: number | null = windowStart ?? null
+  let effectiveEnd:   number | null = windowEnd   ?? null
+  if (effectiveStart === null || effectiveEnd === null) {
+    const [defaults] = await db.select().from(backupDefaults).limit(1).all()
+    effectiveStart = defaults?.scheduleStart ?? null
+    effectiveEnd   = defaults?.scheduleEnd   ?? null
+  }
+  if (!isWithinWindow(now.getHours(), effectiveStart, effectiveEnd)) {
+    const windowLabel = `${String(effectiveStart ?? '?').padStart(2, '0')}:00–${String(effectiveEnd ?? '?').padStart(2, '0')}:00`
+    await db.insert(backupRuns).values({
+      id:           crypto.randomUUID(),
+      jobId,
+      repositoryId: job.repositoryId,
+      agentId:      job.agentId ?? null,
+      status:       'failed',
+      trigger:      'manual',
+      startedAt:    now,
+      completedAt:  now,
+      errorMessage: `Outside backup window ${windowLabel} — retry when inside the window or adjust the window at /settings/schedule-windows`,
+    })
+    await db.update(backupJobs).set({ lastRunAt: now, lastRunStatus: 'failed' }).where(eq(backupJobs.id, jobId))
+    redirect(`/jobs/${jobId}`)
+  }
+
   const runId = crypto.randomUUID()
 
   await db.insert(backupRuns).values({

--- a/apps/web/lib/schedule-window.ts
+++ b/apps/web/lib/schedule-window.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure helper for schedule-window enforcement.
+ *
+ * Hours are 0-23. A null start or end means "no window configured" → always allowed.
+ * start=0, end=23 is treated as "always" (full day).
+ * Wrap-around windows (start > end, e.g. 22-06) allow overnight ranges correctly.
+ */
+export function isWithinWindow(
+  currentHour: number,
+  start: number | null,
+  end: number | null,
+): boolean {
+  if (start === null || end === null) return true
+  if (start === 0 && end === 23) return true
+  if (start === end) return true
+
+  if (start < end) {
+    return currentHour >= start && currentHour < end
+  }
+  // Wrap-around: e.g. 22 to 06 — allow 22,23,00,01…05
+  return currentHour >= start || currentHour < end
+}

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -1,10 +1,11 @@
 import * as cron from 'node-cron'
 import { parseExpression } from 'cron-parser'
-import { getDb, backupJobs, backupRuns, repositories, agents, bandwidthProfiles, bandwidthRules, eq, and, or, lt, lte, gte, isNotNull, isNull } from '@backupos/db'
+import { getDb, backupJobs, backupRuns, repositories, agents, backupDefaults, bandwidthProfiles, bandwidthRules, eq, and, or, lt, lte, gte, isNotNull, isNull } from '@backupos/db'
 import { decryptField } from './repo-crypto'
 import { sendAlert } from './alerts'
 import { dispatch, connectedAgentIds } from './ws-state'
 import { ensureRepoMountedOnAgent } from './repo-mount'
+import { isWithinWindow } from './schedule-window'
 import type { ServerMessage, MountConfig, ComposeProjectConfig } from '@backupos/agent-protocol'
 
 interface SourceConfig {
@@ -72,6 +73,14 @@ async function stampNextRunIfMissing(db: Db, jobId: string, schedule: string): P
   if (next) {
     await db.update(backupJobs).set({ nextRunAt: next }).where(eq(backupJobs.id, jobId))
   }
+}
+
+async function resolveJobWindow(db: Db, job: Job): Promise<{ start: number | null; end: number | null }> {
+  if (job.scheduleStart !== null && job.scheduleEnd !== null) {
+    return { start: job.scheduleStart, end: job.scheduleEnd }
+  }
+  const [defaults] = await db.select().from(backupDefaults).limit(1).all()
+  return { start: defaults?.scheduleStart ?? null, end: defaults?.scheduleEnd ?? null }
 }
 
 async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Promise<boolean> {
@@ -202,6 +211,17 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
 async function runJob(db: Db, job: Job, trigger: 'cron' | 'manual'): Promise<void> {
   if (!job.repositoryId) return
 
+  // Cron-triggered jobs are silently deferred when outside the window.
+  // Tick-triggered (manual) jobs have their window check in triggerTick so nextRunAt is
+  // not reset, allowing the tick to retry until the window opens.
+  if (trigger === 'cron') {
+    const { start, end } = await resolveJobWindow(db, job)
+    if (!isWithinWindow(new Date().getHours(), start, end)) {
+      console.log(`[scheduler] deferring "${job.name}" (cron) — outside window ${start ?? '?'}–${end ?? '?'}`)
+      return
+    }
+  }
+
   const now = new Date()
 
   if (!job.agentId) {
@@ -254,6 +274,14 @@ async function triggerTick(db: Db): Promise<void> {
       and(eq(backupRuns.jobId, job.id), eq(backupRuns.status, 'running'))
     ).limit(1).all()
     if (active) continue
+
+    // Check schedule window before resetting nextRunAt — if outside the window, leave
+    // nextRunAt as-is so the next tick (5s) retries until the window opens.
+    const { start, end } = await resolveJobWindow(db, job)
+    if (!isWithinWindow(new Date().getHours(), start, end)) {
+      console.log(`[scheduler] deferring "${job.name}" — outside window ${start ?? '?'}–${end ?? '?'}`)
+      continue
+    }
 
     // Reset nextRunAt before dispatching so the next tick doesn't re-fire
     const next = nextRunDate(job.schedule)

--- a/packages/db/migrations/0031_job_schedule_windows.sql
+++ b/packages/db/migrations/0031_job_schedule_windows.sql
@@ -1,0 +1,3 @@
+ALTER TABLE backup_jobs ADD COLUMN schedule_start INTEGER;
+--> statement-breakpoint
+ALTER TABLE backup_jobs ADD COLUMN schedule_end INTEGER;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1745884800001,
       "tag": "0030_seed_backup_defaults",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1745971200001,
+      "tag": "0031_job_schedule_windows",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -109,6 +109,10 @@ export const backupJobs = sqliteTable('backup_jobs', {
   createdAt:     integer('created_at',      { mode: 'timestamp_ms' }).notNull(),
   bandwidthProfileId: text('bandwidth_profile_id').references(() => bandwidthProfiles.id),
 
+  // Per-job schedule window override (0-23 hours; null = use global default)
+  scheduleStart: integer('schedule_start'),
+  scheduleEnd:   integer('schedule_end'),
+
   // Pre-flight checks
   preflightEnabled:    integer('preflight_enabled',    { mode: 'boolean' }).default(true),
   lastPreflightAt:     integer('last_preflight_at',    { mode: 'timestamp_ms' }),


### PR DESCRIPTION
## Summary

Schedule windows were saved to \`backup_defaults.schedule_start/end\` but the scheduler never read them — all backups dispatched whenever their cron fired, regardless of window. The page claimed "Backups outside this window will be delayed" but this was false.

## Pipeline added

```
Per-job override (backup_jobs.schedule_start/end)
  → fall back to global default (backup_defaults.schedule_start/end)
  → isWithinWindow(currentHour, start, end)
    → cron path: skip silently; cron fires again at next schedule time
    → tick path: skip WITHOUT resetting nextRunAt; tick retries every 5s until window opens
    → retryRun: fail run immediately with clear message "Outside backup window HH:00–HH:00"
```

## Per-job override

Added `schedule_start` / `schedule_end` columns to `backup_jobs` via migration `0031_job_schedule_windows.sql`. Both nullable — null means "use global default". Useful for jobs that need a different window from the global one.

## Window resolution: `isWithinWindow`

Pure function in `apps/web/lib/schedule-window.ts`:
- `null` start or end → always allowed
- `start=0, end=23` → always allowed (full day sentinel)
- `start < end` (e.g. 08–18) → non-wrapping range
- `start > end` (e.g. 22–06) → wrap-around: `hour >= 22 || hour < 6` ✓

Test cases:
| start | end | hour | result |
|-------|-----|------|--------|
| 0 | 23 | any | ✅ always |
| null | null | any | ✅ always |
| 22 | 6 | 23 | ✅ |
| 22 | 6 | 5 | ✅ |
| 22 | 6 | 10 | ❌ |
| 8 | 18 | 14 | ✅ |
| 8 | 18 | 20 | ❌ |

## Manual "Run now" UX

`triggerJob` (sets `nextRunAt = now`) feeds into the trigger tick which now enforces windows. The job will be held until the window opens — no failure, no noise.

`retryRun` (Retry button on job detail page) fails immediately with a human-readable message so the user knows why the backup didn't start, rather than silently deferring.

## Deferred cron behaviour

When a cron fires outside the window, `runJob` returns early without creating a run row. No error is recorded. The next cron fire is checked against the window again. This matches the documented claim: "delayed to the next window start".

Closes #104