### PR TITLE
feat(scheduler): periodic monitor sync — every 5 minutes (#77)

### DIFF
--- a/apps/web/app/actions/monitors.ts
+++ b/apps/web/app/actions/monitors.ts
@@ -2,8 +2,9 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { getDb, backupMonitors, monitorResults, repositories, eq } from '@backupos/db'
-import { MONITOR_REGISTRY, type MonitorConfig, type PBSConfig } from '@backupos/monitors'
+import { getDb, backupMonitors, repositories, eq } from '@backupos/db'
+import { type PBSConfig } from '@backupos/monitors'
+import { performMonitorSync } from '@/lib/monitors'
 
 export async function promoteMonitorToRepo(monitorId: string, formData: FormData): Promise<void> {
   const password = (formData.get('password') as string)?.trim()
@@ -119,43 +120,8 @@ export async function deleteMonitor(id: string): Promise<void> {
 }
 
 export async function syncMonitor(monitorId: string): Promise<{ ok: boolean; error?: string }> {
-  const db      = getDb()
-  const [monitor] = await db.select().from(backupMonitors).where(eq(backupMonitors.id, monitorId)).limit(1)
-  if (!monitor) return { ok: false, error: 'Monitor not found' }
-
-  const adapter = MONITOR_REGISTRY[monitor.type]
-  if (!adapter) return { ok: false, error: `Unknown monitor type: ${monitor.type}` }
-
-  try {
-    const config = JSON.parse(monitor.config) as MonitorConfig
-    const result = await adapter.sync(config)
-
-    await db.insert(monitorResults).values({
-      id:               crypto.randomUUID(),
-      monitorId,
-      status:           result.status,
-      lastBackupAt:     result.lastBackupAt,
-      lastBackupStatus: result.lastBackupStatus,
-      sizeBytes:        result.sizeBytes,
-      details:          JSON.stringify(result.details ?? {}),
-      checkedAt:        new Date(),
-    })
-
-    await db.update(backupMonitors)
-      .set({ lastSyncedAt: new Date(), status: result.status })
-      .where(eq(backupMonitors.id, monitorId))
-
-    revalidatePath(`/monitors/${monitorId}`)
-    return { ok: true }
-  } catch (err) {
-    let msg: string
-    if (err instanceof AggregateError && err.errors.length > 0) {
-      msg = err.errors.map((e: unknown) => (e instanceof Error ? e.message : String(e))).join('; ')
-    } else if (err instanceof Error) {
-      msg = err.message
-    } else {
-      msg = String(err)
-    }
-    return { ok: false, error: msg || 'Sync failed' }
-  }
+  const db     = getDb()
+  const result = await performMonitorSync(monitorId, db)
+  if (result.ok) revalidatePath(`/monitors/${monitorId}`)
+  return result
 }

--- a/apps/web/lib/monitors.ts
+++ b/apps/web/lib/monitors.ts
@@ -1,0 +1,47 @@
+import { getDb, backupMonitors, monitorResults, eq } from '@backupos/db'
+import { MONITOR_REGISTRY, type MonitorConfig } from '@backupos/monitors'
+
+type Db = ReturnType<typeof getDb>
+
+export async function performMonitorSync(
+  monitorId: string,
+  db: Db,
+): Promise<{ ok: boolean; error?: string; status?: string }> {
+  const [monitor] = await db.select().from(backupMonitors).where(eq(backupMonitors.id, monitorId)).limit(1)
+  if (!monitor) return { ok: false, error: 'Monitor not found' }
+
+  const adapter = MONITOR_REGISTRY[monitor.type]
+  if (!adapter) return { ok: false, error: `Unknown monitor type: ${monitor.type}` }
+
+  try {
+    const config = JSON.parse(monitor.config) as MonitorConfig
+    const result = await adapter.sync(config)
+
+    await db.insert(monitorResults).values({
+      id:               crypto.randomUUID(),
+      monitorId,
+      status:           result.status,
+      lastBackupAt:     result.lastBackupAt,
+      lastBackupStatus: result.lastBackupStatus,
+      sizeBytes:        result.sizeBytes,
+      details:          JSON.stringify(result.details ?? {}),
+      checkedAt:        new Date(),
+    })
+
+    await db.update(backupMonitors)
+      .set({ lastSyncedAt: new Date(), status: result.status })
+      .where(eq(backupMonitors.id, monitorId))
+
+    return { ok: true, status: result.status }
+  } catch (err) {
+    let msg: string
+    if (err instanceof AggregateError && err.errors.length > 0) {
+      msg = err.errors.map((e: unknown) => (e instanceof Error ? e.message : String(e))).join('; ')
+    } else if (err instanceof Error) {
+      msg = err.message
+    } else {
+      msg = String(err)
+    }
+    return { ok: false, error: msg || 'Sync failed' }
+  }
+}

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -1,6 +1,6 @@
 import * as cron from 'node-cron'
 import { parseExpression } from 'cron-parser'
-import { getDb, backupJobs, backupRuns, repositories, agents, backupDefaults, bandwidthProfiles, bandwidthRules, eq, and, or, lt, lte, gte, isNotNull, isNull } from '@backupos/db'
+import { getDb, backupJobs, backupRuns, repositories, agents, backupMonitors, backupDefaults, bandwidthProfiles, bandwidthRules, eq, and, or, lt, lte, gte, isNotNull, isNull } from '@backupos/db'
 import { decryptField } from './repo-crypto'
 import { sendAlert } from './alerts'
 import { dispatch, connectedAgentIds } from './ws-state'
@@ -9,6 +9,7 @@ import { isWithinWindow } from './schedule-window'
 import type { ServerMessage, MountConfig, ComposeProjectConfig } from '@backupos/agent-protocol'
 import { pruneRetainedLogs } from './retention'
 import { appendLog } from './logger'
+import { performMonitorSync } from './monitors'
 
 interface SourceConfig {
   paths?:    string[]
@@ -51,6 +52,10 @@ export async function initScheduler(): Promise<void> {
   // Daily retention sweep at 03:00 UTC
   cron.schedule('0 3 * * *', () => { void runRetentionSweep(db) }, { timezone: 'UTC' })
   console.log('[scheduler] Retention sweep active (daily 03:00 UTC)')
+
+  // Sync all monitors every 5 minutes
+  setInterval(() => { void checkMonitors(db) }, 5 * 60 * 1000)
+  console.log('[scheduler] Monitor sync active (5 min interval)')
 }
 
 type Db = ReturnType<typeof getDb>
@@ -382,6 +387,32 @@ async function runRetentionSweep(db: Db): Promise<void> {
   } catch (err) {
     console.error('[scheduler] Retention sweep failed:', err instanceof Error ? err.message : String(err))
   }
+}
+
+async function checkMonitors(db: Db): Promise<void> {
+  const monitors = await db.select().from(backupMonitors).all()
+  if (monitors.length === 0) return
+
+  await Promise.allSettled(
+    monitors.map(async monitor => {
+      try {
+        const result = await performMonitorSync(monitor.id, db)
+        const status = result.ok ? (result.status ?? 'ok') : 'failed'
+        console.log(`[scheduler] Monitor "${monitor.name}" synced: ${status}`)
+        try {
+          appendLog({
+            level:      result.ok ? 'info' : 'warn',
+            component:  'monitor',
+            message:    `Monitor sync: ${monitor.name} → ${status}${result.error ? ` (${result.error})` : ''}`,
+            entityType: 'monitor',
+            entityId:   monitor.id,
+          })
+        } catch (err) { console.error('[logger]', err) }
+      } catch (err) {
+        console.error(`[scheduler] Monitor "${monitor.name}" sync threw:`, err)
+      }
+    })
+  )
 }
 
 async function checkAgents(db: Db): Promise<void> {


### PR DESCRIPTION
## Scope

V1: global 5-minute interval — all `backup_monitors` rows synced on each tick, `Promise.allSettled` isolation so one broken monitor never blocks others.

## What changed

- **`apps/web/lib/monitors.ts`** (new) — `performMonitorSync(monitorId, db)` shared helper: loads monitor, looks up adapter in `MONITOR_REGISTRY`, calls `adapter.sync()`, inserts a `monitor_results` row, and updates `backup_monitors.last_synced_at` + `status`. No Next.js side effects.
- **`apps/web/lib/scheduler.ts`** — new `checkMonitors(db)` function iterates all monitors with `Promise.allSettled`; logs each result via `console.log` and `appendLog`. New independent `setInterval(() => { void checkMonitors(db) }, 5 * 60 * 1000)` added to `initScheduler`, printed to startup banner alongside existing ticks.
- **`apps/web/app/actions/monitors.ts`** — `syncMonitor` refactored to call `performMonitorSync` + `revalidatePath`. Logic no longer duplicated.

## Out of scope

- Per-monitor schedule column (all monitors use the same 5-min cadence)
- Exponential backoff on persistent failures
- Skip-if-recently-synced logic
- Manual override of sync interval per monitor
- UI changes to show next-sync timestamp

## Smoke test

After deploy:
- [ ] An existing PBS monitor should auto-populate a new `monitor_results` row within 5 minutes — no manual Sync click required
- [ ] `/logs` shows `[scheduler] Monitor sync: <name> → <status>` entries every ~5 minutes
- [ ] Killing the PBS endpoint causes that monitor to log a failed sync while other monitors continue unaffected
- [ ] Manual Sync button on `/monitors/[id]` still works as before

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)