### PR TITLE
feat(integration-tokens): Phase 1 — schema, crypto helpers, server actions, admin UI (#168)

### DIFF
--- a/apps/web/app/(dashboard)/settings/api-tokens/IntegrationTokenSection.tsx
+++ b/apps/web/app/(dashboard)/settings/api-tokens/IntegrationTokenSection.tsx
@@ -1,0 +1,270 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import {
+  createIntegrationToken,
+  revokeIntegrationToken,
+  rotateIntegrationToken,
+} from '@/app/actions/integration-tokens'
+
+// Scope constants duplicated here to avoid importing the server-only lib
+const ALL_SCOPES = [
+  'instance:read',
+  'services:read',
+  'jobs:read',
+  'runs:read',
+  'agents:read',
+  'repositories:read',
+  'monitors:read',
+  'health:read',
+] as const
+
+const SCOPE_LABELS: Record<string, string> = {
+  'instance:read':     'Instance metadata',
+  'services:read':     'Coverage services',
+  'jobs:read':         'Backup jobs',
+  'runs:read':         'Backup run history',
+  'agents:read':       'Agents',
+  'repositories:read': 'Repositories (no secrets)',
+  'monitors:read':     'Monitors',
+  'health:read':       'Health rollup',
+}
+
+export interface IntegrationTokenRow {
+  id: string
+  name: string
+  tokenPrefix: string
+  scopes: string       // JSON
+  expiresAt: Date | null
+  createdAt: Date
+  lastUsedAt: Date | null
+  revokedAt: Date | null
+  rateLimitRpm: number
+}
+
+function statusBadge(token: IntegrationTokenRow): { label: string; color: string } {
+  const now = Date.now()
+  if (token.revokedAt) {
+    const elapsed = now - token.revokedAt.getTime()
+    const gracePeriodMs = 24 * 60 * 60 * 1000
+    if (elapsed < gracePeriodMs) return { label: 'Grace period', color: 'var(--color-warning)' }
+    return { label: 'Revoked', color: 'var(--color-error)' }
+  }
+  if (token.expiresAt && token.expiresAt.getTime() < now) return { label: 'Expired', color: 'var(--color-error)' }
+  if (token.expiresAt) {
+    const daysLeft = Math.ceil((token.expiresAt.getTime() - now) / 86400000)
+    if (daysLeft <= 7) return { label: `Expires in ${daysLeft}d`, color: 'var(--color-warning)' }
+  }
+  return { label: 'Active', color: 'var(--color-success)' }
+}
+
+function TokenRevealBanner({ token, variant }: { token: string; variant: 'created' | 'rotated' }) {
+  const [copied, setCopied] = useState(false)
+  const bg = variant === 'created' ? 'var(--color-success-muted)' : 'var(--color-info-muted)'
+
+  function copy() {
+    navigator.clipboard.writeText(token)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div style={{ background: bg, border: '1px solid currentColor', borderRadius: 6, padding: '12px 14px', marginBottom: 16 }}>
+      <p style={{ fontWeight: 600, marginBottom: 4 }}>
+        {variant === 'created' ? 'Token created — copy it now' : 'Token rotated — update your connector'}
+      </p>
+      <p style={{ fontSize: 12, marginBottom: 8, opacity: 0.75 }}>
+        This token will only be shown once. Store it securely before leaving this page.
+      </p>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <code style={{ flex: 1, padding: '6px 10px', background: 'rgba(0,0,0,0.1)', borderRadius: 4, fontSize: 13, wordBreak: 'break-all' }}>
+          {token}
+        </code>
+        <button onClick={copy} className="btn btn-sm btn-outline">
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function CreateTokenForm({ onCreated }: { onCreated: (token: string) => void }) {
+  const [pending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError(null)
+    const fd = new FormData(e.currentTarget)
+    startTransition(async () => {
+      const result = await createIntegrationToken(fd)
+      if (result.error) { setError(result.error); return }
+      if (result.token) { onCreated(result.token) }
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div>
+        <label style={{ display: 'block', fontSize: 13, fontWeight: 500, marginBottom: 4 }}>Name</label>
+        <input name="name" required placeholder="e.g. InfraOS — homelab" className="input input-sm" style={{ width: '100%' }} />
+      </div>
+
+      <div>
+        <label style={{ display: 'block', fontSize: 13, fontWeight: 500, marginBottom: 6 }}>Scopes</label>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px 16px' }}>
+          {ALL_SCOPES.map(scope => (
+            <label key={scope} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13 }}>
+              <input type="checkbox" name="scopes" value={scope} defaultChecked />
+              {SCOPE_LABELS[scope]}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label style={{ display: 'block', fontSize: 13, fontWeight: 500, marginBottom: 4 }}>Expires in</label>
+        <select name="expiresInDays" className="input input-sm">
+          <option value="30">30 days</option>
+          <option value="60">60 days</option>
+          <option value="90" selected>90 days</option>
+          <option value="180">180 days</option>
+          <option value="0">Never</option>
+        </select>
+      </div>
+
+      {error && <p style={{ color: 'var(--color-error)', fontSize: 13 }}>{error}</p>}
+
+      <button type="submit" disabled={pending} className="btn btn-primary btn-sm" style={{ alignSelf: 'flex-start' }}>
+        {pending ? 'Creating…' : 'Create token'}
+      </button>
+    </form>
+  )
+}
+
+export function IntegrationTokenSection({ initial }: { initial: IntegrationTokenRow[] }) {
+  const [tokens, setTokens] = useState(initial)
+  const [showForm, setShowForm] = useState(false)
+  const [newToken, setNewToken] = useState<string | null>(null)
+  const [rotatedToken, setRotatedToken] = useState<string | null>(null)
+  const [actionPending, startAction] = useTransition()
+
+  function handleCreated(raw: string) {
+    setNewToken(raw)
+    setShowForm(false)
+    // Refresh by reloading — server component will re-query
+    window.location.reload()
+  }
+
+  function handleRevoke(id: string) {
+    startAction(async () => {
+      await revokeIntegrationToken(id)
+      window.location.reload()
+    })
+  }
+
+  function handleRotate(id: string) {
+    startAction(async () => {
+      const result = await rotateIntegrationToken(id)
+      if (result.token) setRotatedToken(result.token)
+      window.location.reload()
+    })
+  }
+
+  return (
+    <section>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+        <div>
+          <h2 style={{ fontSize: 16, fontWeight: 600 }}>Integration tokens</h2>
+          <p style={{ fontSize: 13, opacity: 0.6, marginTop: 2 }}>
+            Scoped read-only tokens for external consumers such as InfraOS.
+          </p>
+        </div>
+        <button className="btn btn-sm btn-outline" onClick={() => setShowForm(v => !v)}>
+          {showForm ? 'Cancel' : '+ New token'}
+        </button>
+      </div>
+
+      {newToken && (
+        <TokenRevealBanner token={newToken} variant="created" />
+      )}
+      {rotatedToken && (
+        <TokenRevealBanner token={rotatedToken} variant="rotated" />
+      )}
+
+      {showForm && (
+        <div style={{ background: 'var(--color-surface-raised)', borderRadius: 8, padding: 16, marginBottom: 16 }}>
+          <CreateTokenForm onCreated={handleCreated} />
+        </div>
+      )}
+
+      {tokens.length === 0 && !showForm ? (
+        <p style={{ fontSize: 13, opacity: 0.5 }}>No integration tokens yet.</p>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {tokens.map(token => {
+            const { label, color } = statusBadge(token)
+            const scopes: string[] = (() => { try { return JSON.parse(token.scopes) } catch { return [] } })()
+            const isActive = !token.revokedAt && !(token.expiresAt && token.expiresAt.getTime() < Date.now())
+
+            return (
+              <div key={token.id} style={{
+                background: 'var(--color-surface-raised)',
+                borderRadius: 8,
+                padding: '12px 14px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 6,
+              }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                  <div>
+                    <span style={{ fontWeight: 600, fontSize: 14 }}>{token.name}</span>
+                    <code style={{ marginLeft: 8, fontSize: 12, opacity: 0.6 }}>{token.tokenPrefix}…</code>
+                    <span style={{ marginLeft: 10, fontSize: 12, color, fontWeight: 500 }}>{label}</span>
+                  </div>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    {isActive && (
+                      <button
+                        className="btn btn-xs btn-outline"
+                        disabled={actionPending}
+                        onClick={() => handleRotate(token.id)}
+                      >
+                        Rotate
+                      </button>
+                    )}
+                    {isActive && (
+                      <button
+                        className="btn btn-xs btn-danger-outline"
+                        disabled={actionPending}
+                        onClick={() => handleRevoke(token.id)}
+                      >
+                        Revoke
+                      </button>
+                    )}
+                  </div>
+                </div>
+                <div style={{ fontSize: 12, opacity: 0.55, display: 'flex', gap: 16 }}>
+                  <span>Created {token.createdAt.toLocaleDateString()}</span>
+                  {token.lastUsedAt && <span>Last used {token.lastUsedAt.toLocaleDateString()}</span>}
+                  {token.expiresAt && <span>Expires {token.expiresAt.toLocaleDateString()}</span>}
+                  <span>{token.rateLimitRpm} rpm</span>
+                </div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                  {scopes.map(s => (
+                    <span key={s} style={{
+                      fontSize: 11,
+                      padding: '2px 6px',
+                      background: 'var(--color-surface)',
+                      borderRadius: 4,
+                      fontFamily: 'monospace',
+                    }}>{s}</span>
+                  ))}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/api-tokens/IntegrationTokenSection.tsx
+++ b/apps/web/app/(dashboard)/settings/api-tokens/IntegrationTokenSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
 import {
   createIntegrationToken,
   revokeIntegrationToken,
@@ -124,10 +125,10 @@ function CreateTokenForm({ onCreated }: { onCreated: (token: string) => void }) 
 
       <div>
         <label style={{ display: 'block', fontSize: 13, fontWeight: 500, marginBottom: 4 }}>Expires in</label>
-        <select name="expiresInDays" className="input input-sm">
+        <select name="expiresInDays" defaultValue="90" className="input input-sm">
           <option value="30">30 days</option>
           <option value="60">60 days</option>
-          <option value="90" selected>90 days</option>
+          <option value="90">90 days</option>
           <option value="180">180 days</option>
           <option value="0">Never</option>
         </select>
@@ -143,7 +144,7 @@ function CreateTokenForm({ onCreated }: { onCreated: (token: string) => void }) 
 }
 
 export function IntegrationTokenSection({ initial }: { initial: IntegrationTokenRow[] }) {
-  const [tokens, setTokens] = useState(initial)
+  const router = useRouter()
   const [showForm, setShowForm] = useState(false)
   const [newToken, setNewToken] = useState<string | null>(null)
   const [rotatedToken, setRotatedToken] = useState<string | null>(null)
@@ -152,14 +153,13 @@ export function IntegrationTokenSection({ initial }: { initial: IntegrationToken
   function handleCreated(raw: string) {
     setNewToken(raw)
     setShowForm(false)
-    // Refresh by reloading — server component will re-query
-    window.location.reload()
+    router.refresh()
   }
 
   function handleRevoke(id: string) {
     startAction(async () => {
       await revokeIntegrationToken(id)
-      window.location.reload()
+      router.refresh()
     })
   }
 
@@ -167,7 +167,7 @@ export function IntegrationTokenSection({ initial }: { initial: IntegrationToken
     startAction(async () => {
       const result = await rotateIntegrationToken(id)
       if (result.token) setRotatedToken(result.token)
-      window.location.reload()
+      router.refresh()
     })
   }
 
@@ -198,11 +198,11 @@ export function IntegrationTokenSection({ initial }: { initial: IntegrationToken
         </div>
       )}
 
-      {tokens.length === 0 && !showForm ? (
+      {initial.length === 0 && !showForm ? (
         <p style={{ fontSize: 13, opacity: 0.5 }}>No integration tokens yet.</p>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {tokens.map(token => {
+          {initial.map(token => {
             const { label, color } = statusBadge(token)
             const scopes: string[] = (() => { try { return JSON.parse(token.scopes) } catch { return [] } })()
             const isActive = !token.revokedAt && !(token.expiresAt && token.expiresAt.getTime() < Date.now())

--- a/apps/web/app/(dashboard)/settings/api-tokens/page.tsx
+++ b/apps/web/app/(dashboard)/settings/api-tokens/page.tsx
@@ -1,23 +1,41 @@
 import { redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/user'
-import { getDb, apiTokens, eq } from '@backupos/db'
+import { getDb, apiTokens, integrationTokens, eq } from '@backupos/db'
 import { ApiTokensClient } from './client'
+import { IntegrationTokenSection } from './IntegrationTokenSection'
 
 export default async function ApiTokensPage() {
   const user = await getCurrentUser()
   if (!user) redirect('/login')
 
   const db = getDb()
-  const tokens = await db.select().from(apiTokens).where(eq(apiTokens.userId, user.id)).all()
+  const [tokens, intTokens] = await Promise.all([
+    db.select().from(apiTokens).where(eq(apiTokens.userId, user.id)).all(),
+    db.select().from(integrationTokens).all(),
+  ])
 
   return (
-    <ApiTokensClient initial={tokens.map(t => ({
-      id: t.id,
-      name: t.name,
-      tokenPrefix: t.tokenPrefix,
-      lastUsedAt: t.lastUsedAt,
-      expiresAt: t.expiresAt,
-      createdAt: t.createdAt,
-    }))} />
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 40 }}>
+      <ApiTokensClient initial={tokens.map(t => ({
+        id: t.id,
+        name: t.name,
+        tokenPrefix: t.tokenPrefix,
+        lastUsedAt: t.lastUsedAt,
+        expiresAt: t.expiresAt,
+        createdAt: t.createdAt,
+      }))} />
+
+      <IntegrationTokenSection initial={intTokens.map(t => ({
+        id: t.id,
+        name: t.name,
+        tokenPrefix: t.tokenPrefix,
+        scopes: t.scopes,
+        expiresAt: t.expiresAt ?? null,
+        createdAt: t.createdAt,
+        lastUsedAt: t.lastUsedAt ?? null,
+        revokedAt: t.revokedAt ?? null,
+        rateLimitRpm: t.rateLimitRpm,
+      }))} />
+    </div>
   )
 }

--- a/apps/web/app/actions/integration-tokens.ts
+++ b/apps/web/app/actions/integration-tokens.ts
@@ -1,0 +1,119 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { getDb, integrationTokens, eq } from '@backupos/db'
+import { requireAdmin } from '@/lib/user'
+import { appendAuditEntry } from '@/lib/audit'
+import { generateRawToken, hashToken, extractPrefix, ALL_SCOPES } from '@/lib/integration-tokens'
+
+export async function createIntegrationToken(formData: FormData): Promise<{ token?: string; id?: string; error?: string }> {
+  const adminUser     = await requireAdmin()
+  const name          = (formData.get('name') as string | null)?.trim()
+  const expiresInDays = parseInt((formData.get('expiresInDays') as string | null) ?? '90', 10)
+  const scopesRaw     = formData.getAll('scopes') as string[]
+
+  if (!name) return { error: 'Name is required' }
+  if (scopesRaw.length === 0) return { error: 'At least one scope is required' }
+
+  const validScopes = scopesRaw.filter(s => (ALL_SCOPES as string[]).includes(s))
+  if (validScopes.length !== scopesRaw.length) return { error: 'Invalid scope detected' }
+
+  const rawToken    = generateRawToken()
+  const tokenHash   = hashToken(rawToken)
+  const tokenPrefix = extractPrefix(rawToken)
+  const expiresAt   = expiresInDays > 0
+    ? new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000)
+    : null
+
+  const id = crypto.randomUUID()
+  const db = getDb()
+
+  await db.insert(integrationTokens).values({
+    id,
+    name,
+    tokenHash,
+    tokenPrefix,
+    scopes:       JSON.stringify(validScopes),
+    expiresAt:    expiresAt ?? undefined,
+    createdAt:    new Date(),
+    createdBy:    adminUser.id,
+    lastUsedAt:   undefined,
+    revokedAt:    undefined,
+    rateLimitRpm: 60,
+  })
+
+  appendAuditEntry({
+    action:       'integration_token.created',
+    resourceType: 'integration_token',
+    resourceId:   id,
+    actor:        adminUser.email,
+    detail:       { name, scopes: validScopes, expiresAt: expiresAt?.toISOString() ?? null },
+  })
+
+  revalidatePath('/settings/api-tokens')
+  return { token: rawToken, id }
+}
+
+export async function revokeIntegrationToken(id: string): Promise<{ error?: string }> {
+  const adminUser = await requireAdmin()
+  const db = getDb()
+
+  const [existing] = await db.select().from(integrationTokens).where(eq(integrationTokens.id, id)).limit(1)
+  if (!existing) return { error: 'Token not found' }
+  if (existing.revokedAt) return { error: 'Token already revoked' }
+
+  await db.update(integrationTokens).set({ revokedAt: new Date() }).where(eq(integrationTokens.id, id))
+
+  appendAuditEntry({
+    action:       'integration_token.revoked',
+    resourceType: 'integration_token',
+    resourceId:   id,
+    actor:        adminUser.email,
+    detail:       { name: existing.name },
+  })
+
+  revalidatePath('/settings/api-tokens')
+  return {}
+}
+
+export async function rotateIntegrationToken(id: string): Promise<{ token?: string; newId?: string; error?: string }> {
+  const adminUser = await requireAdmin()
+  const db = getDb()
+
+  const [existing] = await db.select().from(integrationTokens).where(eq(integrationTokens.id, id)).limit(1)
+  if (!existing) return { error: 'Token not found' }
+  if (existing.revokedAt) return { error: 'Cannot rotate a revoked token — create a new one instead' }
+
+  const rawToken    = generateRawToken()
+  const tokenHash   = hashToken(rawToken)
+  const tokenPrefix = extractPrefix(rawToken)
+  const newId       = crypto.randomUUID()
+
+  // Mark old token revoked (keeps it valid during 24h grace period for the API middleware)
+  await db.update(integrationTokens).set({ revokedAt: new Date() }).where(eq(integrationTokens.id, id))
+
+  await db.insert(integrationTokens).values({
+    id:           newId,
+    name:         existing.name + ' (rotated)',
+    tokenHash,
+    tokenPrefix,
+    scopes:       existing.scopes,
+    expiresAt:    existing.expiresAt ?? undefined,
+    createdAt:    new Date(),
+    createdBy:    adminUser.id,
+    lastUsedAt:   undefined,
+    revokedAt:    undefined,
+    rateLimitRpm: existing.rateLimitRpm,
+  })
+
+  appendAuditEntry({
+    action:       'integration_token.rotated',
+    resourceType: 'integration_token',
+    resourceId:   id,
+    actor:        adminUser.email,
+    detail:       { newId, name: existing.name },
+  })
+
+  revalidatePath('/settings/api-tokens')
+  return { token: rawToken, newId }
+}

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -12,6 +12,7 @@ export type AuditAction =
   | 'session.created'| 'session.revoked'
   | 'escrow.accessed'
   | 'api_token.created' | 'api_token.revoked'
+  | 'integration_token.created' | 'integration_token.revoked' | 'integration_token.rotated'
   | 'settings.updated'
   | 'user.created'
   | 'user.role_changed'

--- a/apps/web/lib/integration-tokens.ts
+++ b/apps/web/lib/integration-tokens.ts
@@ -1,0 +1,74 @@
+import 'server-only'
+import { randomBytes, createHash } from 'crypto'
+
+export type IntegrationScope =
+  | 'instance:read'
+  | 'services:read'
+  | 'jobs:read'
+  | 'runs:read'
+  | 'agents:read'
+  | 'repositories:read'
+  | 'monitors:read'
+  | 'health:read'
+
+export const ALL_SCOPES: IntegrationScope[] = [
+  'instance:read',
+  'services:read',
+  'jobs:read',
+  'runs:read',
+  'agents:read',
+  'repositories:read',
+  'monitors:read',
+  'health:read',
+]
+
+export const SCOPE_DESCRIPTIONS: Record<IntegrationScope, string> = {
+  'instance:read':      'Read instance metadata (version, name, public URL)',
+  'services:read':      'Read coverage services list',
+  'jobs:read':          'Read backup job list and status',
+  'runs:read':          'Read backup run history',
+  'agents:read':        'Read agent list and online status',
+  'repositories:read':  'Read repository metadata (no secrets or credentials)',
+  'monitors:read':      'Read monitor list and sync status',
+  'health:read':        'Read consolidated health rollup',
+}
+
+export const GRACE_PERIOD_MS = 24 * 60 * 60 * 1000
+
+// Token format: bos_int_<32 base64url chars> — cryptographically random, never Math.random
+export function generateRawToken(): string {
+  return 'bos_int_' + randomBytes(24).toString('base64url').slice(0, 32)
+}
+
+// SHA-256 hex digest — high-entropy tokens don't need bcrypt's slow-hash protection
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex')
+}
+
+// First 16 chars of the full token string (e.g. "bos_int_a1b2c3d4") for UI display
+export function extractPrefix(token: string): string {
+  return token.slice(0, 16)
+}
+
+export function validateScope(grantedScopes: string[], requiredScope: string): boolean {
+  return grantedScopes.includes(requiredScope)
+}
+
+export function parseScopes(scopesJson: string): string[] {
+  try { return JSON.parse(scopesJson) as string[] } catch { return [] }
+}
+
+export function isExpired(token: { expiresAt: Date | null }): boolean {
+  return token.expiresAt !== null && token.expiresAt.getTime() < Date.now()
+}
+
+export function isRevoked(token: { revokedAt: Date | null }): boolean {
+  if (!token.revokedAt) return false
+  return Date.now() - token.revokedAt.getTime() >= GRACE_PERIOD_MS
+}
+
+export function isInGracePeriod(token: { revokedAt: Date | null }): boolean {
+  if (!token.revokedAt) return false
+  const elapsed = Date.now() - token.revokedAt.getTime()
+  return elapsed >= 0 && elapsed < GRACE_PERIOD_MS
+}

--- a/packages/db/migrations/0039_integration_tokens.sql
+++ b/packages/db/migrations/0039_integration_tokens.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `integration_tokens` (
+  `id`              text PRIMARY KEY NOT NULL,
+  `name`            text NOT NULL,
+  `token_hash`      text NOT NULL UNIQUE,
+  `token_prefix`    text NOT NULL,
+  `scopes`          text NOT NULL,
+  `expires_at`      integer,
+  `created_at`      integer NOT NULL,
+  `created_by`      text NOT NULL REFERENCES `user`(`id`),
+  `last_used_at`    integer,
+  `revoked_at`      integer,
+  `rate_limit_rpm`  integer NOT NULL DEFAULT 60
+);
+--> statement-breakpoint
+CREATE INDEX `integration_tokens_hash_idx` ON `integration_tokens` (`token_hash`);

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1747008000000,
       "tag": "0038_invite_role",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1747094400000,
+      "tag": "0039_integration_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -578,6 +578,24 @@ export const apiTokens = sqliteTable('api_tokens', {
   createdAt:   integer('created_at',   { mode: 'timestamp_ms' }).notNull(),
 })
 
+// ── Integration tokens ────────────────────────────────────────────────────
+// Scoped API tokens for external consumers (e.g. InfraOS federation)
+export const integrationTokens = sqliteTable('integration_tokens', {
+  id:           text('id').primaryKey(),
+  name:         text('name').notNull(),
+  tokenHash:    text('token_hash').notNull().unique(),
+  tokenPrefix:  text('token_prefix').notNull(),
+  scopes:       text('scopes').notNull(),            // JSON array of scope strings
+  expiresAt:    integer('expires_at',   { mode: 'timestamp_ms' }),
+  createdAt:    integer('created_at',   { mode: 'timestamp_ms' }).notNull(),
+  createdBy:    text('created_by').notNull().references(() => user.id),
+  lastUsedAt:   integer('last_used_at', { mode: 'timestamp_ms' }),
+  revokedAt:    integer('revoked_at',   { mode: 'timestamp_ms' }),
+  rateLimitRpm: integer('rate_limit_rpm').notNull().default(60),
+}, t => ({
+  hashIdx: index('integration_tokens_hash_idx').on(t.tokenHash),
+}))
+
 // ── Backup defaults ───────────────────────────────────────────────────────
 export const backupDefaults = sqliteTable('backup_defaults', {
   id:            text('id').primaryKey().default('singleton'),


### PR DESCRIPTION
## Summary

- Adds `integration_tokens` table (migration 0039) with hash index, scopes JSON, grace-period revocation, per-token rate limit
- `lib/integration-tokens.ts`: token generation (`bos_int_` prefix, 32-char base64url), SHA-256 hashing, scope validation, `isRevoked`/`isInGracePeriod`/`isExpired` helpers — `server-only` guarded
- `actions/integration-tokens.ts`: `createIntegrationToken`, `revokeIntegrationToken`, `rotateIntegrationToken` — all admin-gated, audit-logged
- `IntegrationTokenSection.tsx`: full CRUD UI with scope checkboxes, one-time token reveal banner (create + rotate), status badges (Active / Grace period / Expired / Revoked), revoke + rotate actions
- `/settings/api-tokens` page now renders both personal API tokens and integration tokens sections

## Test plan

- [ ] Navigate to `/settings/api-tokens` — integration tokens section appears below personal tokens
- [ ] Create a token: name + scopes + expiry → raw token shown once in green banner, copy works
- [ ] Revoke a token: badge changes to "Grace period", then "Revoked" after 24h
- [ ] Rotate a token: old marked revoked (grace period), new raw token shown in blue banner
- [ ] Create with no scopes selected → error "At least one scope is required"
- [ ] Verify `pnpm build` and `tsc --noEmit` pass with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)