### PR TITLE
feat(smtp): test button to verify configuration (#88)

### DIFF
--- a/apps/web/app/(dashboard)/settings/smtp/page.tsx
+++ b/apps/web/app/(dashboard)/settings/smtp/page.tsx
@@ -1,7 +1,8 @@
 import { redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/user'
 import { getDb, smtpConfig } from '@backupos/db'
-import { saveSmtpConfig } from '@/app/actions/settings'
+import { saveSmtpConfig, testSmtpConnection } from '@/app/actions/settings'
+import { SmtpTestButton } from './test-button'
 
 export default async function SmtpSettingsPage({ searchParams }: { searchParams: Promise<{ saved?: string }> }) {
   const user = await getCurrentUser()
@@ -95,9 +96,16 @@ export default async function SmtpSettingsPage({ searchParams }: { searchParams:
           </label>
         </div>
 
-        <button type="submit" style={{ padding: '8px 20px', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)', border: 'none', borderRadius: 'var(--radius-sm)', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
-          Save changes
-        </button>
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, flexWrap: 'wrap' }}>
+          <button type="submit" style={{ padding: '8px 20px', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)', border: 'none', borderRadius: 'var(--radius-sm)', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
+            Save changes
+          </button>
+          <SmtpTestButton
+            testAction={testSmtpConnection}
+            disabled={!(cfg?.enabled && cfg?.host && cfg?.fromEmail && cfg?.toAddresses)}
+            disabledReason={!cfg?.enabled ? 'SMTP is not enabled' : !cfg?.toAddresses ? 'No recipients configured' : 'SMTP not fully configured'}
+          />
+        </div>
       </form>
     </div>
   )

--- a/apps/web/app/(dashboard)/settings/smtp/test-button.tsx
+++ b/apps/web/app/(dashboard)/settings/smtp/test-button.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+
+interface Props {
+  testAction: () => Promise<{ ok: boolean; error?: string; deliveredTo?: string[] }>
+  disabled:   boolean
+  disabledReason?: string
+}
+
+export function SmtpTestButton({ testAction, disabled, disabledReason }: Props) {
+  const [pending, startTransition] = useTransition()
+  const [result, setResult] = useState<{ ok: boolean; error?: string; deliveredTo?: string[] } | null>(null)
+
+  function handleClick() {
+    setResult(null)
+    startTransition(async () => {
+      const res = await testAction()
+      setResult(res)
+    })
+  }
+
+  return (
+    <div style={{ display: 'inline-flex', flexDirection: 'column', gap: 6 }}>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled || pending}
+        title={disabled ? disabledReason : undefined}
+        style={{
+          padding: '8px 20px', border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-sm)', fontSize: 13, fontWeight: 600,
+          cursor: disabled || pending ? 'not-allowed' : 'pointer',
+          color: 'var(--fg)', backgroundColor: 'var(--surf2)',
+          opacity: disabled ? 0.5 : 1,
+        }}
+      >
+        {pending ? 'Sending…' : 'Send test email'}
+      </button>
+
+      {result && (
+        <div style={{
+          fontSize: 12, padding: '4px 8px', borderRadius: 'var(--radius-sm)',
+          color:            result.ok ? 'var(--ok)'   : 'var(--err)',
+          backgroundColor:  result.ok ? 'var(--ok-dim)' : 'var(--err-dim)',
+          border: `1px solid color-mix(in srgb, ${result.ok ? 'var(--ok)' : 'var(--err)'} 30%, transparent)`,
+        }}>
+          {result.ok
+            ? `Test email sent to ${result.deliveredTo!.join(', ')}`
+            : `SMTP test failed: ${result.error}`}
+        </div>
+      )}
+
+      <div style={{ fontSize: 11, color: 'var(--fg-dim)' }}>
+        Sends a test email using the saved configuration. Save changes first if you&apos;ve edited fields above.
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/actions/settings.ts
+++ b/apps/web/app/actions/settings.ts
@@ -1,8 +1,9 @@
 'use server'
 
 import { redirect } from 'next/navigation'
+import nodemailer from 'nodemailer'
 import { getDb, instanceSettings, smtpConfig, backupDefaults } from '@backupos/db'
-import { encryptField } from '@/lib/repo-crypto'
+import { encryptField, decryptField } from '@/lib/repo-crypto'
 
 export async function saveInstanceSettings(formData: FormData) {
   const db = getDb()
@@ -78,4 +79,41 @@ export async function saveBackupDefaults(formData: FormData) {
     .onConflictDoUpdate({ target: backupDefaults.id, set: values })
   const page = formData.get('_page') as string | null
   redirect(page === 'schedule' ? '/settings/schedule-windows?saved=1' : '/settings/retention?saved=1')
+}
+
+export async function testSmtpConnection(): Promise<{ ok: boolean; error?: string; deliveredTo?: string[] }> {
+  const db = getDb()
+  const [cfg] = await db.select().from(smtpConfig).limit(1).all()
+
+  if (!cfg?.enabled || !cfg.host || !cfg.fromEmail) {
+    return { ok: false, error: 'SMTP not configured' }
+  }
+
+  const recipients = cfg.toAddresses
+    ? cfg.toAddresses.split(',').map(s => s.trim()).filter(Boolean)
+    : []
+  if (recipients.length === 0) {
+    return { ok: false, error: 'No recipients configured — add recipients before testing' }
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      host:   cfg.host,
+      port:   cfg.port ?? 587,
+      secure: cfg.tls ?? true,
+      auth:   cfg.username ? { user: cfg.username, pass: cfg.password ? decryptField(cfg.password) : '' } : undefined,
+    })
+
+    await transporter.sendMail({
+      from:    `${cfg.fromName} <${cfg.fromEmail}>`,
+      to:      recipients,
+      subject: '[BackupOS] Test email — SMTP configuration verified',
+      text:    `This is a test email from BackupOS confirming your SMTP configuration is working correctly.\n\nSent at ${new Date().toISOString()}.`,
+    })
+
+    return { ok: true, deliveredTo: recipients }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: message }
+  }
 }


### PR DESCRIPTION
## Problem
The SMTP settings page had no way to verify configuration without waiting for a real alert to fire. Users saved config and discovered delivery failures too late.

## Changes

**New `testSmtpConnection` action** (`apps/web/app/actions/settings.ts`)
- Reads the saved `smtp_config` singleton from DB
- Returns `{ ok: false, error }` if SMTP is not enabled, host/fromEmail missing, or no recipients configured
- Builds a nodemailer transporter using the same decryption pattern as `fireEmail`
- Sends a test email with subject `[BackupOS] Test email — SMTP configuration verified`
- On success: returns `{ ok: true, deliveredTo: string[] }`
- On error: catches and returns the nodemailer error message (no credentials or host details leaked to client)

**New `SmtpTestButton` client component** (`apps/web/app/(dashboard)/settings/smtp/test-button.tsx`)
- "Send test email" button — secondary style (outline, not primary)
- Disabled when SMTP is not fully configured (not enabled, no host, no recipients) — tooltip explains why
- Shows "Sending…" during the async call
- On success: inline green banner — `Test email sent to alice@example.com, bob@example.com`
- On error: inline red banner — `SMTP test failed: <nodemailer message>`
- Help text below button: _"Sends a test email using the saved configuration. Save changes first if you've edited fields above."_

**Updated `/settings/smtp` page** — button rendered alongside "Save changes"

## Test plan
- [ ] With SMTP disabled: button is visually disabled
- [ ] With no recipients: button is disabled
- [ ] With valid config: clicking sends email, success banner appears
- [ ] With bad credentials: clicking shows error banner with nodemailer message
- [ ] TypeScript: `pnpm --filter @backupos/web typecheck` passes

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)