### PR TITLE
feat(scheduler): periodic verification test runs — 60s tick (#141)

### DIFF
--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -1,6 +1,6 @@
 import * as cron from 'node-cron'
 import { parseExpression } from 'cron-parser'
-import { getDb, backupJobs, backupRuns, repositories, agents, backupMonitors, backupDefaults, bandwidthProfiles, bandwidthRules, eq, and, or, lt, lte, gte, isNotNull, isNull } from '@backupos/db'
+import { getDb, backupJobs, backupRuns, repositories, agents, backupMonitors, verificationTests, backupDefaults, bandwidthProfiles, bandwidthRules, eq, and, or, lt, lte, gte, isNotNull, isNull } from '@backupos/db'
 import { decryptField } from './repo-crypto'
 import { sendAlert } from './alerts'
 import { dispatch, connectedAgentIds } from './ws-state'
@@ -10,6 +10,7 @@ import type { ServerMessage, MountConfig, ComposeProjectConfig } from '@backupos
 import { pruneRetainedLogs } from './retention'
 import { appendLog } from './logger'
 import { performMonitorSync } from './monitors'
+import { runVerification } from '../app/actions/verification'
 
 interface SourceConfig {
   paths?:    string[]
@@ -56,6 +57,10 @@ export async function initScheduler(): Promise<void> {
   // Sync all monitors every 5 minutes
   setInterval(() => { void checkMonitors(db) }, 5 * 60 * 1000)
   console.log('[scheduler] Monitor sync active (5 min interval)')
+
+  // Verification tests fire on their cron schedule (60s tick checks all enabled tests)
+  setInterval(() => { void checkVerificationTests(db) }, 60_000)
+  console.log('[scheduler] Verification scheduler active (60s tick)')
 }
 
 type Db = ReturnType<typeof getDb>
@@ -387,6 +392,57 @@ async function runRetentionSweep(db: Db): Promise<void> {
   } catch (err) {
     console.error('[scheduler] Retention sweep failed:', err instanceof Error ? err.message : String(err))
   }
+}
+
+async function checkVerificationTests(db: Db): Promise<void> {
+  const now   = new Date()
+  const tests = await db.select()
+    .from(verificationTests)
+    .where(and(eq(verificationTests.enabled, true), isNotNull(verificationTests.schedule)))
+    .all()
+
+  if (tests.length === 0) return
+
+  await Promise.allSettled(
+    tests.map(async test => {
+      try {
+        if (!test.schedule) return
+
+        if (!test.nextRunAt) {
+          const interval = parseExpression(test.schedule, { tz: 'UTC' })
+          await db.update(verificationTests)
+            .set({ nextRunAt: interval.next().toDate() })
+            .where(eq(verificationTests.id, test.id))
+          console.log(`[verify-scheduler] Test "${test.name}" next_run_at initialized`)
+          return
+        }
+
+        if (test.nextRunAt > now) return
+
+        console.log(`[verify-scheduler] Test "${test.name}" due — dispatching`)
+
+        // Advance next_run_at BEFORE dispatch for restart safety
+        const interval = parseExpression(test.schedule, { tz: 'UTC' })
+        await db.update(verificationTests)
+          .set({ nextRunAt: interval.next().toDate() })
+          .where(eq(verificationTests.id, test.id))
+
+        try {
+          appendLog({
+            level:      'info',
+            component:  'web',
+            message:    `Verification test "${test.name}" dispatched by scheduler`,
+            entityType: 'job',
+            entityId:   test.jobId ?? undefined,
+          })
+        } catch (err) { console.error('[logger]', err) }
+
+        await runVerification(test.id)
+      } catch (err) {
+        console.error(`[verify-scheduler] Test "${test.name}" failed:`, err instanceof Error ? err.message : String(err))
+      }
+    })
+  )
 }
 
 async function checkMonitors(db: Db): Promise<void> {


### PR DESCRIPTION
## Scope

V1: 60-second tick iterates all enabled `verification_tests` rows with a schedule, fires `runVerification()` when `next_run_at` is reached, using `Promise.allSettled` for isolation.

## What changed

- **`apps/web/lib/scheduler.ts`** only:
  - Added `verificationTests` to the `@backupos/db` import
  - Added `runVerification` import from `../app/actions/verification`
  - New `checkVerificationTests(db)` function — selects enabled tests with a schedule, initializes `next_run_at` on first encounter, fires `runVerification(test.id)` when due
  - New `setInterval(() => { void checkVerificationTests(db) }, 60_000)` in `initScheduler`

## Restart safety

`next_run_at` is advanced to the next future cron occurrence **before** `runVerification` is called. A service restart mid-dispatch finds `next_run_at` already in the future and skips the firing window — no double-dispatch.

## Out of scope

- Smart-skip logic (skip if a passing run completed in the last N hours)
- Exponential backoff on repeated failures
- Failure notifications / alerting
- Per-test override of tick frequency

## Smoke test

- [ ] After deploy, a test with schedule `*/2 * * * *` should create a new `verification_runs` row within 2 minutes without any manual trigger
- [ ] `journalctl` (or server log) shows `[verify-scheduler] Test "…" due — dispatching` on each fire
- [ ] A test with no successful backup run logs the thrown error and continues — other tests are unaffected
- [ ] Disabled tests (`enabled=false`) are skipped entirely
- [ ] `next_run_at` in `verification_tests` advances after each scheduled fire

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)