### PR TITLE
feat(users): add 'Create user' option alongside Invite user (#95)

### DIFF
--- a/apps/web/app/(dashboard)/settings/users/client.tsx
+++ b/apps/web/app/(dashboard)/settings/users/client.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import { createInvite, revokeInvite, resendInviteEmail } from '@/app/actions/invite'
+import { createInvite, revokeInvite, resendInviteEmail, createUserDirect } from '@/app/actions/invite'
 
 interface UserRow {
   id:        string
@@ -32,7 +32,8 @@ function fmt(ms: number) {
   return new Date(ms).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
 }
 
-export function UsersClient({ users, invites: initialInvites, baseUrl, smtpConfigured, currentUserId }: Props) {
+export function UsersClient({ users: initialUsers, invites: initialInvites, baseUrl, smtpConfigured, currentUserId }: Props) {
+  const [users,    setUsers]    = useState(initialUsers)
   const [invites,  setInvites]  = useState(initialInvites)
   const [newLink,  setNewLink]  = useState<string | null>(null)
   const [copied,   setCopied]   = useState(false)
@@ -40,6 +41,12 @@ export function UsersClient({ users, invites: initialInvites, baseUrl, smtpConfi
   const [showForm, setShowForm] = useState(false)
   const [resentId, setResentId] = useState<string | null>(null)
   const [pending, startTransition] = useTransition()
+
+  // Create user directly
+  const [showCreateForm, setShowCreateForm] = useState(false)
+  const [createError,    setCreateError]    = useState('')
+  const [createdResult,  setCreatedResult]  = useState<{ name: string; email: string; tempPassword?: string } | null>(null)
+  const [createCopied,   setCreateCopied]   = useState(false)
 
   const pendingInvites = invites.filter(i => i.usedAt === null && i.expiresAt > Date.now())
 
@@ -64,6 +71,24 @@ export function UsersClient({ users, invites: initialInvites, baseUrl, smtpConfi
       expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
       usedAt:    null,
       createdAt: Date.now(),
+    }])
+  }
+
+  async function handleCreateUser(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setCreateError('')
+    setCreatedResult(null)
+    const fd     = new FormData(e.currentTarget)
+    const result = await createUserDirect(fd)
+    if (result.error) { setCreateError(result.error); return }
+    setCreatedResult({ name: result.name!, email: result.email!, tempPassword: result.tempPassword })
+    setShowCreateForm(false)
+    ;(e.target as HTMLFormElement).reset()
+    setUsers(prev => [...prev, {
+      id:        result.id!,
+      name:      result.name!,
+      email:     result.email!,
+      createdAt: result.createdAt!,
     }])
   }
 
@@ -109,9 +134,14 @@ export function UsersClient({ users, invites: initialInvites, baseUrl, smtpConfi
             {!smtpConfigured && <span style={{ color: 'var(--warn)' }}> · SMTP not configured — invites are link-only.</span>}
           </p>
         </div>
-        <button style={btnPrimary} onClick={() => setShowForm(f => !f)}>
-          {showForm ? 'Cancel' : 'Invite user'}
-        </button>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button style={btnGhost} onClick={() => { setShowCreateForm(f => !f); setShowForm(false) }}>
+            {showCreateForm ? 'Cancel' : 'Create user'}
+          </button>
+          <button style={btnPrimary} onClick={() => { setShowForm(f => !f); setShowCreateForm(false) }}>
+            {showForm ? 'Cancel' : 'Invite user'}
+          </button>
+        </div>
       </div>
 
       {/* Invite form */}
@@ -134,6 +164,59 @@ export function UsersClient({ users, invites: initialInvites, baseUrl, smtpConfi
               {smtpConfigured ? 'Send invite email + get link' : 'Create invite link'}
             </button>
           </form>
+        </div>
+      )}
+
+      {/* Create user form */}
+      {showCreateForm && (
+        <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)', padding: '20px 24px', marginBottom: 16 }}>
+          <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', marginBottom: 4 }}>Create user directly</div>
+          <div style={{ fontSize: 12, color: 'var(--fg-dim)', marginBottom: 16 }}>Account is created immediately with email verified. Leave password blank to auto-generate.</div>
+          <form onSubmit={handleCreateUser}>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 12 }}>
+              <div>
+                <label style={{ display: 'block', fontSize: 12, fontWeight: 500, color: 'var(--fg-mute)', marginBottom: 4 }}>Name *</label>
+                <input name="name" type="text" required placeholder="Jane Doe" style={inputStyle} />
+              </div>
+              <div>
+                <label style={{ display: 'block', fontSize: 12, fontWeight: 500, color: 'var(--fg-mute)', marginBottom: 4 }}>Email *</label>
+                <input name="email" type="email" required placeholder="jane@example.com" style={inputStyle} />
+              </div>
+            </div>
+            <div style={{ marginBottom: 16 }}>
+              <label style={{ display: 'block', fontSize: 12, fontWeight: 500, color: 'var(--fg-mute)', marginBottom: 4 }}>Initial password (optional — auto-generated if blank)</label>
+              <input name="password" type="password" placeholder="Leave blank to auto-generate" style={inputStyle} />
+            </div>
+            {createError && <div style={{ fontSize: 13, color: 'var(--err)', marginBottom: 12 }}>{createError}</div>}
+            <button type="submit" style={btnPrimary} disabled={pending}>Create account</button>
+          </form>
+        </div>
+      )}
+
+      {/* Create user success banner */}
+      {createdResult && (
+        <div style={{ backgroundColor: 'var(--ok-dim)', border: '1px solid color-mix(in srgb, var(--ok) 30%, transparent)', borderRadius: 'var(--radius-sm)', padding: '12px 16px', marginBottom: 16 }}>
+          <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--ok)', marginBottom: 6 }}>
+            Account created for {createdResult.name} ({createdResult.email})
+          </div>
+          {createdResult.tempPassword ? (
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--fg-dim)', marginBottom: 4 }}>Temporary password — share securely, shown once:</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: 13, color: 'var(--fg)', wordBreak: 'break-all', flex: 1 }}>{createdResult.tempPassword}</div>
+                <button style={btnGhost} onClick={() => {
+                  navigator.clipboard.writeText(createdResult.tempPassword!).then(() => {
+                    setCreateCopied(true)
+                    setTimeout(() => setCreateCopied(false), 2000)
+                  })
+                }}>
+                  {createCopied ? '✓ Copied' : 'Copy'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div style={{ fontSize: 12, color: 'var(--fg-dim)' }}>User can log in with the password you set.</div>
+          )}
         </div>
       )}
 

--- a/apps/web/app/actions/invite.ts
+++ b/apps/web/app/actions/invite.ts
@@ -1,10 +1,13 @@
 'use server'
 
-import { getDb, invite, user } from '@backupos/db'
-import { eq, and, isNull }    from '@backupos/db'
-import { auth }               from '@/lib/auth'
-import { getCurrentUser }     from '@/lib/user'
-import { sendInviteEmail }    from '@/lib/mailer'
+import { revalidatePath }           from 'next/cache'
+import { randomBytes }              from 'crypto'
+import { getDb, invite, user }      from '@backupos/db'
+import { eq, and, isNull }          from '@backupos/db'
+import { auth }                     from '@/lib/auth'
+import { getCurrentUser }           from '@/lib/user'
+import { sendInviteEmail }          from '@/lib/mailer'
+import { appendAuditEntry }         from '@/lib/audit'
 
 const BASE_URL = process.env['NEXT_PUBLIC_BASE_URL'] ?? 'http://localhost:3000'
 
@@ -112,6 +115,61 @@ export async function resendInviteEmail(id: string): Promise<{ error?: string }>
   const link = `${BASE_URL}/signup?token=${row.token}`
   await sendInviteEmail({ to: row.email, inviterName: currentUser.name, link })
   return {}
+}
+
+// Creates a user account directly (no invite flow). Admin-only.
+// If no password provided, one is auto-generated and returned once.
+export async function createUserDirect(formData: FormData): Promise<{
+  id?: string; name?: string; email?: string; createdAt?: number
+  tempPassword?: string; error?: string
+}> {
+  const currentUser = await getCurrentUser()
+  if (!currentUser) return { error: 'Not authenticated' }
+
+  const name  = (formData.get('name')  as string | null)?.trim() || ''
+  const email = (formData.get('email') as string | null)?.trim() || ''
+  const rawPw = (formData.get('password') as string | null)?.trim() || null
+
+  if (!name)  return { error: 'Name is required' }
+  if (!email) return { error: 'Email is required' }
+
+  const password     = rawPw ?? randomBytes(12).toString('base64url')
+  const isAutoGenPw  = rawPw === null
+
+  try {
+    await auth.api.signUpEmail({ body: { email, name, password } })
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'Could not create account' }
+  }
+
+  const db  = getDb()
+  const now = new Date()
+
+  await db.update(user).set({ emailVerified: true, updatedAt: now }).where(eq(user.email, email))
+
+  const [created] = await db
+    .select({ id: user.id, name: user.name, email: user.email, createdAt: user.createdAt })
+    .from(user).where(eq(user.email, email)).limit(1).all()
+
+  if (!created) return { error: 'User created but could not be retrieved' }
+
+  appendAuditEntry({
+    action:       'user.created',
+    resourceType: 'user',
+    resourceId:   created.id,
+    resourceName: created.email,
+    actor:        currentUser.email,
+    detail:       { createdBy: currentUser.id, direct: true },
+  })
+
+  revalidatePath('/settings/users')
+  return {
+    id:          created.id,
+    name:        created.name,
+    email:       created.email,
+    createdAt:   created.createdAt?.getTime() ?? Date.now(),
+    tempPassword: isAutoGenPw ? password : undefined,
+  }
 }
 
 // Used server-side by the signup page to validate + prefill the invite form.

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -13,6 +13,7 @@ export type AuditAction =
   | 'escrow.accessed'
   | 'api_token.created' | 'api_token.revoked'
   | 'settings.updated'
+  | 'user.created'
 
 function canonical(fields: {
   action: string; resourceType: string; resourceId?: string | null;


### PR DESCRIPTION
## Summary
- **Problem:** `/settings/users` was invite-only — no way for an admin to directly provision an account with name + email + password, which is essential for homelab/self-hosted setups and bulk migrations.
- **What was added:**
  - `createUserDirect` server action in `app/actions/invite.ts` — calls `auth.api.signUpEmail`, then sets `emailVerified: true` directly in the DB (bypassing the email verification flow), appends a `user.created` audit entry, and `revalidatePath`s the users page
  - If no password is submitted, one is auto-generated (12 bytes, base64url) and returned once to the admin
  - `user.created` added to `AuditAction` union in `lib/audit.ts`
  - `UsersClient` updated: `users` prop moved into state so newly created accounts appear immediately; "Create user" button added alongside "Invite user" (mutually exclusive forms); success banner shows the temp password one-time if auto-generated

## Test plan
- [ ] Click "Create user" → form opens; "Invite user" form closes
- [ ] Submit with name + email + no password → account created, temp password shown in banner, new row in Active users list
- [ ] Submit with name + email + password → account created, banner says "User can log in with the password you set", row appears
- [ ] New user can log in immediately with that password
- [ ] Audit log at `/audit` shows a `user.created` entry
- [ ] `pnpm --filter @backupos/web typecheck` passes
- [ ] `pnpm --filter @backupos/web build` succeeds

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)