### PR TITLE
fix(db): seed logging_config singleton row (#132)

### DIFF
--- a/packages/db/migrations/0036_seed_logging_config.sql
+++ b/packages/db/migrations/0036_seed_logging_config.sql
@@ -1,0 +1,3 @@
+INSERT INTO logging_config (id, activity_retention, audit_retention, ops_retention)
+VALUES ('singleton', '90d', '365d', '14d')
+ON CONFLICT(id) DO NOTHING;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1746748800000,
       "tag": "0035_logging_retention_sweep",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "6",
+      "when": 1746835200000,
+      "tag": "0036_seed_logging_config",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Without a seeded default row, `pruneRetainedLogs` (introduced in #130 for #105) exits early on every tick because it reads `logging_config` directly and finds no row. The action layer has in-code fallback defaults for the settings UI, but the sweep does not — so retention was silently inactive on all fresh installs until a user saved the logging settings form at least once.

This migration seeds the singleton row with the same defaults used by the action fallback (`90d` / `365d` / `14d`). `ON CONFLICT(id) DO NOTHING` ensures existing installs that already have the row are unaffected.

Matches the pattern from `0030_seed_backup_defaults.sql` (#101).

Closes #132

## Test plan

- [ ] Fresh install: confirm `logging_config` has a row after migrations run
- [ ] Existing install with row already present: confirm `ON CONFLICT DO NOTHING` leaves it unchanged
- [ ] Retention sweep at 03:00 UTC correctly prunes data on first run after deploy (no early-exit warning in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)