### PR TITLE
feat(error-pages): branded error pages (#164)

### DIFF
--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { LogoMark } from '@/components/ui/logo-mark'
+import { authClient } from '@/lib/auth-client'
 
 type Props = {
   error: Error & { digest?: string }
@@ -42,6 +44,8 @@ function copyFor(kind: ErrorKind, message: string): { title: string; body: strin
 }
 
 export default function ErrorPage({ error, reset }: Props) {
+  const router = useRouter()
+
   useEffect(() => {
     console.error('[error.tsx] caught error', { message: error.message, digest: error.digest })
   }, [error])
@@ -49,6 +53,11 @@ export default function ErrorPage({ error, reset }: Props) {
   const kind = classifyError(error.message)
   const { title, body } = copyFor(kind, error.message)
   const showSignOut = kind === 'permission'
+
+  async function handleSignOut() {
+    await authClient.signOut()
+    router.push('/login')
+  }
 
   return (
     <div
@@ -141,8 +150,8 @@ export default function ErrorPage({ error, reset }: Props) {
           </Link>
 
           {showSignOut && (
-            <Link
-              href="/logout"
+            <button
+              onClick={handleSignOut}
               style={{
                 background: 'transparent',
                 color: 'var(--fg-mute)',
@@ -151,13 +160,14 @@ export default function ErrorPage({ error, reset }: Props) {
                 padding: '10px 16px',
                 fontSize: 14,
                 fontWeight: 500,
-                textDecoration: 'none',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
                 display: 'inline-flex',
                 alignItems: 'center',
               }}
             >
               Sign out
-            </Link>
+            </button>
           )}
         </div>
       </div>

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { LogoMark } from '@/components/ui/logo-mark'
+
+type Props = {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+type ErrorKind = 'permission' | 'user_action' | 'generic'
+
+function classifyError(message: string): ErrorKind {
+  if (message.startsWith('Forbidden:')) return 'permission'
+  if (message.startsWith('Cannot '))    return 'user_action'
+  return 'generic'
+}
+
+function copyFor(kind: ErrorKind, message: string): { title: string; body: string } {
+  switch (kind) {
+    case 'permission':
+      return {
+        title: 'Permission denied',
+        body:
+          message.replace(/^Forbidden:\s*/, '') ||
+          'You do not have permission to perform this action.',
+      }
+    case 'user_action':
+      return {
+        title: 'Try a different action',
+        body: message,
+      }
+    case 'generic':
+      return {
+        title: 'Something went wrong',
+        body:
+          'An unexpected error occurred. Try going back, or return to the dashboard. ' +
+          'If this keeps happening, contact your administrator.',
+      }
+  }
+}
+
+export default function ErrorPage({ error, reset }: Props) {
+  useEffect(() => {
+    console.error('[error.tsx] caught error', { message: error.message, digest: error.digest })
+  }, [error])
+
+  const kind = classifyError(error.message)
+  const { title, body } = copyFor(kind, error.message)
+  const showSignOut = kind === 'permission'
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: 'var(--bg)',
+        color: 'var(--fg)',
+        fontFamily: 'var(--font-sans)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 'var(--space-6)',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 480,
+          background: 'var(--surf)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius)',
+          padding: 'var(--space-8)',
+          boxShadow: 'var(--shadow)',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)', marginBottom: 'var(--space-6)' }}>
+          <LogoMark size={40} />
+          <span style={{ fontSize: 16, fontWeight: 600, color: 'var(--fg)' }}>BackupOS</span>
+        </div>
+
+        <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginBottom: 'var(--space-3)' }}>
+          {title}
+        </h1>
+
+        <p style={{ fontSize: 14, color: 'var(--fg-mute)', lineHeight: 1.5, marginBottom: 'var(--space-6)' }}>
+          {body}
+        </p>
+
+        {error.digest && (
+          <div
+            style={{
+              fontSize: 12,
+              fontFamily: 'var(--font-mono)',
+              color: 'var(--fg-dim)',
+              background: 'var(--surf2)',
+              border: '1px solid var(--border2)',
+              borderRadius: 'var(--radius-sm)',
+              padding: 'var(--space-3)',
+              marginBottom: 'var(--space-6)',
+            }}
+          >
+            Error ID: {error.digest}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 'var(--space-3)', flexWrap: 'wrap' }}>
+          <button
+            onClick={reset}
+            style={{
+              background: 'var(--accent)',
+              color: 'var(--accent-fg)',
+              border: 'none',
+              borderRadius: 'var(--radius-sm)',
+              padding: '10px 16px',
+              fontSize: 14,
+              fontWeight: 500,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+            }}
+          >
+            Try again
+          </button>
+
+          <Link
+            href="/"
+            style={{
+              background: 'var(--surf2)',
+              color: 'var(--fg)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius-sm)',
+              padding: '10px 16px',
+              fontSize: 14,
+              fontWeight: 500,
+              textDecoration: 'none',
+              display: 'inline-flex',
+              alignItems: 'center',
+            }}
+          >
+            Go to dashboard
+          </Link>
+
+          {showSignOut && (
+            <Link
+              href="/logout"
+              style={{
+                background: 'transparent',
+                color: 'var(--fg-mute)',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--radius-sm)',
+                padding: '10px 16px',
+                fontSize: 14,
+                fontWeight: 500,
+                textDecoration: 'none',
+                display: 'inline-flex',
+                alignItems: 'center',
+              }}
+            >
+              Sign out
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+type Props = {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function GlobalErrorPage({ error, reset }: Props) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, fontFamily: 'system-ui, -apple-system, sans-serif', background: '#0A0A0A', color: '#EDEDED' }}>
+        <div
+          style={{
+            minHeight: '100vh',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 24,
+          }}
+        >
+          <div
+            style={{
+              width: '100%',
+              maxWidth: 480,
+              background: '#141414',
+              border: '1px solid #242424',
+              borderRadius: 12,
+              padding: 32,
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 24 }}>
+              <svg width="40" height="40" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-label="BackupOS">
+                <rect width="48" height="48" rx="16" fill="#1A1206" />
+                <rect x="6"  y="6"  width="16" height="16" rx="2" fill="#F5A623" />
+                <rect x="26" y="6"  width="16" height="16" rx="2" fill="#854F0B" />
+                <rect x="6"  y="26" width="16" height="16" rx="2" fill="#854F0B" />
+                <rect x="26" y="26" width="16" height="16" rx="2" fill="#C77A14" />
+                <rect x="18" y="18" width="12" height="12" rx="2" fill="#FEF5E0" />
+              </svg>
+              <span style={{ fontSize: 16, fontWeight: 600 }}>BackupOS</span>
+            </div>
+
+            <h1 style={{ fontSize: 22, fontWeight: 600, marginBottom: 12 }}>Application error</h1>
+
+            <p style={{ fontSize: 14, color: '#9A9A9A', lineHeight: 1.5, marginBottom: 24 }}>
+              The application encountered a critical error and could not load. Try reloading the page.
+              If this keeps happening, contact your administrator.
+            </p>
+
+            {error.digest && (
+              <div
+                style={{
+                  fontSize: 12,
+                  fontFamily: 'ui-monospace, monospace',
+                  color: '#6B6B6B',
+                  background: '#1A1A1A',
+                  border: '1px solid #2E2E2E',
+                  borderRadius: 8,
+                  padding: 12,
+                  marginBottom: 24,
+                }}
+              >
+                Error ID: {error.digest}
+              </div>
+            )}
+
+            <button
+              onClick={reset}
+              style={{
+                background: '#F5A623',
+                color: '#000000',
+                border: 'none',
+                borderRadius: 8,
+                padding: '10px 16px',
+                fontSize: 14,
+                fontWeight: 500,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link'
+import { LogoMark } from '@/components/ui/logo-mark'
+
+export default function NotFound() {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: 'var(--bg)',
+        color: 'var(--fg)',
+        fontFamily: 'var(--font-sans)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 'var(--space-6)',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 480,
+          background: 'var(--surf)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius)',
+          padding: 'var(--space-8)',
+          boxShadow: 'var(--shadow)',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)', marginBottom: 'var(--space-6)' }}>
+          <LogoMark size={40} />
+          <span style={{ fontSize: 16, fontWeight: 600, color: 'var(--fg)' }}>BackupOS</span>
+        </div>
+
+        <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginBottom: 'var(--space-3)' }}>
+          Page not found
+        </h1>
+
+        <p style={{ fontSize: 14, color: 'var(--fg-mute)', lineHeight: 1.5, marginBottom: 'var(--space-6)' }}>
+          The page you were looking for does not exist or has been moved.
+        </p>
+
+        <Link
+          href="/"
+          style={{
+            background: 'var(--accent)',
+            color: 'var(--accent-fg)',
+            border: 'none',
+            borderRadius: 'var(--radius-sm)',
+            padding: '10px 16px',
+            fontSize: 14,
+            fontWeight: 500,
+            textDecoration: 'none',
+            display: 'inline-flex',
+            alignItems: 'center',
+          }}
+        >
+          Go to dashboard
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/ui/logo-mark.tsx
+++ b/apps/web/components/ui/logo-mark.tsx
@@ -1,0 +1,24 @@
+type Props = {
+  size?: number
+  className?: string
+}
+
+export function LogoMark({ size = 48, className }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-label="BackupOS"
+    >
+      <rect width="48" height="48" rx="16" fill="#1A1206" />
+      <rect x="6"  y="6"  width="16" height="16" rx="2" fill="#F5A623" />
+      <rect x="26" y="6"  width="16" height="16" rx="2" fill="#854F0B" />
+      <rect x="6"  y="26" width="16" height="16" rx="2" fill="#854F0B" />
+      <rect x="26" y="26" width="16" height="16" rx="2" fill="#C77A14" />
+      <rect x="18" y="18" width="12" height="12" rx="2" fill="#FEF5E0" />
+    </svg>
+  )
+}


### PR DESCRIPTION
Closes #164.

## What this does
- `apps/web/app/error.tsx` — branded error page with three error categories (permission / user_action / generic)
- `apps/web/app/global-error.tsx` — branded fallback for root-layout errors, inlines styles
- `apps/web/app/not-found.tsx` — branded 404
- `apps/web/components/ui/logo-mark.tsx` — reusable inline-SVG logo component

## Behaviour matrix
| Error message starts with | Title | Sign out shown |
|---|---|---|
| `Forbidden:` | Permission denied | Yes |
| `Cannot ` | Try a different action | No |
| anything else | Something went wrong | No |

## Testing on staging after merge
- Trigger a permission error: log in as a viewer and POST to an admin-only server action → page shows 'Permission denied' with Sign out
- Trigger a generic error: e.g. break a DB query temporarily → page shows 'Something went wrong' + digest
- Visit `/this-route-does-not-exist` → page shows 'Page not found'

## Out of scope
- Sentry / error reporting integration (errors are logged to console.error only)
- Localised error messages (English only for V1)