### PR TITLE
feat(coverage): rename + service picker UI (#170 phase 3 of #106)

### DIFF
--- a/apps/web/app/(dashboard)/jobs/new/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/new/page.tsx
@@ -1,4 +1,4 @@
-import { getDb, repositories, agents } from '@backupos/db'
+import { getDb, repositories, agents, infraOsServices } from '@backupos/db'
 import { Button } from '@/components/ui/button'
 import { createJob } from '@/app/actions/jobs'
 import { SourceConfigSection } from '@/components/source-config-section'
@@ -17,9 +17,10 @@ export default async function NewJobPage({
   const composeError        = params.composeError
 
   const db      = getDb()
-  const [repos, agentList] = await Promise.all([
+  const [repos, agentList, services] = await Promise.all([
     db.select().from(repositories).all(),
     db.select().from(agents).all(),
+    db.select().from(infraOsServices).all(),
   ])
 
   return (
@@ -38,7 +39,7 @@ export default async function NewJobPage({
           borderRadius: 'var(--radius-sm)',
           padding: '10px 14px', marginBottom: 16,
         }}>
-          <span>Pre-filled from Infra OS service registry. Adjust fields as needed.</span>
+          <span>Pre-filled from coverage registry. Adjust fields as needed.</span>
         </div>
       )}
 
@@ -100,6 +101,27 @@ export default async function NewJobPage({
             </select>
           </div>
 
+          <div style={{ marginBottom: 20 }}>
+            <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6, fontWeight: 500 }}>
+              Link to coverage entry (optional)
+            </label>
+            <select name="infraServiceId" defaultValue={prefillInfraService} style={{
+              width: '100%', padding: '8px 12px',
+              backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+              borderRadius: 'var(--radius-sm)', color: 'var(--fg)', fontSize: 14, outline: 'none',
+            }}>
+              <option value="">— None —</option>
+              {services.map(s => (
+                <option key={s.id} value={s.id}>
+                  {s.name}{s.serviceType ? ` (${s.serviceType})` : ''}{s.host ? ` · ${s.host}` : ''}
+                </option>
+              ))}
+            </select>
+            <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginTop: 4 }}>
+              Linking this job to a registered service marks the service as covered on the dashboard.
+            </div>
+          </div>
+
           <div style={{ marginBottom: 28 }}>
             <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6, fontWeight: 500 }}>
               Schedule (cron)
@@ -117,10 +139,6 @@ export default async function NewJobPage({
               }}
             />
           </div>
-
-          {prefillInfraService && (
-            <input type="hidden" name="infraServiceId" value={prefillInfraService} />
-          )}
 
           <Button type="submit" variant="primary" size="md">Create job</Button>
         </form>

--- a/apps/web/app/(dashboard)/settings/infra-os/page.tsx
+++ b/apps/web/app/(dashboard)/settings/infra-os/page.tsx
@@ -26,9 +26,9 @@ export default async function InfraOsSettingsPage({ searchParams }: { searchPara
     <div style={{ maxWidth: 640 }}>
       <div style={{ marginBottom: 24 }}>
         <Link href="/settings" style={{ fontSize: 13, color: 'var(--fg-mute)', textDecoration: 'none' }}>← Settings</Link>
-        <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginTop: 8 }}>Infra OS services</h1>
+        <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginTop: 8 }}>Coverage</h1>
         <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginTop: 4 }}>
-          Register services here to track backup coverage. Services without a backup job appear on the dashboard.
+          Register the services and infrastructure your organization runs. BackupOS tracks which ones have backup jobs and surfaces gaps on the dashboard.
         </p>
       </div>
 
@@ -137,6 +137,20 @@ export default async function InfraOsSettingsPage({ searchParams }: { searchPara
                 }}>
                   {covered ? 'Covered ✓' : 'No backup ⚠'}
                 </span>
+                {!covered && (
+                  <Link
+                    href={`/jobs/new?infraServiceId=${svc.id}`}
+                    style={{
+                      fontSize: 12, padding: '4px 12px',
+                      textDecoration: 'none',
+                      borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+                      color: 'var(--accent)', background: 'var(--surf2)',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    Create backup job →
+                  </Link>
+                )}
                 <form action={boundRemove}>
                   <button type="submit" style={{
                     fontSize: 12, padding: '3px 10px', cursor: 'pointer',

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -15,7 +15,7 @@ const LINKED_ITEMS: Record<string, string> = {
   'Retention policy':   '/settings/retention',
   'Schedule windows':   '/settings/schedule-windows',
   'Bandwidth limits':   '/settings/bandwidth',
-  'Infra OS services':  '/settings/infra-os',
+  'Coverage':           '/settings/infra-os',
   'Logging':            '/settings/logging',
   'Profile':            '/settings/profile',
 }
@@ -48,7 +48,7 @@ export default async function SettingsPage() {
         { title: 'General', items: ['General'] },
         { title: 'Integrations', items: ['Email SMTP', 'Integrations', 'Alert channels'] },
         { title: 'Security', items: ['Users', 'Change password', 'API tokens', 'Session management'] },
-        { title: 'Backup defaults', items: ['Retention policy', 'Bandwidth limits', 'Schedule windows', 'Infra OS services'] },
+        { title: 'Backup defaults', items: ['Retention policy', 'Bandwidth limits', 'Schedule windows', 'Coverage'] },
         { title: 'Logging', items: ['Logging'] },
       ].map(section => (
         <div key={section.title} style={{


### PR DESCRIPTION
## Scope

Phase 3 of #106 (InfraOS federation). Pure UI changes — no schema migrations, no API changes, no server-action signature changes.

## What changed

- **`apps/web/app/(dashboard)/settings/page.tsx`** — `'Infra OS services'` → `'Coverage'` in the items array and `LINKED_ITEMS` map (URL `/settings/infra-os` preserved)
- **`apps/web/app/(dashboard)/settings/infra-os/page.tsx`** — H1 heading → `Coverage`; updated subtitle; added `Create backup job →` link on each uncovered service row, linking to `/jobs/new?infraServiceId=<id>`
- **`apps/web/app/(dashboard)/jobs/new/page.tsx`** — replaced the conditional hidden `<input type="hidden" name="infraServiceId">` with a visible `<select>` dropdown above the schedule field; pre-selected via URL param `?infraServiceId=`; updated banner text from "Infra OS service registry" to "coverage registry"

## Out of scope

- Auto-discovery of services from agents
- Coverage SLA tracking / alerting
- Per-service health drill-down

## Naming collision context

`Infra OS` inside BackupOS conflicted with the separate Infra OS product (infraos.app). User-facing labels renamed; URL (`/settings/infra-os`), DB table (`infra_os_services`), and all internal TypeScript identifiers (`infraOsServices`, `addInfraServiceAction`, etc.) are unchanged to avoid a wide refactor with no user benefit.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)