### PR TITLE
fix(users): admin gate on user-creation actions (#125)

### DIFF
--- a/apps/web/app/actions/invite.ts
+++ b/apps/web/app/actions/invite.ts
@@ -18,6 +18,7 @@ export async function createInvite(
 ): Promise<{ id?: string; link?: string; error?: string }> {
   const currentUser = await getCurrentUser()
   if (!currentUser) return { error: 'Not authenticated' }
+  if (currentUser.role !== 'admin') return { error: 'Admin role required to invite users' }
 
   const email = (formData.get('email') as string | null)?.trim()
   const name  = (formData.get('name')  as string | null)?.trim() || null
@@ -125,6 +126,7 @@ export async function createUserDirect(formData: FormData): Promise<{
 }> {
   const currentUser = await getCurrentUser()
   if (!currentUser) return { error: 'Not authenticated' }
+  if (currentUser.role !== 'admin') return { error: 'Admin role required to create users' }
 
   const name  = (formData.get('name')  as string | null)?.trim() || ''
   const email = (formData.get('email') as string | null)?.trim() || ''

--- a/apps/web/lib/user.ts
+++ b/apps/web/lib/user.ts
@@ -1,7 +1,15 @@
-import { headers } from 'next/headers'
-import { auth }    from './auth'
+import { headers }                   from 'next/headers'
+import { auth }                      from './auth'
+import { getDb, user as userTable }  from '@backupos/db'
+import { eq }                        from '@backupos/db'
 
-export async function getCurrentUser() {
+export type AuthUser = typeof auth.$Infer.Session.user & { role: string }
+
+export async function getCurrentUser(): Promise<AuthUser | null> {
   const session = await auth.api.getSession({ headers: await headers() })
-  return session?.user ?? null
+  if (!session?.user) return null
+
+  const db    = getDb()
+  const [row] = await db.select({ role: userTable.role }).from(userTable).where(eq(userTable.id, session.user.id)).limit(1).all()
+  return { ...session.user, role: row?.role ?? 'admin' }
 }

--- a/packages/db/migrations/0033_add_user_role.sql
+++ b/packages/db/migrations/0033_add_user_role.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN role TEXT NOT NULL DEFAULT 'admin';

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1746057601000,
       "tag": "0032_encrypt_smtp_password",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1746144000000,
+      "tag": "0033_add_user_role",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -486,6 +486,7 @@ export const user = sqliteTable('user', {
   notifyWeekly:    integer('notify_weekly',     { mode: 'boolean' }).notNull().default(true),
   notifyUpdates:   integer('notify_updates',    { mode: 'boolean' }).notNull().default(false),
   twoFactorEnabled: integer('two_factor_enabled', { mode: 'boolean' }).notNull().default(false),
+  role:             text('role').notNull().default('admin'),
 })
 
 export const session = sqliteTable('session', {


### PR DESCRIPTION
## Summary
- **Problem:** `createUserDirect` (added in PR #124) and `createInvite` had no role check. Once RBAC (#96) ships and non-admin roles exist, any authenticated user could escalate privilege by creating a new admin account via these actions.
- **Schema change:** Added `role TEXT NOT NULL DEFAULT 'admin'` column to the `user` table (migration `0033_add_user_role.sql`). All existing users automatically get `role = 'admin'` — this PR is non-breaking.
- **`getCurrentUser` updated** (`apps/web/lib/user.ts`): now fetches the `role` column from the DB alongside the session and returns it in the user object. The `AuthUser` type is exported for use in typed callers.
- **Actions gated:** Both `createInvite` and `createUserDirect` in `apps/web/app/actions/invite.ts` now return `{ error: 'Admin role required…' }` if `currentUser.role !== 'admin'`.
- **Forward-compatible with #96:** The `role` column is the foundation the RBAC issue will build on. No RBAC architecture changes are made here — that belongs in #96.

## Test plan
- [ ] Existing admin user can still create invites and direct-create users
- [ ] Once #96 ships and a non-admin user exists, calling either action returns the role error
- [ ] All existing users have `role = 'admin'` after migration (`SELECT id, role FROM user`)
- [ ] `pnpm --filter @backupos/web typecheck` passes
- [ ] `pnpm --filter @backupos/web build` succeeds

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)