### PR TITLE
fix(profile): remove duplicate upload button and decorative fields

### DIFF
--- a/apps/web/app/(dashboard)/settings/profile/avatar-upload.tsx
+++ b/apps/web/app/(dashboard)/settings/profile/avatar-upload.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useRef } from 'react'
+import { Avatar } from '@/components/avatar'
+
+interface Props {
+  src:          string | null
+  name:         string
+  uploadAction: (fd: FormData) => Promise<void>
+  removeAction: () => Promise<void>
+}
+
+const btnStyle: React.CSSProperties = {
+  padding: '6px 12px', borderRadius: 'var(--radius-sm)',
+  border: '1px solid var(--border)', fontSize: 13, cursor: 'pointer',
+  color: 'var(--fg)', backgroundColor: 'var(--surf2)',
+}
+
+export function AvatarUpload({ src, name, uploadAction, removeAction }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const formRef  = useRef<HTMLFormElement>(null)
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
+      <Avatar src={src} name={name} size={80} />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <form ref={formRef} action={uploadAction}>
+          <input
+            ref={inputRef}
+            name="avatar"
+            type="file"
+            accept=".jpg,.jpeg,.png,.webp"
+            style={{ display: 'none' }}
+            onChange={() => formRef.current?.requestSubmit()}
+          />
+          <button type="button" style={btnStyle} onClick={() => inputRef.current?.click()}>
+            Upload image
+          </button>
+        </form>
+        <form action={removeAction}>
+          <button type="submit" style={{ ...btnStyle, color: 'var(--fg-mute)', backgroundColor: 'transparent' }}>
+            Remove
+          </button>
+        </form>
+        <p style={{ fontSize: 12, color: 'var(--fg-dim)' }}>Self-hosted: stored locally. Max 1 MB, JPG/PNG/WebP.</p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/profile/page.tsx
+++ b/apps/web/app/(dashboard)/settings/profile/page.tsx
@@ -2,7 +2,7 @@ import { redirect }       from 'next/navigation'
 import { getCurrentUser } from '@/lib/user'
 import { getDb, user }    from '@backupos/db'
 import { eq }             from '@backupos/db'
-import { Avatar }         from '@/components/avatar'
+import { AvatarUpload }   from './avatar-upload'
 import { updateProfile, uploadAvatar, removeAvatar } from '@/app/actions/user'
 
 async function handleUpdateProfile(formData: FormData): Promise<void> {
@@ -23,11 +23,6 @@ async function handleRemoveAvatar(): Promise<void> {
   redirect('/settings/profile?saved=1')
 }
 
-const TIMEZONES = [
-  'UTC', 'Africa/Johannesburg', 'America/New_York', 'America/Chicago',
-  'America/Denver', 'America/Los_Angeles', 'Europe/London',
-  'Europe/Berlin', 'Asia/Tokyo', 'Australia/Sydney',
-]
 
 export default async function ProfilePage({ searchParams }: { searchParams: Promise<{ saved?: string }> }) {
   const me = await getCurrentUser()
@@ -51,38 +46,7 @@ export default async function ProfilePage({ searchParams }: { searchParams: Prom
       {/* Avatar section */}
       <section style={{ marginBottom: 32 }}>
         <h2 style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', marginBottom: 16 }}>Avatar</h2>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
-          <Avatar src={profile.image} name={profile.name} size={80} />
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <form action={handleUploadAvatar}>
-              <label style={{
-                display: 'inline-flex', alignItems: 'center', gap: 6,
-                padding: '6px 12px', borderRadius: 'var(--radius-sm)',
-                border: '1px solid var(--border)', fontSize: 13, cursor: 'pointer',
-                color: 'var(--fg)', backgroundColor: 'var(--surf2)',
-              }}>
-                Upload image
-                <input
-                  name="avatar" type="file" accept=".jpg,.jpeg,.png,.webp"
-                  style={{ display: 'none' }}
-                />
-              </label>
-              <button type="submit" style={{
-                marginTop: 6, padding: '6px 12px', borderRadius: 'var(--radius-sm)',
-                border: '1px solid var(--border)', fontSize: 13, cursor: 'pointer',
-                color: 'var(--fg)', backgroundColor: 'var(--surf2)', display: 'block',
-              }}>Upload</button>
-            </form>
-            <form action={handleRemoveAvatar}>
-              <button type="submit" style={{
-                padding: '6px 12px', borderRadius: 'var(--radius-sm)',
-                border: '1px solid var(--border)', fontSize: 13, cursor: 'pointer',
-                color: 'var(--fg-mute)', backgroundColor: 'transparent',
-              }}>Remove</button>
-            </form>
-            <p style={{ fontSize: 12, color: 'var(--fg-dim)' }}>Self-hosted: stored locally. Max 1 MB, JPG/PNG/WebP.</p>
-          </div>
-        </div>
+        <AvatarUpload src={profile.image} name={profile.name} uploadAction={handleUploadAvatar} removeAction={handleRemoveAvatar} />
       </section>
 
       <div style={{ borderTop: '1px solid var(--border)', marginBottom: 32 }} />
@@ -94,7 +58,6 @@ export default async function ProfilePage({ searchParams }: { searchParams: Prom
           {([
             { name: 'name',        label: 'Full name',    type: 'text', required: true,  value: profile.name },
             { name: 'displayName', label: 'Display name', type: 'text', required: false, value: profile.displayName ?? '' },
-            { name: 'phone',       label: 'Phone number', type: 'tel',  required: false, value: profile.phone ?? '' },
           ] as const).map(f => (
             <div key={f.name}>
               <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6 }}>
@@ -123,33 +86,10 @@ export default async function ProfilePage({ searchParams }: { searchParams: Prom
             />
           </div>
 
-          <div>
-            <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6 }}>Timezone</label>
-            <select name="timezone" defaultValue={profile.timezone} style={{
-              width: '100%', padding: '8px 12px', boxSizing: 'border-box',
-              backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
-              borderRadius: 'var(--radius-sm)', color: 'var(--fg)', fontSize: 14,
-            }}>
-              {TIMEZONES.map(tz => <option key={tz} value={tz}>{tz}</option>)}
-            </select>
-          </div>
-
-          <div>
-            <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6 }}>Language</label>
-            <select name="language" defaultValue={profile.language} style={{
-              width: '100%', padding: '8px 12px', boxSizing: 'border-box',
-              backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
-              borderRadius: 'var(--radius-sm)', color: 'var(--fg)', fontSize: 14,
-            }}>
-              <option value="en">English</option>
-            </select>
-          </div>
-
           <div style={{ borderTop: '1px solid var(--border)', paddingTop: 16 }}>
             <h2 style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', marginBottom: 16 }}>Contact preferences</h2>
             {([
               { name: 'emailNotify',   label: 'Email notifications (master toggle)', checked: profile.emailNotify },
-              { name: 'smsNotify',     label: 'SMS notifications (requires verified phone)', checked: profile.smsNotify },
               { name: 'notifyAlerts',  label: 'Alerts',          checked: profile.notifyAlerts },
               { name: 'notifyWeekly',  label: 'Weekly summary',  checked: profile.notifyWeekly },
               { name: 'notifyUpdates', label: 'Product updates', checked: profile.notifyUpdates },

--- a/apps/web/app/actions/user.ts
+++ b/apps/web/app/actions/user.ts
@@ -15,11 +15,7 @@ export async function updateProfile(formData: FormData): Promise<{ error?: strin
 
   const name          = ((formData.get('name')        ?? '') as string).trim()
   const displayName   = ((formData.get('displayName') ?? '') as string).trim()
-  const phone         = ((formData.get('phone')       ?? '') as string).trim()
-  const timezone      = ((formData.get('timezone')    ?? 'UTC') as string).trim()
-  const language      = ((formData.get('language')    ?? 'en') as string).trim()
   const emailNotify   = formData.get('emailNotify')   === 'on'
-  const smsNotify     = formData.get('smsNotify')     === 'on'
   const notifyAlerts  = formData.get('notifyAlerts')  === 'on'
   const notifyWeekly  = formData.get('notifyWeekly')  === 'on'
   const notifyUpdates = formData.get('notifyUpdates') === 'on'
@@ -30,11 +26,7 @@ export async function updateProfile(formData: FormData): Promise<{ error?: strin
   await db.update(user).set({
     name,
     displayName:  displayName  || null,
-    phone:        phone        || null,
-    timezone,
-    language,
     emailNotify,
-    smsNotify,
     notifyAlerts,
     notifyWeekly,
     notifyUpdates,


### PR DESCRIPTION
## Summary
- Replace duplicate avatar upload (styled label + explicit Upload button) with `AvatarUpload` client component — single button, auto-submits on file selection
- Remove timezone, language, phone, and smsNotify fields from the profile form and `updateProfile` server action (no backend support for these yet)
- Remove unused `TIMEZONES` constant and `Avatar` direct import from the page

## Test plan
- [ ] Visit `/settings/profile` — avatar section shows one "Upload image" button; picking a file uploads immediately with no second click
- [ ] "Remove" button still works
- [ ] Full name and display name fields save correctly
- [ ] Email notifications / Alerts / Weekly / Updates checkboxes save correctly
- [ ] No TypeScript errors (`pnpm --filter @backupos/web typecheck`)

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)