### PR TITLE
feat(alerts): expand alert channels — Zulip, Telegram, PagerDuty, ntfy, Gotify, Pushover (#93 PR 1 of 2)

### DIFF
--- a/apps/web/app/(dashboard)/settings/alerts/AddChannelForm.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/AddChannelForm.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useState } from 'react'
+import { createAlertChannel } from '@/app/actions/alerts'
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', padding: '7px 10px', fontSize: 13, boxSizing: 'border-box',
+  backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none',
+}
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 12, color: 'var(--fg-dim)', display: 'block', marginBottom: 4,
+}
+
+function Field({ label, name, type = 'text', placeholder, required }: {
+  label: string; name: string; type?: string; placeholder?: string; required?: boolean
+}) {
+  return (
+    <div>
+      <label style={labelStyle}>{label}{required ? '' : ' (optional)'}</label>
+      <input name={name} type={type} placeholder={placeholder} style={inputStyle} />
+    </div>
+  )
+}
+
+export function AddChannelForm() {
+  const [type, setType] = useState('discord')
+
+  return (
+    <form action={createAlertChannel} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div>
+        <label style={labelStyle}>Name</label>
+        <input name="name" required placeholder="e.g. Ops Discord" style={inputStyle} />
+      </div>
+      <div>
+        <label style={labelStyle}>Type</label>
+        <select
+          name="type"
+          required
+          value={type}
+          onChange={e => setType(e.target.value)}
+          style={inputStyle}
+        >
+          <option value="discord">Discord</option>
+          <option value="slack">Slack</option>
+          <option value="webhook">Generic webhook</option>
+          <option value="zulip">Zulip</option>
+          <option value="telegram">Telegram</option>
+          <option value="pagerduty">PagerDuty</option>
+          <option value="ntfy">ntfy</option>
+          <option value="gotify">Gotify</option>
+          <option value="pushover">Pushover</option>
+        </select>
+      </div>
+
+      {/* URL-based types */}
+      {['discord', 'slack', 'webhook', 'zulip', 'ntfy', 'gotify'].includes(type) && (
+        <Field label="URL" name="url" type="url" placeholder="https://…" required />
+      )}
+
+      {/* Zulip-specific */}
+      {type === 'zulip' && <>
+        <Field label="Bot email" name="email" placeholder="bot@example.com" required />
+        <Field label="API key" name="apiKey" placeholder="Zulip bot API key" required />
+        <Field label="Stream" name="stream" placeholder="e.g. ops-alerts" required />
+        <Field label="Topic" name="topic" placeholder="e.g. BackupOS alerts" />
+      </>}
+
+      {/* Telegram */}
+      {type === 'telegram' && <>
+        <Field label="Bot token" name="botToken" placeholder="1234567890:ABC…" required />
+        <Field label="Chat ID" name="chatId" placeholder="-100123456789" required />
+      </>}
+
+      {/* PagerDuty */}
+      {type === 'pagerduty' && (
+        <Field label="Integration key" name="integrationKey" placeholder="Events API v2 routing key" required />
+      )}
+
+      {/* ntfy-specific */}
+      {type === 'ntfy' && <>
+        <Field label="Topic" name="topic" placeholder="my-backup-alerts" required />
+        <Field label="Authorization header" name="auth" placeholder="Bearer tk_…" />
+      </>}
+
+      {/* Gotify */}
+      {type === 'gotify' && (
+        <Field label="App token" name="appToken" placeholder="Gotify app token" required />
+      )}
+
+      {/* Pushover */}
+      {type === 'pushover' && <>
+        <Field label="API token" name="apiToken" placeholder="Pushover application token" required />
+        <Field label="User key" name="userKey" placeholder="Pushover user/group key" required />
+      </>}
+
+      <button
+        type="submit"
+        style={{
+          alignSelf: 'flex-start', padding: '7px 18px', fontSize: 13, fontWeight: 500,
+          borderRadius: 'var(--radius-sm)', border: 'none',
+          background: 'var(--accent)', color: '#fff', cursor: 'pointer',
+        }}
+      >
+        Add channel
+      </button>
+    </form>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/alerts/page.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/page.tsx
@@ -1,10 +1,17 @@
 import { getDb, alertChannels } from '@backupos/db'
-import { createAlertChannel, deleteAlertChannel } from '@/app/actions/alerts'
+import { deleteAlertChannel } from '@/app/actions/alerts'
+import { AddChannelForm } from './AddChannelForm'
 
 const TYPE_LABELS: Record<string, string> = {
-  discord: 'Discord',
-  slack:   'Slack',
-  webhook: 'Webhook',
+  discord:   'Discord',
+  slack:     'Slack',
+  webhook:   'Webhook',
+  zulip:     'Zulip',
+  telegram:  'Telegram',
+  pagerduty: 'PagerDuty',
+  ntfy:      'ntfy',
+  gotify:    'Gotify',
+  pushover:  'Pushover',
 }
 
 export default async function AlertChannelsPage({ searchParams }: { searchParams: Promise<{ saved?: string }> }) {
@@ -33,8 +40,14 @@ export default async function AlertChannelsPage({ searchParams }: { searchParams
           </div>
           {channels.map(ch => {
             const deleteAction = deleteAlertChannel.bind(null, ch.id)
-            let url = ''
-            try { url = (JSON.parse(ch.config) as { url: string }).url } catch { /* ignore */ }
+            let subtitle = ''
+            try {
+              const cfg = JSON.parse(ch.config) as Record<string, string>
+              if (cfg.url)            { subtitle = cfg.url.slice(0, 48) + (cfg.url.length > 48 ? '…' : '') }
+              else if (cfg.chatId)    { subtitle = `chat ${cfg.chatId}` }
+              else if (cfg.integrationKey) { subtitle = cfg.integrationKey.slice(0, 20) + '…' }
+              else if (cfg.userKey)   { subtitle = `user ${cfg.userKey.slice(0, 16)}…` }
+            } catch { /* ignore */ }
             return (
               <div key={ch.id} style={{
                 padding: '14px 20px', borderTop: '1px solid var(--border)',
@@ -43,7 +56,7 @@ export default async function AlertChannelsPage({ searchParams }: { searchParams
                 <div>
                   <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)' }}>{ch.name}</div>
                   <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginTop: 2 }}>
-                    {TYPE_LABELS[ch.type] ?? ch.type} · {url.slice(0, 40)}{url.length > 40 ? '…' : ''}
+                    {TYPE_LABELS[ch.type] ?? ch.type}{subtitle ? ` · ${subtitle}` : ''}
                   </div>
                 </div>
                 <form action={deleteAction}>
@@ -69,61 +82,7 @@ export default async function AlertChannelsPage({ searchParams }: { searchParams
         borderRadius: 'var(--radius)', padding: '20px 24px',
       }}>
         <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--fg)', marginBottom: 16 }}>Add channel</div>
-        <form action={createAlertChannel} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          <div>
-            <label style={{ fontSize: 12, color: 'var(--fg-dim)', display: 'block', marginBottom: 4 }}>Name</label>
-            <input
-              name="name"
-              required
-              placeholder="e.g. Ops Discord"
-              style={{
-                width: '100%', padding: '7px 10px', fontSize: 13, boxSizing: 'border-box',
-                backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
-                borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none',
-              }}
-            />
-          </div>
-          <div>
-            <label style={{ fontSize: 12, color: 'var(--fg-dim)', display: 'block', marginBottom: 4 }}>Type</label>
-            <select
-              name="type"
-              required
-              style={{
-                width: '100%', padding: '7px 10px', fontSize: 13,
-                backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
-                borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none',
-              }}
-            >
-              <option value="discord">Discord</option>
-              <option value="slack">Slack</option>
-              <option value="webhook">Generic webhook</option>
-            </select>
-          </div>
-          <div>
-            <label style={{ fontSize: 12, color: 'var(--fg-dim)', display: 'block', marginBottom: 4 }}>Webhook URL</label>
-            <input
-              name="url"
-              type="url"
-              required
-              placeholder="https://discord.com/api/webhooks/…"
-              style={{
-                width: '100%', padding: '7px 10px', fontSize: 13, boxSizing: 'border-box',
-                backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
-                borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none',
-              }}
-            />
-          </div>
-          <button
-            type="submit"
-            style={{
-              alignSelf: 'flex-start', padding: '7px 18px', fontSize: 13, fontWeight: 500,
-              borderRadius: 'var(--radius-sm)', border: 'none',
-              background: 'var(--accent)', color: '#fff', cursor: 'pointer',
-            }}
-          >
-            Add channel
-          </button>
-        </form>
+        <AddChannelForm />
       </div>
     </div>
   )

--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -4,7 +4,59 @@ import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { getDb, alerts, alertChannels, eq } from '@backupos/db'
 
-const VALID_CHANNEL_TYPES = ['discord', 'slack', 'webhook'] as const
+const VALID_CHANNEL_TYPES = [
+  'discord', 'slack', 'webhook',
+  'zulip', 'telegram', 'pagerduty', 'ntfy', 'gotify', 'pushover',
+] as const
+
+function str(fd: FormData, key: string): string {
+  const v = fd.get(key)
+  return typeof v === 'string' ? v.trim() : ''
+}
+
+function buildConfig(type: string, fd: FormData): Record<string, string> | null {
+  if (type === 'discord' || type === 'slack' || type === 'webhook') {
+    const url = str(fd, 'url')
+    if (!url) return null
+    return { url }
+  }
+  if (type === 'zulip') {
+    const url = str(fd, 'url'); const email = str(fd, 'email')
+    const apiKey = str(fd, 'apiKey'); const stream = str(fd, 'stream')
+    if (!url || !email || !apiKey || !stream) return null
+    const cfg: Record<string, string> = { url, email, apiKey, stream }
+    const topic = str(fd, 'topic'); if (topic) cfg.topic = topic
+    return cfg
+  }
+  if (type === 'telegram') {
+    const botToken = str(fd, 'botToken'); const chatId = str(fd, 'chatId')
+    if (!botToken || !chatId) return null
+    return { botToken, chatId }
+  }
+  if (type === 'pagerduty') {
+    const integrationKey = str(fd, 'integrationKey')
+    if (!integrationKey) return null
+    return { integrationKey }
+  }
+  if (type === 'ntfy') {
+    const url = str(fd, 'url'); const topic = str(fd, 'topic')
+    if (!url || !topic) return null
+    const cfg: Record<string, string> = { url, topic }
+    const auth = str(fd, 'auth'); if (auth) cfg.auth = auth
+    return cfg
+  }
+  if (type === 'gotify') {
+    const url = str(fd, 'url'); const appToken = str(fd, 'appToken')
+    if (!url || !appToken) return null
+    return { url, appToken }
+  }
+  if (type === 'pushover') {
+    const apiToken = str(fd, 'apiToken'); const userKey = str(fd, 'userKey')
+    if (!apiToken || !userKey) return null
+    return { apiToken, userKey }
+  }
+  return null
+}
 
 export async function snoozeAlert(id: string, hours: number): Promise<void> {
   if (!id || hours <= 0) return
@@ -15,20 +67,21 @@ export async function snoozeAlert(id: string, hours: number): Promise<void> {
 }
 
 export async function createAlertChannel(formData: FormData): Promise<void> {
-  const name = formData.get('name')
-  const type = formData.get('type')
-  const url = formData.get('url')
+  const name = str(formData, 'name')
+  const type = str(formData, 'type')
 
-  if (typeof name !== 'string' || !name.trim()) return
-  if (typeof type !== 'string' || !(VALID_CHANNEL_TYPES as readonly string[]).includes(type)) return
-  if (typeof url !== 'string' || !url.trim()) return
+  if (!name) return
+  if (!(VALID_CHANNEL_TYPES as readonly string[]).includes(type)) return
+
+  const config = buildConfig(type, formData)
+  if (!config) return
 
   const db = getDb()
   await db.insert(alertChannels).values({
     id: crypto.randomUUID(),
-    name: name.trim(),
+    name,
     type,
-    config: JSON.stringify({ url: url.trim() }),
+    config: JSON.stringify(config),
     enabled: true,
     createdAt: new Date(),
   })

--- a/apps/web/lib/alerts.ts
+++ b/apps/web/lib/alerts.ts
@@ -22,6 +22,17 @@ const DISCORD_COLOR: Record<string, number> = {
   info:    0x5865F2,
 }
 
+const SEVERITY_EMOJI: Record<string, string> = {
+  error:   '❌',
+  warning: '⚠️',
+  info:    'ℹ️',
+}
+
+const NTFY_PRIORITY:     Record<string, number> = { error: 5, warning: 4, info: 3 }
+const GOTIFY_PRIORITY:   Record<string, number> = { error: 8, warning: 5, info: 3 }
+const PUSHOVER_PRIORITY: Record<string, number> = { error: 1, warning: 0, info: -1 }
+const PAGERDUTY_SEV:     Record<string, string> = { error: 'error', warning: 'warning', info: 'info' }
+
 function buildMessage(type: AlertType, payload: AlertPayload): string {
   if (type === 'backup_failed') {
     const p = payload as AlertBackupFailed
@@ -91,6 +102,94 @@ async function fireEmail(type: AlertType, message: string): Promise<void> {
   })
 }
 
+interface ZulipConfig    { url: string; email: string; apiKey: string; stream: string; topic?: string }
+interface TelegramConfig { botToken: string; chatId: string }
+interface PagerDutyConfig { integrationKey: string }
+interface NtfyConfig     { url: string; topic: string; auth?: string }
+interface GotifyConfig   { url: string; appToken: string }
+interface PushoverConfig { apiToken: string; userKey: string }
+
+async function fireZulip(cfg: ZulipConfig, type: AlertType, message: string, severity: string): Promise<void> {
+  const emoji = SEVERITY_EMOJI[severity] ?? ''
+  const params = new URLSearchParams({
+    type:    'stream',
+    to:      cfg.stream,
+    topic:   cfg.topic ?? '[BackupOS] alerts',
+    content: `${emoji} ${message}`,
+  })
+  await fetch(`${cfg.url}/api/v1/messages`, {
+    method:  'POST',
+    headers: {
+      'Authorization': `Basic ${Buffer.from(`${cfg.email}:${cfg.apiKey}`).toString('base64')}`,
+      'Content-Type':  'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  })
+}
+
+async function fireTelegram(cfg: TelegramConfig, type: AlertType, message: string, severity: string): Promise<void> {
+  const emoji = SEVERITY_EMOJI[severity] ?? ''
+  await fetch(`https://api.telegram.org/bot${cfg.botToken}/sendMessage`, {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body:    JSON.stringify({ chat_id: cfg.chatId, text: `${emoji} ${message}`, parse_mode: 'Markdown' }),
+  })
+}
+
+async function firePagerDuty(cfg: PagerDutyConfig, type: AlertType, message: string, severity: string, payload: AlertPayload): Promise<void> {
+  await fetch('https://events.pagerduty.com/v2/enqueue', {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body:    JSON.stringify({
+      routing_key:  cfg.integrationKey,
+      event_action: 'trigger',
+      payload: {
+        summary:        message,
+        source:         'backupos',
+        severity:       PAGERDUTY_SEV[severity] ?? 'info',
+        custom_details: payload,
+      },
+    }),
+  })
+}
+
+async function fireNtfy(cfg: NtfyConfig, type: AlertType, message: string, severity: string): Promise<void> {
+  const headers: Record<string, string> = {
+    'Title':    `BackupOS — ${type.replace(/_/g, ' ')}`,
+    'Priority': String(NTFY_PRIORITY[severity] ?? 3),
+    'Tags':     type,
+  }
+  if (cfg.auth) headers['Authorization'] = cfg.auth
+  await fetch(`${cfg.url}/${cfg.topic}`, { method: 'POST', headers, body: message })
+}
+
+async function fireGotify(cfg: GotifyConfig, type: AlertType, message: string, severity: string): Promise<void> {
+  await fetch(`${cfg.url}/message?token=${cfg.appToken}`, {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body:    JSON.stringify({
+      title:    `[BackupOS] ${type.replace(/_/g, ' ')}`,
+      message,
+      priority: GOTIFY_PRIORITY[severity] ?? 3,
+    }),
+  })
+}
+
+async function firePushover(cfg: PushoverConfig, type: AlertType, message: string, severity: string): Promise<void> {
+  const params = new URLSearchParams({
+    token:    cfg.apiToken,
+    user:     cfg.userKey,
+    title:    `[BackupOS] ${type.replace(/_/g, ' ')}`,
+    message,
+    priority: String(PUSHOVER_PRIORITY[severity] ?? -1),
+  })
+  await fetch('https://api.pushover.net/1/messages.json', {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body:    params.toString(),
+  })
+}
+
 export async function sendAlert(type: AlertType, payload: AlertPayload): Promise<void> {
   const db       = getDb()
   const severity = SEVERITY[type]
@@ -111,12 +210,18 @@ export async function sendAlert(type: AlertType, payload: AlertPayload): Promise
   await Promise.allSettled(
     enabled.map(async channel => {
       try {
-        const cfg = JSON.parse(channel.config) as { url?: string }
-        const url = cfg.url ?? ''
-        if (!url) return
-        if (channel.type === 'discord') await fireDiscord(url, type, message, severity)
-        else if (channel.type === 'slack') await fireSlack(url, type, message)
-        else await fireWebhook(url, type, severity, message, payload)
+        const cfg = JSON.parse(channel.config) as Record<string, unknown>
+        const url = (cfg.url as string | undefined) ?? ''
+
+        if      (channel.type === 'discord')    await fireDiscord(url, type, message, severity)
+        else if (channel.type === 'slack')       await fireSlack(url, type, message)
+        else if (channel.type === 'zulip')       await fireZulip(cfg as unknown as ZulipConfig, type, message, severity)
+        else if (channel.type === 'telegram')    await fireTelegram(cfg as unknown as TelegramConfig, type, message, severity)
+        else if (channel.type === 'pagerduty')   await firePagerDuty(cfg as unknown as PagerDutyConfig, type, message, severity, payload)
+        else if (channel.type === 'ntfy')        await fireNtfy(cfg as unknown as NtfyConfig, type, message, severity)
+        else if (channel.type === 'gotify')      await fireGotify(cfg as unknown as GotifyConfig, type, message, severity)
+        else if (channel.type === 'pushover')    await firePushover(cfg as unknown as PushoverConfig, type, message, severity)
+        else if (url)                            await fireWebhook(url, type, severity, message, payload)
       } catch (err) {
         console.error(`[alerts] channel ${channel.id} delivery failed:`, err)
       }


### PR DESCRIPTION
## Summary

- Adds 6 new notification channel types to the alert pipeline: Zulip, Telegram, PagerDuty, ntfy, Gotify, Pushover
- Backend: `lib/alerts.ts` gains `fireZulip`, `fireTelegram`, `firePagerDuty`, `fireNtfy`, `fireGotify`, `firePushover` with per-channel priority/severity mapping
- Frontend: `settings/alerts` form is now a client component with dynamic fields per channel type; server action builds the correct config shape per type

## Test plan

- [ ] Add a Discord/Slack/webhook channel — existing flow unchanged
- [ ] Add a Telegram channel — fields show bot token + chat ID; config saved as `{ botToken, chatId }`
- [ ] Add a PagerDuty channel — only integration key field shown
- [ ] Add a Pushover channel — API token + user key fields shown
- [ ] Add a Zulip channel — URL, email, API key, stream (+ optional topic) shown
- [ ] Add an ntfy channel — URL + topic required, auth optional
- [ ] Add a Gotify channel — URL + app token shown
- [ ] Channel list subtitle shows URL or appropriate identifier for non-URL types
- [ ] `tsc --noEmit` passes with no errors

Part 1 of 2 for #93 — does not close the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)