### PR TITLE
fix(smtp): encrypt password at rest

### DIFF
--- a/apps/web/app/actions/settings.ts
+++ b/apps/web/app/actions/settings.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from 'next/navigation'
 import { getDb, instanceSettings, smtpConfig, backupDefaults } from '@backupos/db'
+import { encryptField } from '@/lib/repo-crypto'
 
 export async function saveInstanceSettings(formData: FormData) {
   const db = getDb()
@@ -25,11 +26,22 @@ export async function saveInstanceSettings(formData: FormData) {
 
 export async function saveSmtpConfig(formData: FormData) {
   const db = getDb()
+  const rawPassword = (formData.get('password') as string | null) ?? ''
+
+  // If the form submits an empty password, keep the existing encrypted value
+  let password: string | null
+  if (rawPassword === '') {
+    const [existing] = await db.select({ password: smtpConfig.password }).from(smtpConfig).limit(1).all()
+    password = existing?.password ?? null
+  } else {
+    password = encryptField(rawPassword)
+  }
+
   const values = {
     host:      formData.get('host') as string | null,
     port:      Number(formData.get('port') ?? 587),
     username:  formData.get('username') as string | null,
-    password:  formData.get('password') as string | null,
+    password,
     fromName:  String(formData.get('fromName') ?? 'BackupOS'),
     fromEmail: formData.get('fromEmail') as string | null,
     tls:       formData.get('tls') === 'on',

--- a/apps/web/lib/alerts.ts
+++ b/apps/web/lib/alerts.ts
@@ -1,5 +1,6 @@
 import nodemailer from 'nodemailer'
 import { getDb, alerts, alertChannels, smtpConfig, eq } from '@backupos/db'
+import { decryptField } from './repo-crypto'
 
 type AlertType = 'backup_failed' | 'backup_missed' | 'agent_disconnected'
 
@@ -71,7 +72,7 @@ async function fireEmail(type: AlertType, message: string): Promise<void> {
     host: cfg.host,
     port: cfg.port ?? 587,
     secure: cfg.tls ?? true,
-    auth: cfg.username ? { user: cfg.username, pass: cfg.password ?? '' } : undefined,
+    auth: cfg.username ? { user: cfg.username, pass: cfg.password ? decryptField(cfg.password) : '' } : undefined,
   })
 
   await transporter.sendMail({

--- a/packages/db/migrations/0032_encrypt_smtp_password.sql
+++ b/packages/db/migrations/0032_encrypt_smtp_password.sql
@@ -1,0 +1,1 @@
+UPDATE smtp_config SET password = NULL;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1745971200001,
       "tag": "0031_job_schedule_windows",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "6",
+      "when": 1746057601000,
+      "tag": "0032_encrypt_smtp_password",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `saveSmtpConfig` now encrypts the submitted password with `encryptField` before writing to `smtp_config.password`
- Empty password submission (masked field left blank) preserves the existing encrypted value rather than overwriting with null
- `fireEmail` decrypts `cfg.password` with `decryptField` before passing to nodemailer
- Migration 0032 NULLs any existing plaintext passwords so they are re-entered encrypted on next save

## Test plan
- [ ] Save SMTP config with a password → verify `sqlite3` shows `enc:v1:` prefix in `smtp_config.password`
- [ ] Save SMTP config again leaving password blank → verify stored value is unchanged
- [ ] Trigger an alert → verify email delivery still works (nodemailer receives decrypted password)
- [ ] Typecheck passes: `pnpm --filter @backupos/web typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)