### PR TITLE
fix: integration tokens section width + clipboard fallback (closes #163)

### DIFF
--- a/apps/web/app/(dashboard)/settings/api-tokens/IntegrationTokenSection.tsx
+++ b/apps/web/app/(dashboard)/settings/api-tokens/IntegrationTokenSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
+import { copyToClipboard } from '@/lib/copy-to-clipboard'
 import {
   createIntegrationToken,
   revokeIntegrationToken,
@@ -64,9 +65,10 @@ function TokenRevealBanner({ token, variant }: { token: string; variant: 'create
   const bg = variant === 'created' ? 'var(--color-success-muted)' : 'var(--color-info-muted)'
 
   function copy() {
-    navigator.clipboard.writeText(token)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    copyToClipboard(token).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
   }
 
   return (
@@ -172,7 +174,7 @@ export function IntegrationTokenSection({ initial }: { initial: IntegrationToken
   }
 
   return (
-    <section>
+    <section style={{ maxWidth: 580 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
         <div>
           <h2 style={{ fontSize: 16, fontWeight: 600 }}>Integration tokens</h2>

--- a/apps/web/app/(dashboard)/settings/users/client.tsx
+++ b/apps/web/app/(dashboard)/settings/users/client.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from 'react'
 import { createInvite, revokeInvite, resendInviteEmail, createUserDirect, updateUserRole } from '@/app/actions/invite'
+import { copyToClipboard } from '@/lib/copy-to-clipboard'
 
 interface UserRow {
   id:        string
@@ -114,7 +115,7 @@ export function UsersClient({ users: initialUsers, invites: initialInvites, base
   }
 
   function copyLink(link: string) {
-    navigator.clipboard.writeText(link).then(() => {
+    copyToClipboard(link).then(() => {
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     })
@@ -247,7 +248,7 @@ export function UsersClient({ users: initialUsers, invites: initialInvites, base
               <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                 <div style={{ fontFamily: 'var(--font-mono)', fontSize: 13, color: 'var(--fg)', wordBreak: 'break-all', flex: 1 }}>{createdResult.tempPassword}</div>
                 <button style={btnGhost} onClick={() => {
-                  navigator.clipboard.writeText(createdResult.tempPassword!).then(() => {
+                  copyToClipboard(createdResult.tempPassword!).then(() => {
                     setCreateCopied(true)
                     setTimeout(() => setCreateCopied(false), 2000)
                   })

--- a/apps/web/components/copy-command-button.tsx
+++ b/apps/web/components/copy-command-button.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from 'react'
 import { Copy, Check } from 'lucide-react'
 import { getResticCommand } from '@/app/actions/runs'
+import { copyToClipboard } from '@/lib/copy-to-clipboard'
 
 export function CopyCommandButton({ runId }: { runId: string }) {
   const [copied,    setCopied]       = useState(false)
@@ -12,18 +13,7 @@ export function CopyCommandButton({ runId }: { runId: string }) {
     if (isPending || copied) return
     startTransition(async () => {
       const cmd = await getResticCommand(runId)
-      if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(cmd)
-      } else {
-        const ta = document.createElement('textarea')
-        ta.value = cmd
-        ta.style.position = 'fixed'
-        ta.style.opacity = '0'
-        document.body.appendChild(ta)
-        ta.select()
-        document.execCommand('copy')
-        document.body.removeChild(ta)
-      }
+      await copyToClipboard(cmd)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     })

--- a/apps/web/components/totp-setup-modal.tsx
+++ b/apps/web/components/totp-setup-modal.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import QRCode from 'react-qr-code'
 import { authClient } from '@/lib/auth-client'
+import { copyToClipboard } from '@/lib/copy-to-clipboard'
 
 interface Props { onClose: () => void; onEnabled: () => void }
 
@@ -148,9 +149,7 @@ export function TotpSetupModal({ onClose, onEnabled }: Props) {
             <div style={{ display: 'flex', gap: 8, marginBottom: 20 }}>
               <button
                 onClick={() => {
-                  navigator.clipboard.writeText(backupCodes.join('\n')).catch(() => {
-                    window.prompt('Copy your backup codes:', backupCodes.join('\n'))
-                  })
+                  copyToClipboard(backupCodes.join('\n'))
                 }}
                 style={{ padding: '6px 12px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'none', fontSize: 12, cursor: 'pointer', color: 'var(--fg)' }}
               >

--- a/apps/web/lib/copy-to-clipboard.ts
+++ b/apps/web/lib/copy-to-clipboard.ts
@@ -1,0 +1,10 @@
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try { await navigator.clipboard.writeText(text); return true } catch {}
+  const ta = document.createElement('textarea')
+  ta.value = text
+  ta.style.position = 'fixed'
+  ta.style.left = '-9999px'
+  document.body.appendChild(ta)
+  ta.select()
+  try { return document.execCommand('copy') } finally { document.body.removeChild(ta) }
+}


### PR DESCRIPTION
## Summary

- **Width fix**: `IntegrationTokenSection` now has `maxWidth: 580` matching `ApiTokensClient` above it on the same page — the two sections align visually on wide screens
- **Clipboard fallback** (`lib/copy-to-clipboard.ts`): new shared helper that tries `navigator.clipboard.writeText()` first, then falls back to a hidden `textarea` + `document.execCommand('copy')` — works on plain HTTP LAN deployments where the Clipboard API is unavailable. Closes #163.

## Files changed

| File | Change |
|---|---|
| `apps/web/lib/copy-to-clipboard.ts` | New shared helper with HTTP fallback |
| `apps/web/app/(dashboard)/settings/api-tokens/IntegrationTokenSection.tsx` | maxWidth: 580; use helper for Copy button |
| `apps/web/app/(dashboard)/settings/users/client.tsx` | Use helper for invite link Copy + temp password Copy |
| `apps/web/components/copy-command-button.tsx` | Use helper (replaces inline conditional fallback) |
| `apps/web/components/totp-setup-modal.tsx` | Use helper for backup codes Copy all |

## Test plan

- [ ] `/settings/api-tokens` — Integration Tokens section width matches API Tokens section above
- [ ] Create an integration token — Copy button works over HTTP (test on LAN, not localhost)
- [ ] Create user directly — temp password Copy button works over HTTP
- [ ] Invite user — copy link works over HTTP
- [ ] TOTP setup — Copy all backup codes works over HTTP
- [ ] `pnpm --filter @backupos/web typecheck` passes
- [ ] `pnpm --filter @backupos/web build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)