### PR TITLE
feat(snapshots): wire snapshots table population — V1 (#71)

### DIFF
--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -7,7 +7,7 @@ import type { IncomingMessage } from 'http'
 import next from 'next'
 import { WebSocketServer } from 'ws'
 import type { WebSocket } from 'ws'
-import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, verificationRuns, verificationTests, eq, and, desc } from '@backupos/db'
+import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, verificationRuns, verificationTests, snapshots, eq, and, desc } from '@backupos/db'
 import { ResticEngine } from '@backupos/engine'
 import { parseExpression } from 'cron-parser'
 import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository } from './lib/ws-state'
@@ -494,6 +494,39 @@ void app.prepare().then(() => {
             actor: agentId, detail: JSON.stringify({ snapshotId: msg.snapshotId }),
             createdAt: new Date(),
           })
+
+          // Populate snapshots table
+          if (msg.snapshotId && run.repositoryId) {
+            try {
+              const [snapJob] = await db.select({ sourceType: backupJobs.sourceType, sourceConfig: backupJobs.sourceConfig })
+                .from(backupJobs).where(eq(backupJobs.id, msg.jobId)).limit(1)
+              const [snapAgent] = await db.select({ hostname: agents.hostname })
+                .from(agents).where(eq(agents.id, agentId)).limit(1)
+              let paths: string | null = null
+              if (snapJob?.sourceConfig) {
+                try {
+                  const cfg = JSON.parse(snapJob.sourceConfig) as { paths?: string[]; volumes?: string[] }
+                  if (snapJob.sourceType === 'docker_volume') {
+                    paths = JSON.stringify((cfg.volumes ?? []).map(v => `/var/lib/docker/volumes/${v}/_data`))
+                  } else if (snapJob.sourceType !== 'compose_project') {
+                    paths = JSON.stringify(cfg.paths ?? [])
+                  }
+                } catch { /* paths stays null */ }
+              }
+              await db.insert(snapshots).values({
+                id:           msg.snapshotId,
+                repositoryId: run.repositoryId,
+                jobId:        msg.jobId,
+                hostname:     snapAgent?.hostname ?? null,
+                paths,
+                tags:         null,
+                sizeBytes:    msg.stats.totalBytesProcessed > 0 ? msg.stats.totalBytesProcessed : null,
+                createdAt:    new Date(),
+              }).onConflictDoNothing()
+            } catch (err) {
+              console.error('[server] snapshot insert failed:', err instanceof Error ? err.message : err)
+            }
+          }
 
           // Run forget/prune using the job's retention policy (falls back to global defaults)
           void (async () => {

--- a/packages/db/migrations/0037_backfill_snapshots.sql
+++ b/packages/db/migrations/0037_backfill_snapshots.sql
@@ -1,0 +1,20 @@
+-- Backfill snapshots table from existing successful backup_runs.
+-- paths stored as NULL for backfilled rows (sourceConfig is an object, not a plain array;
+-- new backups from server.ts will have proper paths going forward).
+INSERT INTO snapshots (id, repository_id, job_id, hostname, paths, tags, size_bytes, created_at)
+SELECT
+  br.snapshot_id,
+  bj.repository_id,
+  br.job_id,
+  a.hostname,
+  NULL,
+  NULL,
+  br.total_size,
+  COALESCE(br.completed_at, br.started_at)
+FROM backup_runs br
+LEFT JOIN backup_jobs bj ON bj.id = br.job_id
+LEFT JOIN agents a ON a.id = bj.agent_id
+WHERE br.status = 'success'
+  AND br.snapshot_id IS NOT NULL
+  AND br.snapshot_id != ''
+ON CONFLICT(id) DO NOTHING;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1746835200000,
       "tag": "0036_seed_logging_config",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "6",
+      "when": 1746921600000,
+      "tag": "0037_backfill_snapshots",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Scope

V1 only: wire the two events that must populate the snapshots table so all read consumers unblock. No protocol changes, no scheduler tick, no UI additions.

## What changed

**`apps/web/server.ts`** — inside the `backup_complete` handler's success branch, after the `auditLog` insert:
- Fetches the job's `sourceType` + `sourceConfig` to derive paths (filesystem/windows_system → `paths` array; docker_volume → mapped `/var/lib/docker/volumes/<v>/_data` paths; compose_project → `null`)
- Fetches the agent's `hostname`
- Inserts into `snapshots` with `ON CONFLICT(id) DO NOTHING` so re-reported snapshots are silently skipped
- Entire block is `try/catch` — a snapshot insert failure never affects the `backup_runs` success update

**`packages/db/migrations/0037_backfill_snapshots.sql`** — one-time backfill:
- `INSERT ... SELECT` from `backup_runs LEFT JOIN backup_jobs LEFT JOIN agents` where `status='success'` and `snapshot_id IS NOT NULL`
- `paths` stored as `NULL` for backfilled rows (sourceConfig is an object, not a plain paths array; new backups populate properly going forward)
- `ON CONFLICT(id) DO NOTHING` — idempotent, safe to re-run

## Out of scope (file as follow-ups)

- `restic snapshots --json` as source of truth (needs new agent protocol message)
- Periodic 15-minute full sync via scheduler tick
- Manual 'Refresh' button on snapshots page
- Stale-row cleanup when restic forget prunes a snapshot
- Snapshot pinning / retention hold UI
- Custom tags UI

## Smoke test

After deploy:
1. Migration 0037 runs automatically → existing 18 successful backup_runs are backfilled into snapshots
2. `/repositories/<id>/snapshots` should immediately show those 18 rows
3. Run a new backup → a snapshot row with `paths` populated appears after `backup_complete`

Closes #71