### PR TITLE
feat(logger): operational logger wiring — agent lifecycle, backup runs, scheduler events, verification (#74)

### DIFF
--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -8,6 +8,7 @@ import { dispatchToAgent } from '@/lib/internal-dispatch'
 import { validateCron } from '@/lib/cron-validate'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 import { isWithinWindow } from '@/lib/schedule-window'
+import { appendLog } from '@/lib/logger'
 
 function parseSourceConfig(sourceType: string, fd: FormData): string {
   const str = (k: string) => (fd.get(k) as string | null)?.trim() || undefined
@@ -340,7 +341,9 @@ export async function retryRun(jobId: string): Promise<void> {
     })
   }
 
-  if (!result.ok) {
+  if (result.ok) {
+    try { appendLog({ level: 'info', component: 'web', message: `Backup dispatched for job "${job.name}"`, entityType: 'job', entityId: jobId, payload: { trigger: 'manual', runId } }) } catch (err) { console.error('[logger]', err) }
+  } else {
     await db.update(backupRuns).set({
       status:       'failed',
       completedAt:  now,

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -8,6 +8,7 @@ import { ensureRepoMountedOnAgent } from './repo-mount'
 import { isWithinWindow } from './schedule-window'
 import type { ServerMessage, MountConfig, ComposeProjectConfig } from '@backupos/agent-protocol'
 import { pruneRetainedLogs } from './retention'
+import { appendLog } from './logger'
 
 interface SourceConfig {
   paths?:    string[]
@@ -197,6 +198,7 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
   // Reset nextRunAt so the trigger tick doesn't re-fire this job
   await stampNextRun(db, job.id, job.schedule)
   console.log(`[scheduler] Dispatched job "${job.name}" (${job.sourceType}) to agent ${job.agentId}`)
+  try { appendLog({ level: 'info', component: 'web', message: `Backup dispatched for job "${job.name}"`, entityType: 'job', entityId: job.id, payload: { trigger, runId } }) } catch (err) { console.error('[logger]', err) }
   return true
 }
 
@@ -362,6 +364,7 @@ async function checkMissedBackups(db: Db): Promise<void> {
       if (missed && !missedAlertSent.has(job.id)) {
         missedAlertSent.add(job.id)
         await sendAlert('backup_missed', { jobId: job.id, jobName: job.name })
+        try { appendLog({ level: 'warn', component: 'monitor', message: `Missed backup detected for job "${job.name}"`, entityType: 'job', entityId: job.id, payload: { expectedAt: prevExpected.toISOString(), lastRunAt: lastRun?.toISOString() ?? null } }) } catch (err) { console.error('[logger]', err) }
       } else if (!missed) {
         // Clear flag once the job has run successfully again
         missedAlertSent.delete(job.id)
@@ -392,6 +395,7 @@ async function checkAgents(db: Db): Promise<void> {
   for (const agent of stale) {
     await db.update(agents).set({ status: 'disconnected' }).where(eq(agents.id, agent.id))
     await sendAlert('agent_disconnected', { agentId: agent.id, agentName: agent.name })
+    try { appendLog({ level: 'warn', component: 'monitor', message: `Agent ${agent.hostname ?? agent.id} marked stale (no heartbeat)`, entityType: 'agent', entityId: agent.id }) } catch (err) { console.error('[logger]', err) }
   }
 
 }

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -14,6 +14,7 @@ import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTe
 import { loadOrCreateInternalToken } from './lib/internal-token'
 import { decryptField } from './lib/repo-crypto'
 import { sendAlert } from './lib/alerts'
+import { appendLog } from './lib/logger'
 import { auth } from './lib/auth'
 import type { AgentMessage, ServerMessage, MountConfig } from '@backupos/agent-protocol'
 
@@ -395,6 +396,7 @@ void app.prepare().then(() => {
           if (msg.bundleHash && BUNDLE_HASH && msg.bundleHash !== BUNDLE_HASH) {
             console.log(`[server] Agent ${agentId} bundle mismatch — sending force_update`)
             ws.send(JSON.stringify({ type: 'force_update' } satisfies ServerMessage))
+            try { appendLog({ level: 'info', component: 'agent', message: `Agent ${agentId} bundle mismatch — force update sent`, entityType: 'agent', entityId: agentId }) } catch (err) { console.error('[logger]', err) }
           }
 
           // Auto-detect capabilities on every connect so the UI is always up to date
@@ -414,6 +416,7 @@ void app.prepare().then(() => {
             resourceType: 'agent', resourceId: agentId,
             actor: agentId, createdAt: new Date(),
           })
+          try { appendLog({ level: 'info', component: 'agent', message: `Agent ${msg.hostname ?? agentId} connected`, entityType: 'agent', entityId: agentId, payload: { ip: msg.ip, agentVersion: msg.agentVersion, protocolVersion: msg.protocolVersion } }) } catch (err) { console.error('[logger]', err) }
 
         } else if (msg.type === 'ping') {
           if (agentId) {
@@ -476,6 +479,7 @@ void app.prepare().then(() => {
             totalSize:       msg.stats.totalBytesProcessed,
             duration:        msg.stats.durationMs,
           }).where(eq(backupRuns.id, run.id))
+          try { appendLog({ level: 'info', component: 'web', message: `Backup succeeded for job ${msg.jobId}`, entityType: 'job', entityId: msg.jobId, payload: { runId: run.id, snapshotId: msg.snapshotId, durationMs: msg.stats.durationMs, sizeBytes: msg.stats.totalBytesProcessed } }) } catch (err) { console.error('[logger]', err) }
 
           const [jobForNext] = await db.select({ schedule: backupJobs.schedule })
             .from(backupJobs).where(eq(backupJobs.id, msg.jobId)).limit(1)
@@ -559,6 +563,7 @@ void app.prepare().then(() => {
             log:          msg.log ?? null,
             errorMessage: msg.error, errorDetail: msg.detail,
           }).where(eq(backupRuns.id, run.id))
+          try { appendLog({ level: 'error', component: 'web', message: `Backup failed for job ${msg.jobId}: ${msg.error}`, entityType: 'job', entityId: msg.jobId, payload: { runId: run.id, errorMessage: msg.error } }) } catch (err) { console.error('[logger]', err) }
 
           await db.update(backupJobs).set({ lastRunAt: new Date(), lastRunStatus: 'failed' })
             .where(eq(backupJobs.id, msg.jobId))
@@ -635,12 +640,14 @@ void app.prepare().then(() => {
               .where(eq(verificationTests.id, run.testId))
           }
           console.log(`[verify] ${msg.verificationRunId} — ${outcome}`)
+          try { appendLog({ level: msg.success ? 'info' : 'error', component: 'web', message: `Verification ${outcome} for run ${msg.verificationRunId}`, entityType: 'job', entityId: run?.testId ?? undefined, payload: { verificationRunId: msg.verificationRunId, ...(msg.errorMessage ? { errorMessage: msg.errorMessage } : {}) } }) } catch (err) { console.error('[logger]', err) }
 
         } else if (msg.type === 'restore_complete' && agentId) {
           await db.update(restoreRuns).set({
             status:      msg.success ? 'success' : 'failed',
             completedAt: new Date(),
           }).where(eq(restoreRuns.id, msg.restoreId))
+          try { appendLog({ level: msg.success ? 'info' : 'error', component: 'web', message: msg.success ? 'Restore succeeded' : 'Restore failed', entityType: 'restore_run', entityId: msg.restoreId }) } catch (err) { console.error('[logger]', err) }
 
           await db.insert(auditLog).values({
             id: crypto.randomUUID(),
@@ -667,6 +674,7 @@ void app.prepare().then(() => {
             resourceType: 'agent', resourceId: agentId,
             actor: 'system', createdAt: new Date(),
           })
+          try { appendLog({ level: 'info', component: 'agent', message: `Agent ${agentId} disconnected`, entityType: 'agent', entityId: agentId }) } catch (err) { console.error('[logger]', err) }
         }
       })()
     })


### PR DESCRIPTION
## Scope

Wiring only — no new infrastructure. The `appendLog` helper, `operationalLogs` table, and `/logs` UI already exist. This PR adds the call sites so the table actually receives entries.

## Call sites added

| # | Location | Event | Level | Component |
|---|----------|-------|-------|-----------|
| a | `server.ts` hello handler | Agent connects | info | agent |
| b | `server.ts` close handler | Agent disconnects | info | agent |
| c | `server.ts` hello handler | Bundle mismatch → force update sent | info | agent |
| d | `scheduler.ts` dispatchToAgent | Backup dispatched (cron or trigger tick) | info | web |
| d | `jobs.ts` retryRun | Backup dispatched (manual retry) | info | web |
| e | `server.ts` backup_complete handler | Backup succeeded | info | web |
| f | `server.ts` backup_failed handler | Backup failed | error | web |
| h | `server.ts` restore_complete (success) | Restore succeeded | info | web |
| i | `server.ts` restore_complete (failure) | Restore failed | error | web |
| j | `scheduler.ts` checkMissedBackups | Missed backup detected | warn | monitor |
| k | `scheduler.ts` checkAgents | Agent marked stale | warn | monitor |
| l | `server.ts` verification_complete | Verification passed/failed | info/error | web |

Every call is wrapped in `try { appendLog(...) } catch (err) { console.error('[logger]', err) }` — a logging failure can never break the operation it's logging.

## Out of scope

- Debug-level entries (V1 = info/warn/error only)
- Agent-side logging (agents run on separate hosts with no DB access; they send messages back which the server logs)
- Per-iteration or per-message logging (heartbeats, ping/pong, progress streaming)
- Hot path logging (metrics tick, trigger tick deferred entries)

## Verification

1. Connect an agent → `/logs` shows `Agent <hostname> connected` (agent/info)
2. Trigger a manual backup via Retry → `/logs` shows `Backup dispatched for job "..."` (web/info)
3. Wait for backup to complete → `/logs` shows `Backup succeeded...` (web/info) or `Backup failed...` (web/error)
4. Let the scheduler miss a backup window → `/logs` shows `Missed backup detected...` (monitor/warn)
5. Disconnect an agent while the health monitor runs → `/logs` shows `Agent ... marked stale` (monitor/warn)

Closes #74