### PR TITLE
feat(integrations): full per-integration UX — 9 channels, setup guides, test button (#93)

### DIFF
--- a/apps/web/app/(dashboard)/settings/integrations/[type]/IntegrationAddForm.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/[type]/IntegrationAddForm.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import type { ConfigField } from '@/lib/integrations'
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', padding: '7px 10px', fontSize: 13, boxSizing: 'border-box',
+  backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none',
+}
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 12, color: 'var(--fg-dim)', display: 'block', marginBottom: 4,
+}
+
+interface Props {
+  configFields: ConfigField[]
+  addAction:    (formData: FormData) => Promise<void>
+}
+
+export function IntegrationAddForm({ configFields, addAction }: Props) {
+  return (
+    <form action={addAction} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div>
+        <label style={labelStyle}>Channel name</label>
+        <input name="name" required placeholder="e.g. Ops alerts" style={inputStyle} />
+      </div>
+
+      {configFields.map(field => (
+        <div key={field.name}>
+          <label style={labelStyle}>
+            {field.label}{!field.required && ' (optional)'}
+          </label>
+          {field.helpText && (
+            <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginBottom: 4 }}>
+              {field.helpText}
+            </div>
+          )}
+          <input
+            name={field.name}
+            type={field.type}
+            placeholder={field.placeholder}
+            required={field.required}
+            style={inputStyle}
+          />
+        </div>
+      ))}
+
+      <button
+        type="submit"
+        style={{
+          alignSelf: 'flex-start', padding: '7px 18px', fontSize: 13, fontWeight: 500,
+          borderRadius: 'var(--radius-sm)', border: 'none',
+          background: 'var(--accent)', color: '#fff', cursor: 'pointer',
+        }}
+      >
+        Add channel
+      </button>
+    </form>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/integrations/[type]/SendTestButton.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/[type]/SendTestButton.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { sendTestAlert } from '@/app/actions/alerts'
+
+export function SendTestButton({ channelId }: { channelId: string }) {
+  const [isPending, start] = useTransition()
+  const [result, setResult] = useState<{ ok: boolean; error?: string } | null>(null)
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <button
+        disabled={isPending}
+        onClick={() => {
+          setResult(null)
+          start(async () => {
+            const r = await sendTestAlert(channelId)
+            setResult(r)
+          })
+        }}
+        style={{
+          padding: '4px 12px', fontSize: 12,
+          cursor: isPending ? 'not-allowed' : 'pointer',
+          borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+          background: 'var(--surf2)', color: 'var(--fg)',
+        }}
+      >
+        {isPending ? 'Sending…' : 'Send test'}
+      </button>
+      {result && (
+        <span style={{ fontSize: 12, color: result.ok ? 'var(--ok)' : 'var(--err)' }}>
+          {result.ok ? 'Sent ✓' : `Failed: ${result.error}`}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/integrations/[type]/page.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/[type]/page.tsx
@@ -1,0 +1,157 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { getDb, alertChannels, eq } from '@backupos/db'
+import { INTEGRATIONS_REGISTRY } from '@/lib/integrations'
+import { createAlertChannelForType, deleteAlertChannelForType } from '@/app/actions/alerts'
+import { IntegrationAddForm } from './IntegrationAddForm'
+import { SendTestButton } from './SendTestButton'
+
+export default async function IntegrationDetailPage({ params }: { params: Promise<{ type: string }> }) {
+  const { type } = await params
+  const integ = INTEGRATIONS_REGISTRY.find(i => i.type === type)
+  if (!integ) notFound()
+
+  const db       = getDb()
+  const channels = await db.select().from(alertChannels).where(eq(alertChannels.type, type)).all()
+
+  const addAction    = createAlertChannelForType.bind(null, integ.type)
+
+  return (
+    <div style={{ maxWidth: 580 }}>
+      {/* Breadcrumb */}
+      <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 24, fontSize: 13, color: 'var(--fg-dim)' }}>
+        <a href="/settings" style={{ color: 'var(--fg-dim)', textDecoration: 'none' }}>Settings</a>
+        <span>›</span>
+        <a href="/settings/integrations" style={{ color: 'var(--fg-dim)', textDecoration: 'none' }}>Integrations</a>
+        <span>›</span>
+        <span style={{ color: 'var(--fg)' }}>{integ.name}</span>
+      </div>
+
+      {/* Header */}
+      <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginBottom: 6 }}>{integ.name}</h1>
+      <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginBottom: 28, lineHeight: 1.5 }}>
+        {integ.description}
+      </p>
+
+      {/* Setup guide */}
+      <div style={{
+        backgroundColor: 'var(--surf)', border: '1px solid var(--border)',
+        borderRadius: 'var(--radius)', padding: '20px 24px', marginBottom: 20,
+      }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', marginBottom: 14 }}>Setup guide</div>
+        <ol style={{ margin: 0, paddingLeft: 20, display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {integ.setupSteps.map((step, i) => (
+            <li key={i} style={{ fontSize: 13, color: 'var(--fg-mute)', lineHeight: 1.55 }}>
+              {step}
+            </li>
+          ))}
+        </ol>
+        <a
+          href={integ.externalDocsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 4, marginTop: 14, fontSize: 12, color: 'var(--accent)', textDecoration: 'none' }}
+        >
+          {integ.name} documentation ↗
+        </a>
+      </div>
+
+      {/* Sample alert preview */}
+      <div style={{
+        backgroundColor: 'var(--surf)', border: '1px solid var(--border)',
+        borderRadius: 'var(--radius)', padding: '20px 24px', marginBottom: 20,
+      }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', marginBottom: 14 }}>Sample alert preview</div>
+        <p style={{ fontSize: 12, color: 'var(--fg-dim)', marginBottom: 12 }}>
+          This is how a <code style={{ fontSize: 11, fontFamily: 'var(--font-mono)', backgroundColor: 'var(--surf2)', padding: '1px 5px', borderRadius: 3 }}>backup_failed</code> alert appears in {integ.name}.
+        </p>
+        <div style={{
+          backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-sm)', padding: '12px 16px',
+          fontFamily: 'var(--font-mono)', fontSize: 12,
+        }}>
+          <div style={{ fontWeight: 600, color: 'var(--fg)', marginBottom: 4 }}>{integ.samplePayload.title}</div>
+          <div style={{ color: 'var(--fg-mute)', lineHeight: 1.5, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+            {integ.samplePayload.body}
+          </div>
+          {integ.samplePayload.footer && (
+            <div style={{ marginTop: 8, fontSize: 11, color: 'var(--fg-dim)', borderTop: '1px solid var(--border)', paddingTop: 8 }}>
+              {integ.samplePayload.footer}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Connected channels */}
+      <div style={{
+        backgroundColor: 'var(--surf)', border: '1px solid var(--border)',
+        borderRadius: 'var(--radius)', marginBottom: 20,
+      }}>
+        <div style={{ padding: '14px 20px', borderBottom: '1px solid var(--border2)', fontSize: 14, fontWeight: 600, color: 'var(--fg)' }}>
+          Connected channels ({channels.length})
+        </div>
+
+        {channels.length === 0 ? (
+          <div style={{ padding: '28px 20px', textAlign: 'center', fontSize: 13, color: 'var(--fg-dim)' }}>
+            No {integ.name} channels configured yet.
+          </div>
+        ) : (
+          channels.map(ch => {
+            const deleteAction = deleteAlertChannelForType.bind(null, ch.id, integ.type)
+            let subtitle = ''
+            try {
+              const cfg = JSON.parse(ch.config) as Record<string, string>
+              if (cfg.url)            subtitle = cfg.url.slice(0, 50) + (cfg.url.length > 50 ? '…' : '')
+              else if (cfg.chatId)    subtitle = `chat ${cfg.chatId}`
+              else if (cfg.stream)    subtitle = `stream: ${cfg.stream}`
+              else if (cfg.userKey)   subtitle = `user ${cfg.userKey.slice(0, 16)}…`
+              else if (cfg.integrationKey) subtitle = cfg.integrationKey.slice(0, 12) + '…'
+            } catch { /* ignore */ }
+
+            return (
+              <div key={ch.id} style={{
+                padding: '14px 20px', borderTop: '1px solid var(--border)',
+                display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12,
+              }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)' }}>{ch.name}</div>
+                  {subtitle && (
+                    <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {subtitle}
+                    </div>
+                  )}
+                  <div style={{ marginTop: 6 }}>
+                    <SendTestButton channelId={ch.id} />
+                  </div>
+                </div>
+                <form action={deleteAction} style={{ flexShrink: 0 }}>
+                  <button
+                    type="submit"
+                    style={{
+                      padding: '4px 12px', fontSize: 12, cursor: 'pointer',
+                      borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+                      background: 'var(--surf2)', color: 'var(--err)',
+                    }}
+                  >
+                    Remove
+                  </button>
+                </form>
+              </div>
+            )
+          })
+        )}
+      </div>
+
+      {/* Add channel */}
+      <div style={{
+        backgroundColor: 'var(--surf)', border: '1px solid var(--border)',
+        borderRadius: 'var(--radius)', padding: '20px 24px',
+      }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', marginBottom: 16 }}>
+          Add {integ.name} channel
+        </div>
+        <IntegrationAddForm configFields={integ.configFields} addAction={addAction} />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/integrations/page.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/page.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link'
+import { getDb, alertChannels } from '@backupos/db'
+import { INTEGRATIONS_REGISTRY } from '@/lib/integrations'
+
+export default async function IntegrationsPage() {
+  const db       = getDb()
+  const channels = await db.select({ type: alertChannels.type }).from(alertChannels).all()
+
+  const countByType: Record<string, number> = {}
+  for (const ch of channels) {
+    countByType[ch.type] = (countByType[ch.type] ?? 0) + 1
+  }
+
+  return (
+    <div style={{ maxWidth: 620 }}>
+      <a
+        href="/settings"
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--fg-dim)', textDecoration: 'none', marginBottom: 24 }}
+      >
+        ← Settings
+      </a>
+
+      <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginBottom: 6 }}>Integrations</h1>
+      <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginBottom: 28, lineHeight: 1.5 }}>
+        Connect BackupOS to your notification and incident management tools. Each integration is first-class with per-channel setup and test delivery.
+      </p>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 12 }}>
+        {INTEGRATIONS_REGISTRY.map(integ => {
+          const count = countByType[integ.type] ?? 0
+          return (
+            <Link
+              key={integ.type}
+              href={`/settings/integrations/${integ.type}`}
+              style={{ textDecoration: 'none' }}
+            >
+              <div style={{
+                backgroundColor: 'var(--surf)', border: '1px solid var(--border)',
+                borderRadius: 'var(--radius)', padding: '16px 20px',
+                cursor: 'pointer', transition: 'border-color 0.1s',
+                display: 'flex', flexDirection: 'column', gap: 8, height: '100%', boxSizing: 'border-box',
+              }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                  <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)' }}>{integ.name}</span>
+                  {count > 0 && (
+                    <span style={{
+                      fontSize: 11, fontWeight: 500,
+                      padding: '2px 8px', borderRadius: 'var(--radius-sm)',
+                      backgroundColor: 'color-mix(in srgb, var(--accent) 15%, transparent)',
+                      color: 'var(--accent)',
+                      border: '1px solid color-mix(in srgb, var(--accent) 30%, transparent)',
+                    }}>
+                      {count} channel{count !== 1 ? 's' : ''}
+                    </span>
+                  )}
+                </div>
+                <p style={{ fontSize: 12, color: 'var(--fg-mute)', margin: 0, lineHeight: 1.5 }}>
+                  {integ.description}
+                </p>
+                <span style={{ fontSize: 12, color: 'var(--accent)', marginTop: 'auto' }}>
+                  Configure →
+                </span>
+              </div>
+            </Link>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -6,8 +6,7 @@ import { Key } from 'lucide-react'
 const LINKED_ITEMS: Record<string, string> = {
   'General':            '/settings/general',
   'Email SMTP':         '/settings/smtp',
-  'Webhook URL':        '/settings/webhook',
-  'Slack integration':  '/settings/slack',
+  'Integrations':       '/settings/integrations',
   'Alert channels':     '/settings/alerts',
   'Users':              '/settings/users',
   'Change password':    '/settings/security',
@@ -47,7 +46,7 @@ export default async function SettingsPage() {
 
       {[
         { title: 'General', items: ['General'] },
-        { title: 'Notifications', items: ['Email SMTP', 'Webhook URL', 'Slack integration', 'Alert channels'] },
+        { title: 'Integrations', items: ['Email SMTP', 'Integrations', 'Alert channels'] },
         { title: 'Security', items: ['Users', 'Change password', 'API tokens', 'Session management'] },
         { title: 'Backup defaults', items: ['Retention policy', 'Bandwidth limits', 'Schedule windows', 'Infra OS services'] },
         { title: 'Logging', items: ['Logging'] },

--- a/apps/web/app/(dashboard)/settings/slack/page.tsx
+++ b/apps/web/app/(dashboard)/settings/slack/page.tsx
@@ -1,50 +1,5 @@
 import { redirect } from 'next/navigation'
-import Link from 'next/link'
-import { getCurrentUser } from '@/lib/user'
-import { getDb, alertChannels, eq } from '@backupos/db'
 
-export default async function SlackSettingsPage() {
-  const user = await getCurrentUser()
-  if (!user) redirect('/login')
-
-  const db = getDb()
-  const channels = await db.select().from(alertChannels)
-    .where(eq(alertChannels.type, 'slack')).all()
-
-  return (
-    <div style={{ maxWidth: 580 }}>
-      <a href="/settings" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--fg-dim)', textDecoration: 'none', marginBottom: 24 }}>← Settings</a>
-      <h1 style={{ fontSize: 20, fontWeight: 700, color: 'var(--fg)', marginBottom: 4 }}>Slack integration</h1>
-      <p style={{ fontSize: 13, color: 'var(--fg-dim)', marginBottom: 24 }}>
-        Slack channels are managed in Alert channels.{' '}
-        <Link href="/settings/alerts" style={{ color: 'var(--accent)', textDecoration: 'none' }}>Configure alert channels →</Link>
-      </p>
-
-      <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)', overflow: 'hidden' }}>
-        <div style={{ padding: '14px 20px', borderBottom: '1px solid var(--border2)', fontSize: 13, fontWeight: 600, color: 'var(--fg)' }}>
-          Active Slack channels ({channels.length})
-        </div>
-        {channels.length === 0 ? (
-          <div style={{ padding: '32px 20px', textAlign: 'center', color: 'var(--fg-dim)', fontSize: 13 }}>
-            No Slack channels configured.{' '}
-            <Link href="/settings/alerts" style={{ color: 'var(--accent)', textDecoration: 'none' }}>Add one in Alert channels.</Link>
-          </div>
-        ) : channels.map(ch => (
-          <div key={ch.id} style={{ padding: '12px 20px', borderTop: '1px solid var(--border2)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <div>
-              <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)' }}>{ch.name}</div>
-              <div style={{ fontSize: 11, color: 'var(--fg-faint)', marginTop: 2 }}>{ch.enabled ? 'Active' : 'Disabled'}</div>
-            </div>
-            <Link href="/settings/alerts" style={{ fontSize: 12, color: 'var(--accent)', textDecoration: 'none' }}>Manage →</Link>
-          </div>
-        ))}
-      </div>
-
-      <div style={{ marginTop: 16 }}>
-        <Link href="/settings/alerts" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '8px 16px', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)', borderRadius: 'var(--radius-sm)', fontSize: 13, fontWeight: 600, textDecoration: 'none' }}>
-          + Add Slack channel
-        </Link>
-      </div>
-    </div>
-  )
+export default function SlackSettingsPage() {
+  redirect('/settings/integrations/slack')
 }

--- a/apps/web/app/(dashboard)/settings/webhook/page.tsx
+++ b/apps/web/app/(dashboard)/settings/webhook/page.tsx
@@ -1,52 +1,5 @@
 import { redirect } from 'next/navigation'
-import Link from 'next/link'
-import { getCurrentUser } from '@/lib/user'
-import { getDb, alertChannels, eq } from '@backupos/db'
 
-export default async function WebhookSettingsPage() {
-  const user = await getCurrentUser()
-  if (!user) redirect('/login')
-
-  const db = getDb()
-  const channels = await db.select().from(alertChannels)
-    .where(eq(alertChannels.type, 'webhook')).all()
-
-  return (
-    <div style={{ maxWidth: 580 }}>
-      <a href="/settings" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--fg-dim)', textDecoration: 'none', marginBottom: 24 }}>← Settings</a>
-      <h1 style={{ fontSize: 20, fontWeight: 700, color: 'var(--fg)', marginBottom: 4 }}>Webhook URL</h1>
-      <p style={{ fontSize: 13, color: 'var(--fg-dim)', marginBottom: 24 }}>
-        Webhook channels are managed in Alert channels.{' '}
-        <Link href="/settings/alerts" style={{ color: 'var(--accent)', textDecoration: 'none' }}>Configure alert channels →</Link>
-      </p>
-
-      <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)', overflow: 'hidden' }}>
-        <div style={{ padding: '14px 20px', borderBottom: '1px solid var(--border2)', fontSize: 13, fontWeight: 600, color: 'var(--fg)' }}>
-          Active webhook channels ({channels.length})
-        </div>
-        {channels.length === 0 ? (
-          <div style={{ padding: '32px 20px', textAlign: 'center', color: 'var(--fg-dim)', fontSize: 13 }}>
-            No webhook channels configured.{' '}
-            <Link href="/settings/alerts" style={{ color: 'var(--accent)', textDecoration: 'none' }}>Add one in Alert channels.</Link>
-          </div>
-        ) : channels.map(ch => (
-          <div key={ch.id} style={{ padding: '12px 20px', borderTop: '1px solid var(--border2)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <div>
-              <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)' }}>{ch.name}</div>
-              <div style={{ fontSize: 11, color: 'var(--fg-faint)', marginTop: 2 }}>
-                {ch.enabled ? 'Active' : 'Disabled'}
-              </div>
-            </div>
-            <Link href="/settings/alerts" style={{ fontSize: 12, color: 'var(--accent)', textDecoration: 'none' }}>Manage →</Link>
-          </div>
-        ))}
-      </div>
-
-      <div style={{ marginTop: 16 }}>
-        <Link href="/settings/alerts" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '8px 16px', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)', borderRadius: 'var(--radius-sm)', fontSize: 13, fontWeight: 600, textDecoration: 'none' }}>
-          + Add webhook channel
-        </Link>
-      </div>
-    </div>
-  )
+export default function WebhookSettingsPage() {
+  redirect('/settings/integrations/webhook')
 }

--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { getDb, alerts, alertChannels, eq } from '@backupos/db'
 import { requireAdmin } from '@/lib/user'
+import { dispatchToChannel } from '@/lib/alerts'
 
 const VALID_CHANNEL_TYPES = [
   'discord', 'slack', 'webhook',
@@ -96,4 +97,47 @@ export async function deleteAlertChannel(id: string): Promise<void> {
   const db = getDb()
   await db.delete(alertChannels).where(eq(alertChannels.id, id))
   redirect('/settings/alerts?saved=1')
+}
+
+export async function createAlertChannelForType(integType: string, formData: FormData): Promise<void> {
+  await requireAdmin()
+  const name = str(formData, 'name')
+  if (!name) return
+  if (!(VALID_CHANNEL_TYPES as readonly string[]).includes(integType)) return
+  const config = buildConfig(integType, formData)
+  if (!config) return
+  const db = getDb()
+  await db.insert(alertChannels).values({
+    id: crypto.randomUUID(),
+    name,
+    type: integType,
+    config: JSON.stringify(config),
+    enabled: true,
+    createdAt: new Date(),
+  })
+  redirect(`/settings/integrations/${integType}?saved=1`)
+}
+
+export async function deleteAlertChannelForType(channelId: string, integType: string): Promise<void> {
+  await requireAdmin()
+  if (!channelId) return
+  const db = getDb()
+  await db.delete(alertChannels).where(eq(alertChannels.id, channelId))
+  redirect(`/settings/integrations/${integType}?saved=1`)
+}
+
+export async function sendTestAlert(channelId: string): Promise<{ ok: boolean; error?: string }> {
+  await requireAdmin()
+  const db = getDb()
+  const [channel] = await db.select().from(alertChannels).where(eq(alertChannels.id, channelId)).limit(1)
+  if (!channel) return { ok: false, error: 'Channel not found' }
+  if (!channel.enabled) return { ok: false, error: 'Channel is disabled' }
+
+  const testPayload = { jobId: 'test', jobName: 'Test alert', error: 'This is a test message from BackupOS — your channel is wired correctly.' }
+  try {
+    await dispatchToChannel(channel, 'backup_failed', `Test alert: ${testPayload.error}`, 'info', testPayload)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
 }

--- a/apps/web/lib/alerts.ts
+++ b/apps/web/lib/alerts.ts
@@ -2,13 +2,13 @@ import nodemailer from 'nodemailer'
 import { getDb, alerts, alertChannels, smtpConfig, eq } from '@backupos/db'
 import { decryptField } from './repo-crypto'
 
-type AlertType = 'backup_failed' | 'backup_missed' | 'agent_disconnected'
+export type AlertType = 'backup_failed' | 'backup_missed' | 'agent_disconnected'
 
 export interface AlertBackupFailed  { jobId: string; jobName: string; error: string }
 export interface AlertBackupMissed  { jobId: string; jobName: string }
 export interface AlertAgentDisc     { agentId: string; agentName: string }
 
-type AlertPayload = AlertBackupFailed | AlertBackupMissed | AlertAgentDisc
+export type AlertPayload = AlertBackupFailed | AlertBackupMissed | AlertAgentDisc
 
 const SEVERITY: Record<AlertType, string> = {
   backup_failed:       'error',
@@ -102,12 +102,12 @@ async function fireEmail(type: AlertType, message: string): Promise<void> {
   })
 }
 
-interface ZulipConfig    { url: string; email: string; apiKey: string; stream: string; topic?: string }
-interface TelegramConfig { botToken: string; chatId: string }
-interface PagerDutyConfig { integrationKey: string }
-interface NtfyConfig     { url: string; topic: string; auth?: string }
-interface GotifyConfig   { url: string; appToken: string }
-interface PushoverConfig { apiToken: string; userKey: string }
+export interface ZulipConfig     { url: string; email: string; apiKey: string; stream: string; topic?: string }
+export interface TelegramConfig  { botToken: string; chatId: string }
+export interface PagerDutyConfig { integrationKey: string }
+export interface NtfyConfig      { url: string; topic: string; auth?: string }
+export interface GotifyConfig    { url: string; appToken: string }
+export interface PushoverConfig  { apiToken: string; userKey: string }
 
 async function fireZulip(cfg: ZulipConfig, type: AlertType, message: string, severity: string): Promise<void> {
   const emoji = SEVERITY_EMOJI[severity] ?? ''
@@ -190,6 +190,27 @@ async function firePushover(cfg: PushoverConfig, type: AlertType, message: strin
   })
 }
 
+export async function dispatchToChannel(
+  channel: { id: string; type: string; config: string },
+  type: AlertType,
+  message: string,
+  severity: string,
+  payload: AlertPayload,
+): Promise<void> {
+  const cfg = JSON.parse(channel.config) as Record<string, unknown>
+  const url = (cfg.url as string | undefined) ?? ''
+
+  if      (channel.type === 'discord')   await fireDiscord(url, type, message, severity)
+  else if (channel.type === 'slack')     await fireSlack(url, type, message)
+  else if (channel.type === 'zulip')     await fireZulip(cfg as unknown as ZulipConfig, type, message, severity)
+  else if (channel.type === 'telegram')  await fireTelegram(cfg as unknown as TelegramConfig, type, message, severity)
+  else if (channel.type === 'pagerduty') await firePagerDuty(cfg as unknown as PagerDutyConfig, type, message, severity, payload)
+  else if (channel.type === 'ntfy')      await fireNtfy(cfg as unknown as NtfyConfig, type, message, severity)
+  else if (channel.type === 'gotify')    await fireGotify(cfg as unknown as GotifyConfig, type, message, severity)
+  else if (channel.type === 'pushover')  await firePushover(cfg as unknown as PushoverConfig, type, message, severity)
+  else if (url)                          await fireWebhook(url, type, severity, message, payload)
+}
+
 export async function sendAlert(type: AlertType, payload: AlertPayload): Promise<void> {
   const db       = getDb()
   const severity = SEVERITY[type]
@@ -210,18 +231,7 @@ export async function sendAlert(type: AlertType, payload: AlertPayload): Promise
   await Promise.allSettled(
     enabled.map(async channel => {
       try {
-        const cfg = JSON.parse(channel.config) as Record<string, unknown>
-        const url = (cfg.url as string | undefined) ?? ''
-
-        if      (channel.type === 'discord')    await fireDiscord(url, type, message, severity)
-        else if (channel.type === 'slack')       await fireSlack(url, type, message)
-        else if (channel.type === 'zulip')       await fireZulip(cfg as unknown as ZulipConfig, type, message, severity)
-        else if (channel.type === 'telegram')    await fireTelegram(cfg as unknown as TelegramConfig, type, message, severity)
-        else if (channel.type === 'pagerduty')   await firePagerDuty(cfg as unknown as PagerDutyConfig, type, message, severity, payload)
-        else if (channel.type === 'ntfy')        await fireNtfy(cfg as unknown as NtfyConfig, type, message, severity)
-        else if (channel.type === 'gotify')      await fireGotify(cfg as unknown as GotifyConfig, type, message, severity)
-        else if (channel.type === 'pushover')    await firePushover(cfg as unknown as PushoverConfig, type, message, severity)
-        else if (url)                            await fireWebhook(url, type, severity, message, payload)
+        await dispatchToChannel(channel, type, message, severity, payload)
       } catch (err) {
         console.error(`[alerts] channel ${channel.id} delivery failed:`, err)
       }

--- a/apps/web/lib/integrations.ts
+++ b/apps/web/lib/integrations.ts
@@ -1,0 +1,213 @@
+export type ConfigField = {
+  name:        string
+  label:       string
+  type:        'text' | 'url' | 'password'
+  required:    boolean
+  placeholder?: string
+  helpText?:   string
+}
+
+export type SamplePayload = {
+  title:   string
+  body:    string
+  footer?: string
+}
+
+export type IntegrationDefinition = {
+  type:           string
+  name:           string
+  description:    string
+  setupSteps:     string[]
+  configFields:   ConfigField[]
+  samplePayload:  SamplePayload
+  externalDocsUrl: string
+}
+
+export const INTEGRATIONS_REGISTRY: IntegrationDefinition[] = [
+  {
+    type: 'discord',
+    name: 'Discord',
+    description: 'Send backup alerts to a Discord channel via an incoming webhook. Each alert appears as a rich embed with a severity color indicator.',
+    setupSteps: [
+      'Open your Discord server and go to Server Settings → Integrations → Webhooks.',
+      'Click "New Webhook", choose the target text channel, and copy the Webhook URL.',
+      'Paste the URL into the form below and save.',
+    ],
+    configFields: [
+      { name: 'url', label: 'Webhook URL', type: 'url', required: true, placeholder: 'https://discord.com/api/webhooks/…' },
+    ],
+    samplePayload: {
+      title:  '[BackupOS] backup failed',
+      body:   'Backup job "nightly-prod" failed: repository unreachable',
+      footer: 'error · ' + new Date().toISOString().slice(0, 10),
+    },
+    externalDocsUrl: 'https://discord.com/developers/docs/resources/webhook',
+  },
+  {
+    type: 'gotify',
+    name: 'Gotify',
+    description: 'Push backup alerts to your self-hosted Gotify server as push notifications. Priority scales with alert severity.',
+    setupSteps: [
+      'Self-host Gotify by following the quickstart at gotify.net.',
+      'In the Gotify web UI, navigate to Apps and click the + button to create a new application.',
+      'Copy the generated app token shown in the application list.',
+      'Enter your Gotify server URL (e.g. https://gotify.example.com) and the app token below.',
+    ],
+    configFields: [
+      { name: 'url',      label: 'Server URL', type: 'url',      required: true, placeholder: 'https://gotify.example.com' },
+      { name: 'appToken', label: 'App token',  type: 'password', required: true, placeholder: 'Gotify application token' },
+    ],
+    samplePayload: {
+      title: '[BackupOS] backup failed',
+      body:  'Backup job "nightly-prod" failed: repository unreachable',
+    },
+    externalDocsUrl: 'https://gotify.net/docs/pushmsg',
+  },
+  {
+    type: 'ntfy',
+    name: 'ntfy',
+    description: 'Deliver backup alerts to any ntfy topic — self-hosted or via ntfy.sh. Supports access-controlled topics via an Authorization header.',
+    setupSteps: [
+      'Self-host ntfy following docs.ntfy.sh/install, or use the public server at ntfy.sh (note: topics on ntfy.sh are public by default).',
+      'Choose a topic name (e.g. my-backup-alerts). Topics are created on first publish.',
+      'Subscribe to the topic in the ntfy app on your devices.',
+      'If your server requires authentication, generate an access token in the ntfy web UI under Account → Access tokens, then format it as "Bearer <token>".',
+      'Enter the server URL, topic, and optional Authorization header below.',
+    ],
+    configFields: [
+      { name: 'url',   label: 'Server URL', type: 'url',      required: true,  placeholder: 'https://ntfy.sh' },
+      { name: 'topic', label: 'Topic',      type: 'text',     required: true,  placeholder: 'my-backup-alerts' },
+      { name: 'auth',  label: 'Authorization header', type: 'password', required: false, placeholder: 'Bearer tk_…', helpText: 'Leave blank for public topics.' },
+    ],
+    samplePayload: {
+      title: 'BackupOS — backup failed',
+      body:  'Backup job "nightly-prod" failed: repository unreachable',
+    },
+    externalDocsUrl: 'https://docs.ntfy.sh/publish/',
+  },
+  {
+    type: 'pagerduty',
+    name: 'PagerDuty',
+    description: 'Trigger PagerDuty incidents from backup failures. Uses the Events API v2 to route alerts through your on-call schedules and escalation policies.',
+    setupSteps: [
+      'In PagerDuty, go to Services → Service Directory and open the service that should receive backup alerts (create one if needed).',
+      'Click the Integrations tab, then "Add an integration".',
+      'Search for "Events API v2" and click Add.',
+      'Copy the Integration Key (also called the routing key) — it is a 32-character hex string.',
+      'Paste the key into the field below.',
+    ],
+    configFields: [
+      { name: 'integrationKey', label: 'Integration key', type: 'password', required: true, placeholder: 'Events API v2 routing key (32 chars)' },
+    ],
+    samplePayload: {
+      title:  '[BackupOS] backup failed',
+      body:   'Backup job "nightly-prod" failed: repository unreachable',
+      footer: 'Source: backupos · Severity: error',
+    },
+    externalDocsUrl: 'https://developer.pagerduty.com/docs/events-api-v2/overview/',
+  },
+  {
+    type: 'pushover',
+    name: 'Pushover',
+    description: 'Send backup alerts as Pushover push notifications to your phone or desktop. Alert priority maps to BackupOS severity levels.',
+    setupSteps: [
+      'Register at pushover.net and install the Pushover app on your devices.',
+      'Go to pushover.net/apps/build and create a new application. Name it "BackupOS" and copy the API Token shown after creation.',
+      'Your User Key is shown on your Pushover account dashboard.',
+      'Enter both values below.',
+    ],
+    configFields: [
+      { name: 'apiToken', label: 'API token',  type: 'password', required: true, placeholder: 'Pushover application API token' },
+      { name: 'userKey',  label: 'User key',   type: 'password', required: true, placeholder: 'Your Pushover user or group key' },
+    ],
+    samplePayload: {
+      title: '[BackupOS] backup failed',
+      body:  'Backup job "nightly-prod" failed: repository unreachable',
+    },
+    externalDocsUrl: 'https://pushover.net/api',
+  },
+  {
+    type: 'slack',
+    name: 'Slack',
+    description: 'Post backup alerts to a Slack channel using an incoming webhook. Messages use Block Kit formatting for scannable, structured alerts.',
+    setupSteps: [
+      'Go to api.slack.com/apps and click "Create New App" → "From scratch". Name the app and choose your workspace.',
+      'Under Features in the left sidebar, click "Incoming Webhooks" and toggle it on.',
+      'Click "Add New Webhook to Workspace", select the destination channel, and click Allow.',
+      'Copy the generated Webhook URL — it starts with https://hooks.slack.com/services/…',
+      'Paste the URL into the form below.',
+    ],
+    configFields: [
+      { name: 'url', label: 'Webhook URL', type: 'url', required: true, placeholder: 'https://hooks.slack.com/services/…' },
+    ],
+    samplePayload: {
+      title: '[BackupOS] backup failed',
+      body:  'Backup job "nightly-prod" failed: repository unreachable',
+    },
+    externalDocsUrl: 'https://api.slack.com/messaging/webhooks',
+  },
+  {
+    type: 'telegram',
+    name: 'Telegram',
+    description: 'Receive backup alerts as Telegram messages via a bot. Works with private chats, groups, and channels.',
+    setupSteps: [
+      'Open Telegram and search for @BotFather.',
+      'Send /newbot and follow the prompts. BotFather will provide a bot token.',
+      'Add the bot to the group or channel where you want alerts, or open a direct chat with it and send a message.',
+      'Get the chat ID: forward a message from the target chat to @userinfobot, or call https://api.telegram.org/bot<TOKEN>/getUpdates after sending a message.',
+      'Enter the bot token and chat ID below.',
+    ],
+    configFields: [
+      { name: 'botToken', label: 'Bot token', type: 'password', required: true, placeholder: '1234567890:AABBCCDDEEFFaabbccddeeff…' },
+      { name: 'chatId',   label: 'Chat ID',   type: 'text',     required: true, placeholder: '-100123456789 (group) or 123456789 (private)' },
+    ],
+    samplePayload: {
+      title: '❌ backup failed',
+      body:  'Backup job "nightly-prod" failed: repository unreachable',
+    },
+    externalDocsUrl: 'https://core.telegram.org/bots/api#sendmessage',
+  },
+  {
+    type: 'webhook',
+    name: 'Webhook',
+    description: 'POST alert payloads as JSON to any HTTP endpoint. Useful for custom integrations, automation platforms like Zapier or n8n, or your own scripts.',
+    setupSteps: [
+      'Set up an HTTP endpoint that accepts POST requests with Content-Type: application/json.',
+      'The request body includes: type, severity, message, timestamp, and a payload object with job or agent details.',
+      'Respond with any 2xx status to acknowledge the delivery.',
+      'Paste your endpoint URL into the form below.',
+    ],
+    configFields: [
+      { name: 'url', label: 'Endpoint URL', type: 'url', required: true, placeholder: 'https://your-server.example.com/hook' },
+    ],
+    samplePayload: {
+      title: 'POST /your-endpoint',
+      body:  '{ "type": "backup_failed", "severity": "error", "message": "Backup job \\"nightly-prod\\" failed", "timestamp": "…" }',
+    },
+    externalDocsUrl: 'https://github.com/dariusvorster/backupos',
+  },
+  {
+    type: 'zulip',
+    name: 'Zulip',
+    description: 'Post backup alerts to a Zulip stream using a bot. Supports full stream and topic routing.',
+    setupSteps: [
+      'In your Zulip organization, open your profile menu and go to Personal settings → Bots.',
+      'Click "Add a new bot", choose type "Generic bot" or "Incoming webhook", and create it.',
+      'Note the bot email address and API key shown in the bot list.',
+      'Decide on a stream (channel) and optional topic where BackupOS alerts should appear.',
+      'Enter your Zulip server URL, bot email, API key, and stream below.',
+    ],
+    configFields: [
+      { name: 'url',    label: 'Zulip server URL', type: 'url',      required: true,  placeholder: 'https://your-org.zulipchat.com' },
+      { name: 'email',  label: 'Bot email',        type: 'text',     required: true,  placeholder: 'backupos-bot@your-org.zulipchat.com' },
+      { name: 'apiKey', label: 'Bot API key',      type: 'password', required: true,  placeholder: 'Zulip bot API key' },
+      { name: 'stream', label: 'Stream',           type: 'text',     required: true,  placeholder: 'ops-alerts' },
+      { name: 'topic',  label: 'Topic',            type: 'text',     required: false, placeholder: 'BackupOS alerts', helpText: 'Defaults to "[BackupOS] alerts" if blank.' },
+    ],
+    samplePayload: {
+      title: '❌ ops-alerts / BackupOS alerts',
+      body:  'Backup job "nightly-prod" failed: repository unreachable',
+    },
+    externalDocsUrl: 'https://zulip.com/api/send-message',
+  },
+]


### PR DESCRIPTION
## Scope

Phase 2 of #93. Builds the full per-integration UI on top of PR #156 (which added the 9 channel types to the backend). Not a thin wrapper — every integration gets a dedicated setup page, real docs, and test delivery.

## What changed

- **`lib/integrations.ts`** — `INTEGRATIONS_REGISTRY` with all 9 integration definitions: name, description, real setup steps, config field schema, sample payload, external docs URL
- **`lib/alerts.ts`** — exported `AlertType`, `AlertPayload`, and config interfaces; extracted `dispatchToChannel()` as a shared export; `sendAlert` refactored to use it (no behavior change)
- **`app/actions/alerts.ts`** — added `sendTestAlert`, `createAlertChannelForType`, `deleteAlertChannelForType` (all RBAC-gated via `requireAdmin()`)
- **`settings/integrations/page.tsx`** — index listing all 9 integration cards with live channel counts
- **`settings/integrations/[type]/page.tsx`** — dynamic per-integration page: setup guide, connected channels, send-test button, add-channel form, sample alert preview
- **`settings/integrations/[type]/IntegrationAddForm.tsx`** — client form component, type pre-set, bound server action
- **`settings/integrations/[type]/SendTestButton.tsx`** — client component, `useTransition` + inline feedback
- **`settings/page.tsx`** — "Notifications" section renamed to "Integrations"; `Webhook URL` and `Slack integration` items replaced with single `Integrations` entry
- **`settings/slack/page.tsx`** and **`settings/webhook/page.tsx`** — converted to redirects to `/settings/integrations/slack` and `/settings/integrations/webhook` respectively (preserves bookmarked URLs)

## Integrations supported

| Integration | Type | Config |
|---|---|---|
| Discord | Webhook | URL |
| Gotify | Self-hosted push | URL + app token |
| ntfy | Self-hosted push | URL + topic + optional auth |
| PagerDuty | Incident management | Integration key |
| Pushover | Push notification | API token + user key |
| Slack | Webhook | URL |
| Telegram | Bot | Bot token + chat ID |
| Webhook | Generic HTTP | URL |
| Zulip | Bot | URL + email + API key + stream + topic |

All 9 integrations receive equal treatment — same setup-step depth, same UX, no "Recommended" or "Popular" ordering.

## Out of scope (file follow-ups if needed)

- OAuth flows for Slack/Discord (manual webhook URL entry only for V1)
- Per-rule channel routing UI
- Custom integration types beyond the 9 supported
- Encrypted credential storage (tracked in #157)

## Security note

Credentials (webhook URLs, API keys, tokens) are stored in plaintext in the `alertChannels.config` JSON column. Encrypted storage is tracked in #157. `sendTestAlert` and all mutating actions require admin role.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)