### PR TITLE
feat(rbac): V1 two-role RBAC — admin/viewer (#96)

### DIFF
--- a/apps/web/app/(dashboard)/repositories/[id]/delete-button.tsx
+++ b/apps/web/app/(dashboard)/repositories/[id]/delete-button.tsx
@@ -3,7 +3,8 @@
 import { useState, useTransition } from 'react'
 import { deleteRepository } from '@/app/actions/repositories'
 
-export function DeleteRepositoryButton({ repoId, repoName }: { repoId: string; repoName: string }) {
+export function DeleteRepositoryButton({ repoId, repoName, canEdit }: { repoId: string; repoName: string; canEdit: boolean }) {
+  if (!canEdit) return null
   const [confirming, setConfirming] = useState(false)
   const [isPending, start]          = useTransition()
 

--- a/apps/web/app/(dashboard)/repositories/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/repositories/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getDb, repositories } from '@backupos/db'
 import { eq, desc } from '@backupos/db'
 import { snapshots, backupJobs } from '@backupos/db'
 import { notFound } from 'next/navigation'
+import { getCurrentUser, isAdmin } from '@/lib/user'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { RunCheckButton } from './run-check-button'
@@ -27,6 +28,7 @@ function bytes(n: number | null | undefined): string {
 
 export default async function RepoDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+  const currentUser = await getCurrentUser()
   const db     = getDb()
   const [repo] = await db.select().from(repositories).where(eq(repositories.id, id)).limit(1)
   if (!repo) notFound()
@@ -106,7 +108,7 @@ export default async function RepoDetailPage({ params }: { params: Promise<{ id:
         <Link href={`/repositories/${id}/edit`} style={{ textDecoration: 'none' }}>
           <Button variant="secondary" size="md">Edit</Button>
         </Link>
-        <DeleteRepositoryButton repoId={id} repoName={repo.name} />
+        <DeleteRepositoryButton repoId={id} repoName={repo.name} canEdit={isAdmin(currentUser)} />
       </div>
 
       {/* Environment group */}

--- a/apps/web/app/(dashboard)/settings/users/client.tsx
+++ b/apps/web/app/(dashboard)/settings/users/client.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import { createInvite, revokeInvite, resendInviteEmail, createUserDirect } from '@/app/actions/invite'
+import { createInvite, revokeInvite, resendInviteEmail, createUserDirect, updateUserRole } from '@/app/actions/invite'
 
 interface UserRow {
   id:        string
   name:      string
   email:     string
+  role:      string
   createdAt: number
 }
 
@@ -21,18 +22,21 @@ interface InviteRow {
 }
 
 interface Props {
-  users:          UserRow[]
-  invites:        InviteRow[]
-  baseUrl:        string
-  smtpConfigured: boolean
-  currentUserId:  string
+  users:                UserRow[]
+  invites:              InviteRow[]
+  baseUrl:              string
+  smtpConfigured:       boolean
+  currentUserId:        string
+  currentUserIsAdmin:   boolean
 }
 
 function fmt(ms: number) {
   return new Date(ms).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
 }
 
-export function UsersClient({ users: initialUsers, invites: initialInvites, baseUrl, smtpConfigured, currentUserId }: Props) {
+const ROLE_LABELS: Record<string, string> = { admin: 'Admin', viewer: 'Viewer' }
+
+export function UsersClient({ users: initialUsers, invites: initialInvites, baseUrl, smtpConfigured, currentUserId, currentUserIsAdmin }: Props) {
   const [users,    setUsers]    = useState(initialUsers)
   const [invites,  setInvites]  = useState(initialInvites)
   const [newLink,  setNewLink]  = useState<string | null>(null)
@@ -88,6 +92,7 @@ export function UsersClient({ users: initialUsers, invites: initialInvites, base
       id:        result.id!,
       name:      result.name!,
       email:     result.email!,
+      role:      'viewer',
       createdAt: result.createdAt!,
     }])
   }
@@ -96,6 +101,15 @@ export function UsersClient({ users: initialUsers, invites: initialInvites, base
     startTransition(async () => {
       await revokeInvite(id)
       setInvites(prev => prev.filter(i => i.id !== id))
+    })
+  }
+
+  function handleRoleChange(userId: string, role: 'admin' | 'viewer') {
+    startTransition(async () => {
+      const result = await updateUserRole(userId, role)
+      if (!result.error) {
+        setUsers(prev => prev.map(u => u.id === userId ? { ...u, role } : u))
+      }
     })
   }
 
@@ -134,18 +148,30 @@ export function UsersClient({ users: initialUsers, invites: initialInvites, base
             {!smtpConfigured && <span style={{ color: 'var(--warn)' }}> · SMTP not configured — invites are link-only.</span>}
           </p>
         </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button style={btnGhost} onClick={() => { setShowCreateForm(f => !f); setShowForm(false) }}>
-            {showCreateForm ? 'Cancel' : 'Create user'}
-          </button>
-          <button style={btnPrimary} onClick={() => { setShowForm(f => !f); setShowCreateForm(false) }}>
-            {showForm ? 'Cancel' : 'Invite user'}
-          </button>
-        </div>
+        {currentUserIsAdmin && (
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button style={btnGhost} onClick={() => { setShowCreateForm(f => !f); setShowForm(false) }}>
+              {showCreateForm ? 'Cancel' : 'Create user'}
+            </button>
+            <button style={btnPrimary} onClick={() => { setShowForm(f => !f); setShowCreateForm(false) }}>
+              {showForm ? 'Cancel' : 'Invite user'}
+            </button>
+          </div>
+        )}
       </div>
 
-      {/* Invite form */}
-      {showForm && (
+      {!currentUserIsAdmin && (
+        <div style={{
+          padding: '10px 16px', marginBottom: 20,
+          backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-sm)', fontSize: 13, color: 'var(--fg-dim)',
+        }}>
+          View-only — admin role required to invite or manage users.
+        </div>
+      )}
+
+      {/* Invite form (admin only) */}
+      {currentUserIsAdmin && showForm && (
         <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)', padding: '20px 24px', marginBottom: 16 }}>
           <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', marginBottom: 16 }}>Send an invite</div>
           <form onSubmit={handleCreate}>
@@ -159,6 +185,13 @@ export function UsersClient({ users: initialUsers, invites: initialInvites, base
                 <input name="name" type="text" placeholder="Jane Doe" style={inputStyle} />
               </div>
             </div>
+            <div style={{ marginBottom: 16 }}>
+              <label style={{ display: 'block', fontSize: 12, fontWeight: 500, color: 'var(--fg-mute)', marginBottom: 4 }}>Role</label>
+              <select name="role" defaultValue="viewer" style={{ ...inputStyle, width: 'auto' }}>
+                <option value="viewer">Viewer — read-only access</option>
+                <option value="admin">Admin — full access</option>
+              </select>
+            </div>
             {error && <div style={{ fontSize: 13, color: 'var(--err)', marginBottom: 12 }}>{error}</div>}
             <button type="submit" style={btnPrimary} disabled={pending}>
               {smtpConfigured ? 'Send invite email + get link' : 'Create invite link'}
@@ -167,8 +200,8 @@ export function UsersClient({ users: initialUsers, invites: initialInvites, base
         </div>
       )}
 
-      {/* Create user form */}
-      {showCreateForm && (
+      {/* Create user form (admin only) */}
+      {currentUserIsAdmin && showCreateForm && (
         <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)', padding: '20px 24px', marginBottom: 16 }}>
           <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', marginBottom: 4 }}>Create user directly</div>
           <div style={{ fontSize: 12, color: 'var(--fg-dim)', marginBottom: 16 }}>Account is created immediately with email verified. Leave password blank to auto-generate.</div>
@@ -183,9 +216,18 @@ export function UsersClient({ users: initialUsers, invites: initialInvites, base
                 <input name="email" type="email" required placeholder="jane@example.com" style={inputStyle} />
               </div>
             </div>
-            <div style={{ marginBottom: 16 }}>
-              <label style={{ display: 'block', fontSize: 12, fontWeight: 500, color: 'var(--fg-mute)', marginBottom: 4 }}>Initial password (optional — auto-generated if blank)</label>
-              <input name="password" type="password" placeholder="Leave blank to auto-generate" style={inputStyle} />
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 16 }}>
+              <div>
+                <label style={{ display: 'block', fontSize: 12, fontWeight: 500, color: 'var(--fg-mute)', marginBottom: 4 }}>Initial password (optional)</label>
+                <input name="password" type="password" placeholder="Leave blank to auto-generate" style={inputStyle} />
+              </div>
+              <div>
+                <label style={{ display: 'block', fontSize: 12, fontWeight: 500, color: 'var(--fg-mute)', marginBottom: 4 }}>Role</label>
+                <select name="role" defaultValue="viewer" style={inputStyle}>
+                  <option value="viewer">Viewer</option>
+                  <option value="admin">Admin</option>
+                </select>
+              </div>
             </div>
             {createError && <div style={{ fontSize: 13, color: 'var(--err)', marginBottom: 12 }}>{createError}</div>}
             <button type="submit" style={btnPrimary} disabled={pending}>Create account</button>
@@ -255,6 +297,31 @@ export function UsersClient({ users: initialUsers, invites: initialInvites, base
               <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>{u.email}</div>
             </div>
             <div style={{ fontSize: 12, color: 'var(--fg-dim)', flexShrink: 0 }}>Joined {fmt(u.createdAt)}</div>
+            {/* Role: dropdown for other users (admin only), plain text for self */}
+            {currentUserIsAdmin && u.id !== currentUserId ? (
+              <select
+                value={u.role}
+                disabled={pending}
+                onChange={e => handleRoleChange(u.id, e.target.value as 'admin' | 'viewer')}
+                style={{
+                  padding: '4px 8px', fontSize: 12, flexShrink: 0,
+                  backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)', color: 'var(--fg)', cursor: 'pointer',
+                }}
+              >
+                <option value="viewer">Viewer</option>
+                <option value="admin">Admin</option>
+              </select>
+            ) : (
+              <span style={{
+                fontSize: 11, padding: '3px 8px', borderRadius: 12, flexShrink: 0,
+                backgroundColor: u.role === 'admin' ? 'color-mix(in srgb, var(--surf2) 60%, var(--accent) 15%)' : 'var(--surf2)',
+                border: '1px solid var(--border)',
+                color: u.role === 'admin' ? 'var(--accent)' : 'var(--fg-dim)',
+              }}>
+                {ROLE_LABELS[u.role] ?? u.role}
+              </span>
+            )}
           </div>
         ))}
       </div>
@@ -288,13 +355,15 @@ export function UsersClient({ users: initialUsers, invites: initialInvites, base
                       {resentId === inv.id ? '✓ Sent' : 'Resend email'}
                     </button>
                   )}
-                  <button
-                    style={{ ...btnGhost, color: 'var(--err)', borderColor: 'color-mix(in srgb, var(--err) 40%, transparent)' }}
-                    onClick={() => handleRevoke(inv.id)}
-                    disabled={pending}
-                  >
-                    Revoke
-                  </button>
+                  {currentUserIsAdmin && (
+                    <button
+                      style={{ ...btnGhost, color: 'var(--err)', borderColor: 'color-mix(in srgb, var(--err) 40%, transparent)' }}
+                      onClick={() => handleRevoke(inv.id)}
+                      disabled={pending}
+                    >
+                      Revoke
+                    </button>
+                  )}
                 </div>
               </div>
             )

--- a/apps/web/app/(dashboard)/settings/users/page.tsx
+++ b/apps/web/app/(dashboard)/settings/users/page.tsx
@@ -1,5 +1,5 @@
 import { redirect }       from 'next/navigation'
-import { getCurrentUser } from '@/lib/user'
+import { getCurrentUser, isAdmin } from '@/lib/user'
 import { getDb, user, invite, smtpConfig } from '@backupos/db'
 import { UsersClient }    from './client'
 
@@ -14,6 +14,7 @@ export default async function UsersPage() {
       id:        user.id,
       name:      user.name,
       email:     user.email,
+      role:      user.role,
       createdAt: user.createdAt,
     }).from(user).all(),
 
@@ -39,6 +40,7 @@ export default async function UsersPage() {
       baseUrl={baseUrl}
       smtpConfigured={smtpConfigured}
       currentUserId={currentUser.id}
+      currentUserIsAdmin={isAdmin(currentUser)}
     />
   )
 }

--- a/apps/web/app/actions/agents.ts
+++ b/apps/web/app/actions/agents.ts
@@ -3,8 +3,10 @@
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { getDb, agents, eq } from '@backupos/db'
+import { requireAdmin } from '@/lib/user'
 
 export async function enrollAgent(formData: FormData): Promise<void> {
+  await requireAdmin() // admin only
   const name = (formData.get('name') as string)?.trim()
   if (!name) return
 
@@ -41,6 +43,7 @@ export async function setAgentChannelFromForm(agentId: string, formData: FormDat
 }
 
 export async function forceUpdateAgent(agentId: string): Promise<{ ok: boolean; error?: string }> {
+  await requireAdmin() // admin only
   try {
     const port = process.env['PORT'] ?? '3000'
     const res  = await fetch(`http://127.0.0.1:${port}/api/agents/${agentId}/force-update`, { method: 'POST' })

--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -3,6 +3,7 @@
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { getDb, alerts, alertChannels, eq } from '@backupos/db'
+import { requireAdmin } from '@/lib/user'
 
 const VALID_CHANNEL_TYPES = [
   'discord', 'slack', 'webhook',
@@ -67,6 +68,7 @@ export async function snoozeAlert(id: string, hours: number): Promise<void> {
 }
 
 export async function createAlertChannel(formData: FormData): Promise<void> {
+  await requireAdmin() // admin only
   const name = str(formData, 'name')
   const type = str(formData, 'type')
 
@@ -89,6 +91,7 @@ export async function createAlertChannel(formData: FormData): Promise<void> {
 }
 
 export async function deleteAlertChannel(id: string): Promise<void> {
+  await requireAdmin() // admin only
   if (!id) return
   const db = getDb()
   await db.delete(alertChannels).where(eq(alertChannels.id, id))

--- a/apps/web/app/actions/api-tokens.ts
+++ b/apps/web/app/actions/api-tokens.ts
@@ -4,8 +4,10 @@ import { revalidatePath } from 'next/cache'
 import { randomBytes, createHash } from 'crypto'
 import { getDb, apiTokens, eq } from '@backupos/db'
 import { headers } from 'next/headers'
+import { requireAdmin } from '@/lib/user'
 
 export async function createApiToken(formData: FormData): Promise<{ token?: string; id?: string; error?: string }> {
+  await requireAdmin() // admin only
   const { auth } = await import('@/lib/auth')
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session) return { error: 'Not authenticated' }
@@ -37,6 +39,7 @@ export async function createApiToken(formData: FormData): Promise<{ token?: stri
 }
 
 export async function revokeApiToken(id: string) {
+  await requireAdmin() // admin only
   const db = getDb()
   await db.delete(apiTokens).where(eq(apiTokens.id, id))
   revalidatePath('/settings/api-tokens')

--- a/apps/web/app/actions/bandwidth.ts
+++ b/apps/web/app/actions/bandwidth.ts
@@ -4,8 +4,10 @@ import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { getDb, bandwidthProfiles, bandwidthRules, backupJobs } from '@backupos/db'
 import { eq } from '@backupos/db'
+import { requireAdmin } from '@/lib/user'
 
 export async function createProfile(formData: FormData): Promise<void> {
+  await requireAdmin()
   const name        = (formData.get('name') as string).trim()
   const description = (formData.get('description') as string | null)?.trim() || null
   const isGlobal    = formData.get('isGlobal') === 'on'
@@ -32,6 +34,7 @@ export async function createProfile(formData: FormData): Promise<void> {
 }
 
 export async function deleteProfile(id: string): Promise<void> {
+  await requireAdmin()
   const db = getDb()
   await db.update(backupJobs)
     .set({ bandwidthProfileId: null })
@@ -44,6 +47,7 @@ export async function deleteProfile(id: string): Promise<void> {
 }
 
 export async function addRule(profileId: string, formData: FormData): Promise<void> {
+  await requireAdmin()
   const startHour = parseInt(formData.get('startHour') as string, 10)
   const endHour   = parseInt(formData.get('endHour')   as string, 10)
   const limitRaw  = (formData.get('limitKbps') as string).trim()
@@ -66,6 +70,7 @@ export async function addRule(profileId: string, formData: FormData): Promise<vo
 }
 
 export async function deleteRule(id: string): Promise<void> {
+  await requireAdmin()
   const db = getDb()
   await db.delete(bandwidthRules).where(eq(bandwidthRules.id, id)).run()
   revalidatePath('/settings/bandwidth')
@@ -73,6 +78,7 @@ export async function deleteRule(id: string): Promise<void> {
 }
 
 export async function setJobProfile(jobId: string, formData: FormData): Promise<void> {
+  await requireAdmin()
   const profileId = (formData.get('profileId') as string) || null
   const db = getDb()
   await db.update(backupJobs)

--- a/apps/web/app/actions/escrow.ts
+++ b/apps/web/app/actions/escrow.ts
@@ -4,8 +4,10 @@ import { revalidatePath } from 'next/cache'
 import { getDb, repositories } from '@backupos/db'
 import { eq } from '@backupos/db'
 import { encryptPassword, decryptPassword } from '@/lib/escrow'
+import { requireAdmin } from '@/lib/user'
 
 export async function setEscrow(repoId: string, formData: FormData): Promise<{ error?: string }> {
+  await requireAdmin()
   const password   = ((formData.get('password')   ?? '') as string).trim()
   const passphrase = (formData.get('passphrase')  ?? '') as string             // no trim — spaces are valid
   const confirm    = (formData.get('confirm')     ?? '') as string             // no trim — match raw input
@@ -22,17 +24,20 @@ export async function setEscrow(repoId: string, formData: FormData): Promise<{ e
 }
 
 export async function setEscrowAction(repoId: string, formData: FormData): Promise<void> {
+  await requireAdmin()
   const result = await setEscrow(repoId, formData)
   if (result.error) throw new Error(result.error)
 }
 
 export async function clearEscrow(repoId: string): Promise<void> {
+  await requireAdmin()
   const db = getDb()
   await db.update(repositories).set({ escrowedKey: null }).where(eq(repositories.id, repoId)).run()
   revalidatePath(`/repositories/${repoId}`)
 }
 
 export async function recoverPassword(repoId: string, formData: FormData): Promise<{ password?: string; error?: string }> {
+  await requireAdmin()
   const passphrase = (formData.get('passphrase') ?? '') as string  // no trim
   if (!passphrase) return { error: 'Recovery passphrase is required.' }
 

--- a/apps/web/app/actions/hypervisors.ts
+++ b/apps/web/app/actions/hypervisors.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache'
 import { getDb, hypervisorIntegrations, hypervisorTargets, eq } from '@backupos/db'
 import { ProxmoxHypervisorDriver, XCPNGHypervisorDriver, VMwareHypervisorDriver } from '@backupos/hypervisors'
 import type { ProxmoxConfig, XCPNGConfig, VMwareConfig } from '@backupos/hypervisors'
+import { requireAdmin } from '@/lib/user'
 
 type DiscoverResult = { ok: boolean; count?: number; error?: string }
 
@@ -20,6 +21,7 @@ type TargetRow = {
 }
 
 export async function discoverHypervisorTargets(integrationId: string): Promise<DiscoverResult> {
+  await requireAdmin()
   const db = getDb()
   const [integration] = await db
     .select()

--- a/apps/web/app/actions/infra-os.ts
+++ b/apps/web/app/actions/infra-os.ts
@@ -5,8 +5,10 @@ import { revalidatePath } from 'next/cache'
 import { getDb, infraOsServices, backupJobs } from '@backupos/db'
 import { eq } from '@backupos/db'
 import { randomUUID } from 'crypto'
+import { requireAdmin } from '@/lib/user'
 
 export async function addInfraService(formData: FormData): Promise<{ error?: string }> {
+  await requireAdmin()
   const name        = ((formData.get('name')        ?? '') as string).trim()
   const serviceType = ((formData.get('serviceType') ?? '') as string).trim()
   const host        = ((formData.get('host')        ?? '') as string).trim()
@@ -31,12 +33,14 @@ export async function addInfraService(formData: FormData): Promise<{ error?: str
 }
 
 export async function addInfraServiceAction(formData: FormData): Promise<void> {
+  await requireAdmin()
   const result = await addInfraService(formData)
   if (result.error) throw new Error(result.error)
   redirect('/settings/infra-os?saved=1')
 }
 
 export async function removeInfraService(id: string): Promise<void> {
+  await requireAdmin()
   const db = getDb()
   await db.update(backupJobs).set({ infraServiceId: null }).where(eq(backupJobs.infraServiceId, id)).run()
   await db.delete(infraOsServices).where(eq(infraOsServices.id, id)).run()

--- a/apps/web/app/actions/invite.ts
+++ b/apps/web/app/actions/invite.ts
@@ -5,7 +5,7 @@ import { randomBytes }              from 'crypto'
 import { getDb, invite, user }      from '@backupos/db'
 import { eq, and, isNull }          from '@backupos/db'
 import { auth }                     from '@/lib/auth'
-import { getCurrentUser }           from '@/lib/user'
+import { getCurrentUser, requireAdmin } from '@/lib/user'
 import { sendInviteEmail }          from '@/lib/mailer'
 import { appendAuditEntry }         from '@/lib/audit'
 
@@ -22,6 +22,8 @@ export async function createInvite(
 
   const email = (formData.get('email') as string | null)?.trim()
   const name  = (formData.get('name')  as string | null)?.trim() || null
+  const rawRole = (formData.get('role') as string | null)?.trim()
+  const role  = rawRole === 'admin' ? 'admin' : 'viewer'
 
   if (!email) return { error: 'Email is required' }
 
@@ -35,6 +37,7 @@ export async function createInvite(
     email,
     name,
     token,
+    role,
     createdBy: currentUser.id,
     expiresAt: now + 7 * 24 * 60 * 60 * 1000,
     usedAt:    null,
@@ -69,7 +72,7 @@ export async function acceptInvite(
   const now = Date.now()
 
   const [row] = await db
-    .select()
+    .select({ email: invite.email, name: invite.name, token: invite.token, role: invite.role, usedAt: invite.usedAt, expiresAt: invite.expiresAt })
     .from(invite)
     .where(eq(invite.token, token))
     .limit(1)
@@ -90,6 +93,12 @@ export async function acceptInvite(
     await db.update(invite).set({ usedAt: null }).where(eq(invite.token, token))
     const msg = err instanceof Error ? err.message : 'Could not create account'
     return { error: msg }
+  }
+
+  // Apply the role stored on the invite (defaults to 'viewer')
+  const inviteRole = row.role ?? 'viewer'
+  if (inviteRole !== 'admin') {
+    await db.update(user).set({ role: inviteRole }).where(eq(user.email, row.email))
   }
 
   return { email: row.email }
@@ -128,9 +137,11 @@ export async function createUserDirect(formData: FormData): Promise<{
   if (!currentUser) return { error: 'Not authenticated' }
   if (currentUser.role !== 'admin') return { error: 'Admin role required to create users' }
 
-  const name  = (formData.get('name')  as string | null)?.trim() || ''
-  const email = (formData.get('email') as string | null)?.trim() || ''
-  const rawPw = (formData.get('password') as string | null)?.trim() || null
+  const name    = (formData.get('name')     as string | null)?.trim() || ''
+  const email   = (formData.get('email')    as string | null)?.trim() || ''
+  const rawPw   = (formData.get('password') as string | null)?.trim() || null
+  const rawRole = (formData.get('role')     as string | null)?.trim()
+  const role    = rawRole === 'admin' ? 'admin' : 'viewer'
 
   if (!name)  return { error: 'Name is required' }
   if (!email) return { error: 'Email is required' }
@@ -147,7 +158,7 @@ export async function createUserDirect(formData: FormData): Promise<{
   const db  = getDb()
   const now = new Date()
 
-  await db.update(user).set({ emailVerified: true, updatedAt: now }).where(eq(user.email, email))
+  await db.update(user).set({ emailVerified: true, role, updatedAt: now }).where(eq(user.email, email))
 
   const [created] = await db
     .select({ id: user.id, name: user.name, email: user.email, createdAt: user.createdAt })
@@ -172,6 +183,26 @@ export async function createUserDirect(formData: FormData): Promise<{
     createdAt:   created.createdAt?.getTime() ?? Date.now(),
     tempPassword: isAutoGenPw ? password : undefined,
   }
+}
+
+export async function updateUserRole(userId: string, role: 'admin' | 'viewer'): Promise<{ error?: string }> {
+  const admin = await requireAdmin()
+  if (userId === admin.id) return { error: 'Cannot change your own role' }
+  if (role !== 'admin' && role !== 'viewer') return { error: 'Invalid role' }
+
+  const db = getDb()
+  await db.update(user).set({ role }).where(eq(user.id, userId))
+
+  appendAuditEntry({
+    action:       'user.role_changed',
+    resourceType: 'user',
+    resourceId:   userId,
+    actor:        admin.email,
+    detail:       { newRole: role, changedBy: admin.id },
+  })
+
+  revalidatePath('/settings/users')
+  return {}
 }
 
 // Used server-side by the signup page to validate + prefill the invite form.

--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -9,6 +9,7 @@ import { validateCron } from '@/lib/cron-validate'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 import { isWithinWindow } from '@/lib/schedule-window'
 import { appendLog } from '@/lib/logger'
+import { requireAdmin } from '@/lib/user'
 
 function parseSourceConfig(sourceType: string, fd: FormData): string {
   const str = (k: string) => (fd.get(k) as string | null)?.trim() || undefined
@@ -57,6 +58,7 @@ function parseSourceConfig(sourceType: string, fd: FormData): string {
 }
 
 export async function createJob(formData: FormData): Promise<void> {
+  await requireAdmin() // admin only
   const name           = (formData.get('name')           as string)?.trim()
   const sourceType     = (formData.get('sourceType')     as string)
   const agentId        = (formData.get('agentId')        as string) || null
@@ -96,6 +98,7 @@ export async function createJob(formData: FormData): Promise<void> {
 }
 
 export async function pauseJobs(ids: string[]): Promise<void> {
+  await requireAdmin() // admin only
   if (!ids.length) return
   const db = getDb()
   await db.update(backupJobs).set({ enabled: false }).where(inArray(backupJobs.id, ids))
@@ -103,6 +106,7 @@ export async function pauseJobs(ids: string[]): Promise<void> {
 }
 
 export async function resumeJobs(ids: string[]): Promise<void> {
+  await requireAdmin() // admin only
   if (!ids.length) return
   const db = getDb()
   await db.update(backupJobs).set({ enabled: true }).where(inArray(backupJobs.id, ids))
@@ -110,6 +114,7 @@ export async function resumeJobs(ids: string[]): Promise<void> {
 }
 
 export async function deleteJobs(ids: string[]): Promise<void> {
+  await requireAdmin() // admin only
   if (!ids.length) return
   const db = getDb()
   await db.delete(backupRuns).where(inArray(backupRuns.jobId, ids))
@@ -181,6 +186,7 @@ export async function triggerJob(id: string): Promise<void> {
 }
 
 export async function updateJob(id: string, formData: FormData): Promise<void> {
+  await requireAdmin() // admin only
   const name         = (formData.get('name')         as string)?.trim()
   const sourceType   = (formData.get('sourceType')   as string)
   const agentId      = (formData.get('agentId')      as string) || null
@@ -389,6 +395,7 @@ export async function cancelJob(jobId: string): Promise<void> {
 }
 
 export async function saveJobRetention(id: string, formData: FormData): Promise<void> {
+  await requireAdmin() // admin only
   const parse = (key: string) => {
     const v = parseInt(formData.get(key) as string, 10)
     return isNaN(v) || v === 0 ? null : v

--- a/apps/web/app/actions/logging-config.ts
+++ b/apps/web/app/actions/logging-config.ts
@@ -2,6 +2,7 @@
 
 import { redirect }             from 'next/navigation'
 import { getDb, loggingConfig } from '@backupos/db'
+import { requireAdmin } from '@/lib/user'
 
 const ACTIVITY_OPTIONS = ['30d', '90d', '180d', '365d', 'forever'] as const
 const AUDIT_OPTIONS    = ['90d', '365d', '3y', '7y', 'forever']    as const
@@ -32,6 +33,7 @@ export async function getLoggingConfig(): Promise<LoggingConfigValues> {
 }
 
 export async function saveLoggingConfig(formData: FormData): Promise<void> {
+  await requireAdmin()
   const activityRetention = (formData.get('activityRetention') ?? '') as string
   const auditRetention    = (formData.get('auditRetention')    ?? '') as string
   const opsRetention      = (formData.get('opsRetention')      ?? '') as string

--- a/apps/web/app/actions/monitors.ts
+++ b/apps/web/app/actions/monitors.ts
@@ -5,8 +5,10 @@ import { redirect } from 'next/navigation'
 import { getDb, backupMonitors, repositories, eq } from '@backupos/db'
 import { type PBSConfig } from '@backupos/monitors'
 import { performMonitorSync } from '@/lib/monitors'
+import { requireAdmin } from '@/lib/user'
 
 export async function promoteMonitorToRepo(monitorId: string, formData: FormData): Promise<void> {
+  await requireAdmin() // admin only
   const password = (formData.get('password') as string)?.trim()
   if (!password) return
 
@@ -38,6 +40,7 @@ export async function promoteMonitorToRepo(monitorId: string, formData: FormData
 }
 
 export async function createMonitor(formData: FormData): Promise<void> {
+  await requireAdmin() // admin only
   const name   = (formData.get('name')   as string)?.trim()
   const type   = (formData.get('type')   as string)
   const url    = (formData.get('url')    as string)?.trim()
@@ -87,6 +90,7 @@ export async function testMonitorConnection(url: string): Promise<{ ok: boolean;
 }
 
 export async function updateMonitor(id: string, formData: FormData): Promise<{ error: string } | void> {
+  await requireAdmin() // admin only
   const name   = (formData.get('name')   as string)?.trim()
   const url    = (formData.get('url')    as string)?.trim()
   const apiKey = (formData.get('apiKey') as string)?.trim() || null
@@ -114,6 +118,7 @@ export async function updateMonitor(id: string, formData: FormData): Promise<{ e
 }
 
 export async function deleteMonitor(id: string): Promise<void> {
+  await requireAdmin() // admin only
   const db = getDb()
   await db.delete(backupMonitors).where(eq(backupMonitors.id, id))
   redirect('/monitors')

--- a/apps/web/app/actions/preflight.ts
+++ b/apps/web/app/actions/preflight.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache'
 import { getDb, backupJobs, backupRuns, agents, repositories } from '@backupos/db'
 import { eq, desc } from '@backupos/db'
 import { runPreflightChecks, overallStatus, CheckResult } from '@/lib/preflight'
+import { requireAdmin } from '@/lib/user'
 
 export async function runPreflight(jobId: string): Promise<CheckResult[]> {
   const db  = getDb()
@@ -53,6 +54,7 @@ export async function runPreflight(jobId: string): Promise<CheckResult[]> {
 }
 
 export async function togglePreflight(jobId: string, formData: FormData): Promise<void> {
+  await requireAdmin()
   const enabled = formData.get('preflightEnabled') === 'on'
   const db = getDb()
   await db.update(backupJobs)

--- a/apps/web/app/actions/repositories.ts
+++ b/apps/web/app/actions/repositories.ts
@@ -5,6 +5,7 @@ import { redirect }                 from 'next/navigation'
 import { getDb, repositories, backupJobs, backupDefaults, eq, and } from '@backupos/db'
 import { ResticEngine }             from '@backupos/engine'
 import { encryptField, decryptField } from '@/lib/repo-crypto'
+import { requireAdmin } from '@/lib/user'
 
 function parseRepoConfig(raw: string): Record<string, string> {
   return JSON.parse(decryptField(raw)) as Record<string, string>
@@ -21,6 +22,7 @@ function parseSmbSharePath(raw: string): { host: string; remotePath: string } | 
 }
 
 export async function createRepository(formData: FormData): Promise<{ error: string } | never> {
+  await requireAdmin() // admin only
   const name     = (formData.get('name') as string)?.trim()
   const backend  = formData.get('backend') as string
   const password = formData.get('password') as string
@@ -129,6 +131,7 @@ export async function createRepository(formData: FormData): Promise<{ error: str
 }
 
 export async function updateRepository(id: string, formData: FormData): Promise<{ error: string } | undefined> {
+  await requireAdmin() // admin only
   const name     = (formData.get('name') as string)?.trim()
   const password = (formData.get('password') as string)?.trim()
   const group    = (formData.get('group') as string)?.trim() || null
@@ -235,6 +238,7 @@ export async function updateRepository(id: string, formData: FormData): Promise<
 }
 
 export async function deleteRepository(id: string): Promise<{ error: string } | undefined> {
+  await requireAdmin() // admin only
   const db = getDb()
   await db.delete(backupJobs).where(eq(backupJobs.repositoryId, id))
   await db.delete(repositories).where(eq(repositories.id, id))
@@ -393,6 +397,7 @@ export async function pruneRepository(repoId: string): Promise<{
   jobsProcessed?: number
   error?: string
 }> {
+  await requireAdmin() // admin only
   const db     = getDb()
   const [repo] = await db.select().from(repositories).where(eq(repositories.id, repoId)).limit(1)
   if (!repo) return { ok: false, error: 'Repository not found' }

--- a/apps/web/app/actions/repository-cost.ts
+++ b/apps/web/app/actions/repository-cost.ts
@@ -3,8 +3,10 @@
 import { revalidatePath } from 'next/cache'
 import { getDb, repositories } from '@backupos/db'
 import { eq } from '@backupos/db'
+import { requireAdmin } from '@/lib/user'
 
 export async function saveCostConfig(repoId: string, formData: FormData): Promise<void> {
+  await requireAdmin()
   const costStr   = ((formData.get('costPerGbMonth')    ?? '') as string).trim()
   const budgetStr = ((formData.get('monthlyBudgetCents') ?? '') as string).trim()
 

--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, eq, desc } from '@backupos/db'
 import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult } from '@backupos/restore'
+import { requireAdmin } from '@/lib/user'
 
 export async function validateSpec(yaml: string): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
@@ -15,6 +16,7 @@ export async function validateSpec(yaml: string): Promise<{ ok: true } | { ok: f
 }
 
 export async function createSpec(name: string, yaml: string): Promise<{ error: string } | never> {
+  await requireAdmin() // admin only
   if (!name.trim()) return { error: 'Name is required' }
 
   const validation = await validateSpec(yaml)
@@ -34,6 +36,7 @@ export async function createSpec(name: string, yaml: string): Promise<{ error: s
 }
 
 export async function updateSpec(id: string, name: string, yaml: string): Promise<{ error: string } | never> {
+  await requireAdmin() // admin only
   if (!name.trim()) return { error: 'Name is required' }
 
   const validation = await validateSpec(yaml)
@@ -50,6 +53,7 @@ export async function updateSpec(id: string, name: string, yaml: string): Promis
 }
 
 export async function forkSpec(name: string, yamlContent: string): Promise<void> {
+  await requireAdmin() // admin only
   const db = getDb()
   const id = crypto.randomUUID()
   await db.insert(restoreSpecs).values({

--- a/apps/web/app/actions/settings.ts
+++ b/apps/web/app/actions/settings.ts
@@ -4,8 +4,10 @@ import { redirect } from 'next/navigation'
 import nodemailer from 'nodemailer'
 import { getDb, instanceSettings, smtpConfig, backupDefaults } from '@backupos/db'
 import { encryptField, decryptField } from '@/lib/repo-crypto'
+import { requireAdmin } from '@/lib/user'
 
 export async function saveInstanceSettings(formData: FormData) {
+  await requireAdmin() // admin only
   const db = getDb()
   const rawUrl = String(formData.get('serverPublicUrl') ?? '').trim()
   // Validate URL if provided: must be http:// or https://
@@ -22,6 +24,7 @@ export async function saveInstanceSettings(formData: FormData) {
 }
 
 export async function saveSmtpConfig(formData: FormData) {
+  await requireAdmin() // admin only
   const db = getDb()
   const rawPassword = (formData.get('password') as string | null) ?? ''
 
@@ -60,6 +63,7 @@ export async function saveSmtpConfig(formData: FormData) {
 }
 
 export async function saveBackupDefaults(formData: FormData) {
+  await requireAdmin() // admin only
   const db = getDb()
   const values = {
     keepLast:      Number(formData.get('keepLast') ?? 10),

--- a/apps/web/app/actions/snapshots.ts
+++ b/apps/web/app/actions/snapshots.ts
@@ -3,14 +3,17 @@
 import { revalidatePath } from 'next/cache'
 import { getDb, snapshots } from '@backupos/db'
 import { eq } from '@backupos/db'
+import { requireAdmin } from '@/lib/user'
 
 export async function pinSnapshot(id: string, pinned: boolean): Promise<void> {
+  await requireAdmin()
   const db = getDb()
   await db.update(snapshots).set({ pinned }).where(eq(snapshots.id, id)).run()
   revalidatePath('/snapshots')
 }
 
 export async function addCustomTag(id: string, tag: string): Promise<void> {
+  await requireAdmin()
   const trimmed = tag.trim().toLowerCase().replace(/[^a-z0-9-_]/g, '')
   if (!trimmed) return
 
@@ -31,6 +34,7 @@ export async function addCustomTag(id: string, tag: string): Promise<void> {
 }
 
 export async function removeCustomTag(id: string, tag: string): Promise<void> {
+  await requireAdmin()
   const db = getDb()
   await db.transaction(async tx => {
     const snapshot = await tx.select({ customTags: snapshots.customTags })
@@ -46,6 +50,7 @@ export async function removeCustomTag(id: string, tag: string): Promise<void> {
 }
 
 export async function setRetentionHold(id: string, reason: string, expiresAt: Date | null): Promise<void> {
+  await requireAdmin()
   const db = getDb()
   await db.update(snapshots)
     .set({ retentionHold: true, holdReason: reason.trim() || null, holdExpiresAt: expiresAt })
@@ -54,6 +59,7 @@ export async function setRetentionHold(id: string, reason: string, expiresAt: Da
 }
 
 export async function clearRetentionHold(id: string): Promise<void> {
+  await requireAdmin()
   const db = getDb()
   await db.update(snapshots)
     .set({ retentionHold: false, holdReason: null, holdExpiresAt: null })

--- a/apps/web/app/actions/verification.ts
+++ b/apps/web/app/actions/verification.ts
@@ -7,6 +7,7 @@ import { decryptField } from '@/lib/repo-crypto'
 import { dispatchToAgent } from '@/lib/internal-dispatch'
 import { connectedAgentIds } from '@/lib/ws-state'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
+import { requireAdmin } from '@/lib/user'
 
 export async function createVerificationTest(data: {
   name: string
@@ -15,6 +16,7 @@ export async function createVerificationTest(data: {
   validationHook: string
   schedule: string
 }): Promise<void> {
+  await requireAdmin() // admin only
   const { name, jobId, targetType, validationHook, schedule } = data
   if (!name || !jobId || !targetType || !schedule) return
 

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -14,6 +14,7 @@ export type AuditAction =
   | 'api_token.created' | 'api_token.revoked'
   | 'settings.updated'
   | 'user.created'
+  | 'user.role_changed'
 
 function canonical(fields: {
   action: string; resourceType: string; resourceId?: string | null;

--- a/apps/web/lib/user.ts
+++ b/apps/web/lib/user.ts
@@ -1,4 +1,5 @@
 import { headers }                   from 'next/headers'
+import { redirect }                  from 'next/navigation'
 import { auth }                      from './auth'
 import { getDb, user as userTable }  from '@backupos/db'
 import { eq }                        from '@backupos/db'
@@ -12,4 +13,15 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
   const db    = getDb()
   const [row] = await db.select({ role: userTable.role }).from(userTable).where(eq(userTable.id, session.user.id)).limit(1).all()
   return { ...session.user, role: row?.role ?? 'admin' }
+}
+
+export async function requireAdmin(): Promise<AuthUser> {
+  const u = await getCurrentUser()
+  if (!u) redirect('/login')
+  if (u.role !== 'admin') throw new Error('Forbidden: admin role required')
+  return u
+}
+
+export function isAdmin(u: AuthUser | null): boolean {
+  return u?.role === 'admin'
 }

--- a/packages/db/migrations/0038_invite_role.sql
+++ b/packages/db/migrations/0038_invite_role.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `invite` ADD `role` text NOT NULL DEFAULT 'viewer';

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1746921600000,
       "tag": "0037_backfill_snapshots",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "6",
+      "when": 1747008000000,
+      "tag": "0038_invite_role",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -598,6 +598,7 @@ export const invite = sqliteTable('invite', {
   email:     text('email').notNull(),
   name:      text('name'),
   token:     text('token').notNull().unique(),
+  role:      text('role').notNull().default('viewer'),
   createdBy: text('created_by').notNull().references(() => user.id, { onDelete: 'cascade' }),
   expiresAt: integer('expires_at').notNull(),
   usedAt:    integer('used_at'),


### PR DESCRIPTION
## Summary

- Adds `requireAdmin()` / `isAdmin()` helpers; all destructive server actions (jobs, repos, agents, settings, alerts, monitors, verification, api-tokens, restore) now throw `Forbidden` for non-admins
- New `updateUserRole()` action with self-demotion guard and `user.role_changed` audit log entry
- Invite table gains a `role` column (migration 0038); `createInvite`, `createUserDirect`, and `acceptInvite` all propagate the role to the created user
- Users settings page: role-change dropdown for admins, view-only banner for viewers, admin-gated invite/create buttons
- Delete repository button is hidden entirely for viewer-role users

## Test plan

- [ ] Log in as admin — all destructive buttons visible, role dropdowns present on Users page
- [ ] Log in as viewer — destructive buttons hidden, view-only banner shown, server actions return `Forbidden` if called directly
- [ ] Change a user's role via dropdown, confirm audit log entry
- [ ] Create an invite with role=admin, accept it, confirm user lands as admin
- [ ] Attempt self-demotion via `updateUserRole` — should return error
- [ ] Run migration on a fresh DB and confirm `invite.role` column exists with default `viewer`

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)