### PR TITLE
fix(verification): pre-mount NFS repo before agent dispatch (#75 follow-up)

### DIFF
--- a/apps/web/app/actions/verification.ts
+++ b/apps/web/app/actions/verification.ts
@@ -6,6 +6,7 @@ import { getDb, verificationTests, verificationRuns, backupRuns, backupJobs, rep
 import { decryptField } from '@/lib/repo-crypto'
 import { dispatchToAgent } from '@/lib/internal-dispatch'
 import { connectedAgentIds } from '@/lib/ws-state'
+import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 
 export async function createVerificationTest(data: {
   name: string
@@ -77,9 +78,26 @@ export async function runVerification(testId: string): Promise<void> {
     .set({ lastRunAt: now })
     .where(eq(verificationTests.id, testId))
 
+  try {
+    await ensureRepoMountedOnAgent(agentId, job.repositoryId)
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    await db.update(verificationRuns).set({
+      status:       'failed',
+      completedAt:  new Date(),
+      errorMessage: `NFS mount failed: ${errorMessage}`,
+    }).where(eq(verificationRuns.id, runId))
+    await db.update(verificationTests)
+      .set({ lastResult: 'failed' })
+      .where(eq(verificationTests.id, testId))
+    revalidatePath(`/verification/${testId}`)
+    return
+  }
+
   const result = await dispatchToAgent(agentId, {
     type:              'run_verification',
     verificationRunId: runId,
+    repoId:            job.repositoryId,
     snapshotId:        latestRun.snapshotId,
     repoUrl,
     repoPassword,

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -169,4 +169,4 @@ export type ServerMessage =
   | { type: 'run_compose_backup'; jobId: string; runId: string; config: ComposeProjectConfig; repoId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; bandwidthLimitKbps?: number | null }
   | { type: 'run_compose_restore'; jobId: string; runId: string; repoId: string; config: ComposeRestoreConfig; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
   | { type: 'mount_repository'; requestId: string; repoId: string; nfsServer: string; nfsExport: string; nfsOptions: string }
-  | { type: 'run_verification'; verificationRunId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory'; validationHook?: string | null }
+  | { type: 'run_verification'; verificationRunId: string; repoId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory'; validationHook?: string | null }


### PR DESCRIPTION
## Problem

PR #135 introduced the V1 verification engine but dispatched `run_verification` without calling `ensureRepoMountedOnAgent` first. For NFS-backed restic repositories (where restic's repository URL is a path under `/mnt/backupos/<repo-id>/`), the mount doesn't exist inside the container agent until `mount_repository` is sent. The restore would fail immediately with a path-not-found error.

`run_backup` and `run_compose_backup` both call `ensureRepoMountedOnAgent` before dispatch — verification skipped this entirely.

The `run_verification` message also omitted `repoId`, making the protocol inconsistent with the other repo-bearing messages.

## Fix

- `packages/agent-protocol/src/index.ts` — adds `repoId: string` to the `run_verification` ServerMessage member (consistent with `run_compose_backup`, `run_compose_restore`)
- `apps/web/app/actions/verification.ts` — imports `ensureRepoMountedOnAgent`, calls it after inserting the `running` run row and before dispatching; on mount failure the run is marked `failed` with the error message and the action returns early
- `apps/web/public/agent/bundle.js` — rebuilt; agents auto-update on reconnect

Agent-side handler (`runVerification.ts`) is **unchanged** — the mount is established server-side via the existing `mount_repository` protocol before the agent ever receives `run_verification`.

## References

Closes follow-up to #75 (PR #135)