### PR TITLE
feat(smtp): configurable alert recipients (#86)

### DIFF
--- a/apps/web/app/(dashboard)/settings/smtp/page.tsx
+++ b/apps/web/app/(dashboard)/settings/smtp/page.tsx
@@ -32,6 +32,12 @@ export default async function SmtpSettingsPage({ searchParams }: { searchParams:
         </div>
       )}
 
+      {cfg?.enabled && !cfg?.toAddresses && (
+        <div style={{ padding: '10px 16px', marginBottom: 20, backgroundColor: 'var(--warn-dim)', border: '1px solid color-mix(in srgb, var(--warn) 30%, transparent)', borderRadius: 'var(--radius-sm)', fontSize: 13, color: 'var(--warn)' }}>
+          Alerts will not be delivered — no recipients configured. Add at least one address below.
+        </div>
+      )}
+
       <form action={saveSmtpConfig}>
         <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)', padding: '20px 24px', marginBottom: 16 }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20, paddingBottom: 16, borderBottom: '1px solid var(--border2)' }}>
@@ -75,6 +81,12 @@ export default async function SmtpSettingsPage({ searchParams }: { searchParams:
               <label style={labelStyle}>From email</label>
               <input name="fromEmail" type="email" defaultValue={cfg?.fromEmail ?? ''} placeholder="noreply@example.com" style={inputStyle} />
             </div>
+          </div>
+
+          <div style={fieldStyle}>
+            <label style={labelStyle}>Send alerts to</label>
+            <input name="toAddresses" type="text" defaultValue={cfg?.toAddresses ?? ''} placeholder="alice@example.com, bob@example.com" style={inputStyle} />
+            <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginTop: 4 }}>Comma-separated list of email addresses to receive alerts. Leave blank to disable alert delivery.</div>
           </div>
 
           <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>

--- a/apps/web/app/actions/settings.ts
+++ b/apps/web/app/actions/settings.ts
@@ -37,16 +37,25 @@ export async function saveSmtpConfig(formData: FormData) {
     password = encryptField(rawPassword)
   }
 
+  const rawTo = (formData.get('toAddresses') as string | null) ?? ''
+  const toAddresses = rawTo
+    .split(',')
+    .map(s => s.trim().toLowerCase())
+    .filter(Boolean)
+    .filter((v, i, a) => a.indexOf(v) === i)
+    .join(',') || null
+
   const values = {
-    host:      formData.get('host') as string | null,
-    port:      Number(formData.get('port') ?? 587),
-    username:  formData.get('username') as string | null,
+    host:        formData.get('host') as string | null,
+    port:        Number(formData.get('port') ?? 587),
+    username:    formData.get('username') as string | null,
     password,
-    fromName:  String(formData.get('fromName') ?? 'BackupOS'),
-    fromEmail: formData.get('fromEmail') as string | null,
-    tls:       formData.get('tls') === 'on',
-    enabled:   formData.get('enabled') === 'on',
-    updatedAt: new Date(),
+    fromName:    String(formData.get('fromName') ?? 'BackupOS'),
+    fromEmail:   formData.get('fromEmail') as string | null,
+    toAddresses,
+    tls:         formData.get('tls') === 'on',
+    enabled:     formData.get('enabled') === 'on',
+    updatedAt:   new Date(),
   }
   await db.insert(smtpConfig).values({ id: 'singleton', ...values })
     .onConflictDoUpdate({ target: smtpConfig.id, set: values })

--- a/apps/web/lib/alerts.ts
+++ b/apps/web/lib/alerts.ts
@@ -68,6 +68,14 @@ async function fireEmail(type: AlertType, message: string): Promise<void> {
   const [cfg] = await db.select().from(smtpConfig).where(eq(smtpConfig.id, 'singleton')).limit(1)
   if (!cfg?.enabled || !cfg.host || !cfg.fromEmail) return
 
+  const recipients = cfg.toAddresses
+    ? cfg.toAddresses.split(',').map(s => s.trim()).filter(Boolean)
+    : []
+  if (recipients.length === 0) {
+    console.warn('[alerts] SMTP is enabled but no recipients configured — skipping email delivery')
+    return
+  }
+
   const transporter = nodemailer.createTransport({
     host: cfg.host,
     port: cfg.port ?? 587,
@@ -77,7 +85,7 @@ async function fireEmail(type: AlertType, message: string): Promise<void> {
 
   await transporter.sendMail({
     from: `${cfg.fromName} <${cfg.fromEmail}>`,
-    to: cfg.fromEmail,
+    to:   recipients,
     subject: `[BackupOS] ${type.replace(/_/g, ' ')}`,
     text: message,
   })

--- a/packages/db/migrations/0034_smtp_recipients.sql
+++ b/packages/db/migrations/0034_smtp_recipients.sql
@@ -1,0 +1,1 @@
+ALTER TABLE smtp_config ADD COLUMN to_addresses TEXT;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1746144000000,
       "tag": "0033_add_user_role",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1746230400000,
+      "tag": "0034_smtp_recipients",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -556,9 +556,10 @@ export const smtpConfig = sqliteTable('smtp_config', {
   password:  text('password'),
   fromName:  text('from_name').notNull().default('BackupOS'),
   fromEmail: text('from_email'),
-  tls:       integer('tls',     { mode: 'boolean' }).default(true),
-  enabled:   integer('enabled', { mode: 'boolean' }).default(false),
-  updatedAt: integer('updated_at', { mode: 'timestamp_ms' }),
+  toAddresses: text('to_addresses'),
+  tls:         integer('tls',     { mode: 'boolean' }).default(true),
+  enabled:     integer('enabled', { mode: 'boolean' }).default(false),
+  updatedAt:   integer('updated_at', { mode: 'timestamp_ms' }),
 })
 
 // ── API tokens ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
SMTP outbound was configurable (host, port, auth, from address) but there was no way to set who receives alert emails. `fireEmail` was falling back to `cfg.fromEmail` as the recipient — so alerts were sent to the sender address, which is useless for operator notification.

## Changes

**Schema** (`smtp_config.to_addresses TEXT`)
- New nullable column storing a comma-separated list of recipient addresses
- Migration: `0034_smtp_recipients.sql`

**`saveSmtpConfig`** (`apps/web/app/actions/settings.ts`)
- Reads `toAddresses` from form, trims/lowercases/deduplicates, stores as canonical comma-separated string or NULL if blank

**`fireEmail`** (`apps/web/lib/alerts.ts`)
- Reads `cfg.toAddresses`, splits into recipient array
- If no recipients configured: logs a warning and returns early — does not throw (alerts shouldn't crash if SMTP is misconfigured)
- If recipients present: passes array as `to` to nodemailer (multi-recipient support)

**UI** (`/settings/smtp`)
- New "Send alerts to" field with placeholder and help text: _"Comma-separated list of email addresses to receive alerts. Leave blank to disable alert delivery."_
- Warning banner shown when SMTP is enabled but recipients are empty: _"Alerts will not be delivered — no recipients configured."_

## Test plan
- [ ] Save SMTP config with `alice@example.com, BOB@EXAMPLE.COM` — DB should show `alice@example.com,bob@example.com` (lowercased, deduped, no spaces)
- [ ] Save with blank recipients — DB shows NULL; warning banner appears on page reload
- [ ] Save with valid recipients — no warning banner
- [ ] TypeScript: `pnpm --filter @backupos/web typecheck` passes

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)