### PR TITLE
fix(users): SMTP detection should read from smtp_config table (#94)

### DIFF
--- a/apps/web/app/(dashboard)/settings/users/page.tsx
+++ b/apps/web/app/(dashboard)/settings/users/page.tsx
@@ -1,6 +1,6 @@
 import { redirect }       from 'next/navigation'
 import { getCurrentUser } from '@/lib/user'
-import { getDb, user, invite } from '@backupos/db'
+import { getDb, user, invite, smtpConfig } from '@backupos/db'
 import { UsersClient }    from './client'
 
 export default async function UsersPage() {
@@ -28,8 +28,9 @@ export default async function UsersPage() {
     }).from(invite).all(),
   ])
 
-  const baseUrl       = process.env['NEXT_PUBLIC_BASE_URL'] ?? 'http://localhost:3000'
-  const smtpConfigured = !!process.env['SMTP_HOST']
+  const baseUrl = process.env['NEXT_PUBLIC_BASE_URL'] ?? 'http://localhost:3000'
+  const [smtp] = await db.select().from(smtpConfig).limit(1).all()
+  const smtpConfigured = !!(smtp?.enabled && smtp.host && smtp.fromEmail)
 
   return (
     <UsersClient


### PR DESCRIPTION
## Summary

\`/settings/users\` determined whether SMTP was configured by checking \`process.env['SMTP_HOST']\`. This env var is never set — SMTP is configured via the UI form which writes to the \`smtp_config\` DB table. Result: the page always showed "SMTP not configured — invites are link-only" even after SMTP was successfully configured.

## Fix

Replace the env var check with a DB query:

```typescript
const [smtp] = await db.select().from(smtpConfig).limit(1).all()
const smtpConfigured = !!(smtp?.enabled && smtp.host && smtp.fromEmail)
```

The three-condition check mirrors how `alerts.ts fireEmail()` guards sending: row must exist, be enabled, have a host, and have a from address.

## Other call sites

`apps/web/lib/mailer.ts` also reads env vars for SMTP but that's a separate legacy mailer used for invitation emails — it's not a detection flag and is outside the scope of this fix.

Closes #94