### PR TITLE
fix(api-tokens): newly created token appears in list without page refresh (#100)

### DIFF
--- a/apps/web/app/(dashboard)/settings/api-tokens/client.tsx
+++ b/apps/web/app/(dashboard)/settings/api-tokens/client.tsx
@@ -23,9 +23,21 @@ export function ApiTokensClient({ initial }: { initial: Token[] }) {
     setError('')
     setNewToken(null)
     const fd = new FormData(e.currentTarget)
+    const name = String(fd.get('name') ?? '').trim()
+    const expiresStr = fd.get('expires') as string | null
     const result = await createApiToken(fd)
     if (result.error) { setError(result.error); return }
-    if (result.token) setNewToken(result.token)
+    if (result.token && result.id) {
+      setNewToken(result.token)
+      setTokens(prev => [...prev, {
+        id:          result.id!,
+        name,
+        tokenPrefix: result.token!.slice(0, 12),
+        lastUsedAt:  null,
+        expiresAt:   expiresStr ? new Date(expiresStr) : null,
+        createdAt:   new Date(),
+      }])
+    }
     ;(e.target as HTMLFormElement).reset()
   }
 

--- a/apps/web/app/actions/api-tokens.ts
+++ b/apps/web/app/actions/api-tokens.ts
@@ -5,7 +5,7 @@ import { randomBytes, createHash } from 'crypto'
 import { getDb, apiTokens, eq } from '@backupos/db'
 import { headers } from 'next/headers'
 
-export async function createApiToken(formData: FormData): Promise<{ token?: string; error?: string }> {
+export async function createApiToken(formData: FormData): Promise<{ token?: string; id?: string; error?: string }> {
   const { auth } = await import('@/lib/auth')
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session) return { error: 'Not authenticated' }
@@ -21,8 +21,9 @@ export async function createApiToken(formData: FormData): Promise<{ token?: stri
   const expiresStr = formData.get('expires') as string | null
   const expiresAt = expiresStr ? new Date(expiresStr) : null
 
+  const id = randomBytes(8).toString('hex')
   await db.insert(apiTokens).values({
-    id:          randomBytes(8).toString('hex'),
+    id,
     userId:      session.user.id,
     name,
     tokenHash:   hash,
@@ -32,7 +33,7 @@ export async function createApiToken(formData: FormData): Promise<{ token?: stri
   })
 
   revalidatePath('/settings/api-tokens')
-  return { token: raw }
+  return { token: raw, id }
 }
 
 export async function revokeApiToken(id: string) {


### PR DESCRIPTION
## Summary
- **Problem:** After generating an API token, the active tokens list stayed stale until the user manually refreshed the page. The token was correctly inserted in the DB and `revalidatePath` was already called, but the client component holds `tokens` in local React state initialised once from `initial` props — RSC revalidation alone does not update already-mounted state.
- **Root cause:** Case B — local state not updated after creation.
- **Fix:**
  - `createApiToken` now returns `id` alongside `token` so the client has everything needed to construct the new list row
  - `handleCreate` in `ApiTokensClient` appends the new token to `tokens` state immediately on success (name from form, prefix from `result.token.slice(0,12)`, dates derived locally), so the row appears without any navigation or refresh

Closes #100

## Test plan
- [ ] Create a token → new row appears in "Active tokens" list instantly, no refresh needed
- [ ] The once-shown plaintext banner still appears above the list unchanged
- [ ] Dismiss the banner (or navigate away and back) → the token row remains in the list
- [ ] Revoking a token still removes it from the list immediately
- [ ] `pnpm --filter @backupos/web typecheck` passes
- [ ] `pnpm --filter @backupos/web build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)