### PR TITLE
feat(snapshots): drill-down + per-row Restore (#152, #153)

### DIFF
--- a/apps/web/app/(dashboard)/snapshots/flat-view.tsx
+++ b/apps/web/app/(dashboard)/snapshots/flat-view.tsx
@@ -1,0 +1,220 @@
+import { getDb, snapshots, repositories, backupJobs } from '@backupos/db'
+import { PageHeader } from '@/components/ui/page-header'
+import { eq } from '@backupos/db'
+import { SnapshotActions } from '@/components/snapshot-actions'
+import { Pin, Lock } from 'lucide-react'
+
+function safeParseTags(json: string | null): string[] {
+  if (!json) return []
+  try { return JSON.parse(json) } catch { return [] }
+}
+
+function fmtBytes(bytes: number | null): string {
+  if (!bytes) return '—'
+  if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`
+  if (bytes >= 1_048_576)     return `${(bytes / 1_048_576).toFixed(0)} MB`
+  return `${(bytes / 1024).toFixed(0)} KB`
+}
+
+function buildUrl(
+  repoFilter: string,
+  listFilter: string,
+  tagFilter: string,
+  overrides: Record<string, string>,
+): string {
+  const p = new URLSearchParams()
+  p.set('view', 'all')
+  if (repoFilter)             p.set('repo',   repoFilter)
+  if (listFilter !== 'all')   p.set('filter', listFilter)
+  if (tagFilter)              p.set('tag',    tagFilter)
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v) p.set(k, v); else p.delete(k)
+  }
+  const s = p.toString()
+  return `/snapshots${s ? `?${s}` : ''}`
+}
+
+export async function SnapshotsFlatView({ searchParams }: { searchParams: { repo?: string; filter?: string; tag?: string } }) {
+  const repoFilter = searchParams.repo   ?? ''
+  const listFilter = searchParams.filter ?? 'all'
+  const tagFilter  = searchParams.tag    ?? ''
+
+  const db    = getDb()
+  const repos = await db.select({ id: repositories.id, name: repositories.name }).from(repositories).all()
+  const jobs  = await db.select({ id: backupJobs.id, name: backupJobs.name }).from(backupJobs).all()
+
+  const allSnaps = repoFilter
+    ? await db.select().from(snapshots).where(eq(snapshots.repositoryId, repoFilter)).all()
+    : await db.select().from(snapshots).all()
+
+  const filtered = allSnaps.filter(s => {
+    if (listFilter === 'pinned') return s.pinned
+    if (listFilter === 'held')   return s.retentionHold
+    if (listFilter === 'tagged') return safeParseTags(s.customTags).length > 0
+    return true
+  }).filter(s => {
+    if (!tagFilter) return true
+    return safeParseTags(s.customTags).includes(tagFilter)
+  })
+
+  const pinnedCount = allSnaps.filter(s => s.pinned).length
+  const heldCount   = allSnaps.filter(s => s.retentionHold).length
+
+  const FILTER_TABS = [
+    { id: 'all',    label: 'All' },
+    { id: 'pinned', label: `Pinned${pinnedCount > 0 ? ` (${pinnedCount})` : ''}` },
+    { id: 'held',   label: `Held${heldCount > 0 ? ` (${heldCount})` : ''}` },
+    { id: 'tagged', label: 'Tagged' },
+  ]
+
+  return (
+    <div style={{ padding: '32px 40px' }}>
+      {/* Header */}
+      <div style={{ marginBottom: 24 }}>
+        <PageHeader title="Snapshots" />
+        {(pinnedCount > 0 || heldCount > 0) && (
+          <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>
+            {pinnedCount > 0 && <span>{pinnedCount} pinned</span>}
+            {pinnedCount > 0 && heldCount > 0 && <span> · </span>}
+            {heldCount > 0 && <span>{heldCount} under retention hold</span>}
+            <span style={{ color: 'var(--fg-dim)' }}> — protected from forget policy</span>
+          </div>
+        )}
+      </div>
+
+      {/* Controls row */}
+      <div style={{ display: 'flex', gap: 12, marginBottom: 20, alignItems: 'center', flexWrap: 'wrap' }}>
+        {/* Repo selector as a GET form */}
+        <form method="get" action="/snapshots">
+          <input type="hidden" name="view" value="all" />
+          <select
+            name="repo"
+            defaultValue={repoFilter}
+            style={{
+              padding: '6px 10px', fontSize: 13,
+              backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+              borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none',
+            }}
+          >
+            <option value="">All repositories</option>
+            {repos.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
+          </select>
+          {listFilter !== 'all' && <input type="hidden" name="filter" value={listFilter} />}
+          {tagFilter && <input type="hidden" name="tag" value={tagFilter} />}
+          <button type="submit" style={{
+            marginLeft: 6, padding: '6px 10px', fontSize: 13, cursor: 'pointer',
+            borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+            background: 'none', color: 'var(--fg-mute)',
+          }}>Go</button>
+        </form>
+
+        {/* Filter chips */}
+        <div style={{ display: 'flex', gap: 6 }}>
+          {FILTER_TABS.map(tab => (
+            <a
+              key={tab.id}
+              href={buildUrl(repoFilter, listFilter, tagFilter, { filter: tab.id === 'all' ? '' : tab.id, tag: '' })}
+              style={{
+                padding: '4px 12px', fontSize: 12, borderRadius: 20,
+                textDecoration: 'none', cursor: 'pointer',
+                border: '1px solid var(--border)',
+                backgroundColor: listFilter === tab.id ? 'var(--accent)' : 'var(--surf2)',
+                color: listFilter === tab.id ? '#fff' : 'var(--fg-mute)',
+              }}
+            >
+              {tab.label}
+            </a>
+          ))}
+        </div>
+
+        {tagFilter && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: 'var(--fg-mute)' }}>
+            Tag: <strong style={{ color: 'var(--fg)' }}>{tagFilter}</strong>
+            <a href={buildUrl(repoFilter, listFilter, tagFilter, { tag: '' })} style={{ color: 'var(--fg-dim)', textDecoration: 'none' }}>✕</a>
+          </div>
+        )}
+      </div>
+
+      {/* Table */}
+      {filtered.length === 0 ? (
+        <div style={{ fontSize: 13, color: 'var(--fg-dim)', padding: '40px 0', textAlign: 'center' }}>
+          {allSnaps.length === 0
+            ? 'No snapshots yet. Run a backup job to create the first snapshot.'
+            : 'No snapshots match the current filter.'}
+        </div>
+      ) : (
+        <div style={{ border: '1px solid var(--border)', borderRadius: 'var(--radius)', overflow: 'hidden' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ backgroundColor: 'var(--surf2)', borderBottom: '1px solid var(--border)' }}>
+                {['Snapshot', 'Job', 'Date', 'Size', 'Tags', 'Actions'].map(h => (
+                  <th key={h} style={{ padding: '10px 16px', fontSize: 11, fontWeight: 500, color: 'var(--fg-dim)', textAlign: 'left', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((snap, i) => {
+                const job        = jobs.find(j => j.id === snap.jobId)
+                const resticTags: string[] = safeParseTags(snap.tags)
+                const userTags:   string[] = safeParseTags(snap.customTags)
+                return (
+                  <tr key={snap.id} style={{ borderTop: i === 0 ? 'none' : '1px solid var(--border)', backgroundColor: 'var(--surf)' }}>
+                    <td style={{ padding: '12px 16px' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                        {snap.pinned        && <Pin  size={12} color="var(--accent)" />}
+                        {snap.retentionHold && <span title={snap.holdReason ?? 'Retention hold'}><Lock size={12} color="var(--warn)" /></span>}
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg)' }}>{snap.id}</span>
+                      </div>
+                      {snap.retentionHold && snap.holdExpiresAt && (
+                        <div style={{ fontSize: 11, color: 'var(--warn)', marginTop: 2 }}>
+                          Hold until {snap.holdExpiresAt.toLocaleDateString()}
+                        </div>
+                      )}
+                    </td>
+                    <td style={{ padding: '12px 16px', fontSize: 13, color: 'var(--fg-mute)' }}>
+                      {job?.name ?? '—'}
+                    </td>
+                    <td style={{ padding: '12px 16px', fontSize: 13, color: 'var(--fg-mute)', whiteSpace: 'nowrap' }}>
+                      {snap.createdAt ? snap.createdAt.toLocaleDateString() : '—'}
+                    </td>
+                    <td style={{ padding: '12px 16px', fontSize: 13, color: 'var(--fg-mute)', whiteSpace: 'nowrap' }}>
+                      {fmtBytes(snap.sizeBytes)}
+                    </td>
+                    <td style={{ padding: '12px 16px' }}>
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                        {resticTags.map(t => (
+                          <span key={t} style={{
+                            fontSize: 10, padding: '1px 5px',
+                            backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+                            borderRadius: 3, color: 'var(--fg-dim)',
+                          }}>{t}</span>
+                        ))}
+                        {userTags.map(t => (
+                          <a key={t} href={buildUrl(repoFilter, listFilter, tagFilter, { tag: t, filter: '' })} style={{
+                            fontSize: 10, padding: '1px 5px', textDecoration: 'none',
+                            backgroundColor: 'color-mix(in srgb, var(--surf2) 70%, var(--accent) 20%)',
+                            border: '1px solid var(--accent)', borderRadius: 3, color: 'var(--accent)',
+                          }}>{t}</a>
+                        ))}
+                      </div>
+                    </td>
+                    <td style={{ padding: '12px 16px' }}>
+                      <SnapshotActions
+                        id={snap.id}
+                        pinned={snap.pinned}
+                        retentionHold={snap.retentionHold}
+                        holdReason={snap.holdReason}
+                        holdExpiresAt={snap.holdExpiresAt}
+                        customTags={userTags}
+                      />
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/snapshots/host/[hostname]/job/[jobId]/page.tsx
+++ b/apps/web/app/(dashboard)/snapshots/host/[hostname]/job/[jobId]/page.tsx
@@ -1,0 +1,111 @@
+import { getDb, snapshots, backupJobs } from '@backupos/db'
+import { eq, and, desc } from '@backupos/db'
+import { notFound } from 'next/navigation'
+import { Pin, Lock } from 'lucide-react'
+import { PageHeader } from '@/components/ui/page-header'
+import { SnapshotActions } from '@/components/snapshot-actions'
+
+interface PageProps {
+  params: Promise<{ hostname: string; jobId: string }>
+}
+
+function fmtBytes(bytes: number | null): string {
+  if (!bytes) return '—'
+  if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`
+  if (bytes >= 1_048_576)     return `${(bytes / 1_048_576).toFixed(0)} MB`
+  return `${(bytes / 1024).toFixed(0)} KB`
+}
+
+function safeParseTags(json: string | null): string[] {
+  if (!json) return []
+  try { return JSON.parse(json) } catch { return [] }
+}
+
+export default async function JobSnapshotsPage({ params }: PageProps) {
+  const { hostname: rawHostname, jobId: rawJobId } = await params
+  const hostname = decodeURIComponent(rawHostname)
+  const jobId = decodeURIComponent(rawJobId)
+  const db = getDb()
+
+  const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, jobId)).limit(1)
+  if (!job) notFound()
+
+  const rows = await db
+    .select()
+    .from(snapshots)
+    .where(and(eq(snapshots.hostname, hostname), eq(snapshots.jobId, jobId)))
+    .orderBy(desc(snapshots.createdAt))
+    .all()
+
+  return (
+    <div style={{ padding: '32px 40px' }}>
+      <div style={{ marginBottom: 24 }}>
+        <PageHeader title={job.name} />
+        <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>
+          {rows.length} snapshot{rows.length === 1 ? '' : 's'} on {hostname}
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <div style={{ fontSize: 13, color: 'var(--fg-dim)', padding: '40px 0', textAlign: 'center' }}>
+          No snapshots for this job.
+        </div>
+      ) : (
+        <div style={{ border: '1px solid var(--border)', borderRadius: 'var(--radius)', overflow: 'hidden' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ backgroundColor: 'var(--surf2)', borderBottom: '1px solid var(--border)' }}>
+                {['Snapshot', 'Date', 'Size', 'Tags', 'Actions'].map(h => (
+                  <th key={h} style={{ padding: '10px 16px', fontSize: 11, fontWeight: 500, color: 'var(--fg-dim)', textAlign: 'left', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((snap, i) => {
+                const resticTags = safeParseTags(snap.tags)
+                const userTags   = safeParseTags(snap.customTags)
+                return (
+                  <tr key={snap.id} style={{ borderTop: i === 0 ? 'none' : '1px solid var(--border)', backgroundColor: 'var(--surf)' }}>
+                    <td style={{ padding: '12px 16px' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                        {snap.pinned        && <Pin  size={12} color="var(--accent)" />}
+                        {snap.retentionHold && <span title={snap.holdReason ?? 'Retention hold'}><Lock size={12} color="var(--warn)" /></span>}
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg)' }}>{snap.id}</span>
+                      </div>
+                    </td>
+                    <td style={{ padding: '12px 16px', fontSize: 13, color: 'var(--fg-mute)', whiteSpace: 'nowrap' }}>
+                      {snap.createdAt ? snap.createdAt.toLocaleDateString() : '—'}
+                    </td>
+                    <td style={{ padding: '12px 16px', fontSize: 13, color: 'var(--fg-mute)', whiteSpace: 'nowrap' }}>
+                      {fmtBytes(snap.sizeBytes)}
+                    </td>
+                    <td style={{ padding: '12px 16px' }}>
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                        {resticTags.map(t => (
+                          <span key={t} style={{ fontSize: 10, padding: '1px 5px', backgroundColor: 'var(--surf2)', border: '1px solid var(--border)', borderRadius: 3, color: 'var(--fg-dim)' }}>{t}</span>
+                        ))}
+                        {userTags.map(t => (
+                          <span key={t} style={{ fontSize: 10, padding: '1px 5px', backgroundColor: 'color-mix(in srgb, var(--surf2) 70%, var(--accent) 20%)', border: '1px solid var(--accent)', borderRadius: 3, color: 'var(--accent)' }}>{t}</span>
+                        ))}
+                      </div>
+                    </td>
+                    <td style={{ padding: '12px 16px' }}>
+                      <SnapshotActions
+                        id={snap.id}
+                        pinned={snap.pinned}
+                        retentionHold={snap.retentionHold}
+                        holdReason={snap.holdReason}
+                        holdExpiresAt={snap.holdExpiresAt}
+                        customTags={userTags}
+                      />
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/snapshots/host/[hostname]/job/[jobId]/page.tsx
+++ b/apps/web/app/(dashboard)/snapshots/host/[hostname]/job/[jobId]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import { Pin, Lock } from 'lucide-react'
 import { PageHeader } from '@/components/ui/page-header'
 import { SnapshotActions } from '@/components/snapshot-actions'
+import { RestoreFromSnapshotButton } from '@/components/restore-from-snapshot-modal'
 
 interface PageProps {
   params: Promise<{ hostname: string; jobId: string }>
@@ -19,6 +20,11 @@ function fmtBytes(bytes: number | null): string {
 function safeParseTags(json: string | null): string[] {
   if (!json) return []
   try { return JSON.parse(json) } catch { return [] }
+}
+
+function safeParseArray(json: string | null): string[] {
+  if (!json) return []
+  try { const v = JSON.parse(json); return Array.isArray(v) ? v : [] } catch { return [] }
 }
 
 export default async function JobSnapshotsPage({ params }: PageProps) {
@@ -55,15 +61,16 @@ export default async function JobSnapshotsPage({ params }: PageProps) {
           <table style={{ width: '100%', borderCollapse: 'collapse' }}>
             <thead>
               <tr style={{ backgroundColor: 'var(--surf2)', borderBottom: '1px solid var(--border)' }}>
-                {['Snapshot', 'Date', 'Size', 'Tags', 'Actions'].map(h => (
+                {['Snapshot', 'Date', 'Size', 'Tags', 'Restore', 'Actions'].map(h => (
                   <th key={h} style={{ padding: '10px 16px', fontSize: 11, fontWeight: 500, color: 'var(--fg-dim)', textAlign: 'left', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{h}</th>
                 ))}
               </tr>
             </thead>
             <tbody>
               {rows.map((snap, i) => {
-                const resticTags = safeParseTags(snap.tags)
-                const userTags   = safeParseTags(snap.customTags)
+                const resticTags    = safeParseTags(snap.tags)
+                const userTags      = safeParseTags(snap.customTags)
+                const snapshotPaths = safeParseArray(snap.paths)
                 return (
                   <tr key={snap.id} style={{ borderTop: i === 0 ? 'none' : '1px solid var(--border)', backgroundColor: 'var(--surf)' }}>
                     <td style={{ padding: '12px 16px' }}>
@@ -88,6 +95,12 @@ export default async function JobSnapshotsPage({ params }: PageProps) {
                           <span key={t} style={{ fontSize: 10, padding: '1px 5px', backgroundColor: 'color-mix(in srgb, var(--surf2) 70%, var(--accent) 20%)', border: '1px solid var(--accent)', borderRadius: 3, color: 'var(--accent)' }}>{t}</span>
                         ))}
                       </div>
+                    </td>
+                    <td style={{ padding: '12px 16px' }}>
+                      <RestoreFromSnapshotButton
+                        snapshotId={snap.id}
+                        snapshotPaths={snapshotPaths}
+                      />
                     </td>
                     <td style={{ padding: '12px 16px' }}>
                       <SnapshotActions

--- a/apps/web/app/(dashboard)/snapshots/host/[hostname]/page.tsx
+++ b/apps/web/app/(dashboard)/snapshots/host/[hostname]/page.tsx
@@ -1,91 +1,73 @@
-import { getDb, snapshots } from '@backupos/db'
-import { sql, desc } from '@backupos/db'
+import { getDb, snapshots, backupJobs } from '@backupos/db'
+import { eq, sql, desc } from '@backupos/db'
 import Link from 'next/link'
 import { ChevronRight } from 'lucide-react'
 import { PageHeader } from '@/components/ui/page-header'
-import { SnapshotsFlatView } from './flat-view'
 
 interface PageProps {
-  searchParams: Promise<{
-    view?:   string
-    repo?:   string
-    filter?: string
-    tag?:    string
-  }>
+  params: Promise<{ hostname: string }>
 }
 
-export default async function SnapshotsPage({ searchParams }: PageProps) {
-  const params = await searchParams
+function fmtBytes(bytes: number | null): string {
+  if (!bytes) return '—'
+  if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`
+  if (bytes >= 1_048_576)     return `${(bytes / 1_048_576).toFixed(0)} MB`
+  return `${(bytes / 1024).toFixed(0)} KB`
+}
 
-  if (params.view === 'all') {
-    return <SnapshotsFlatView searchParams={params} />
-  }
-
+export default async function HostJobsPage({ params }: PageProps) {
+  const { hostname: rawHostname } = await params
+  const hostname = decodeURIComponent(rawHostname)
   const db = getDb()
 
   const rows = await db
     .select({
-      hostname:      snapshots.hostname,
+      jobId:         snapshots.jobId,
+      jobName:       backupJobs.name,
       snapshotCount: sql<number>`count(*)`.as('snapshot_count'),
       mostRecent:    sql<number>`max(${snapshots.createdAt})`.as('most_recent'),
+      totalSize:     sql<number>`sum(${snapshots.sizeBytes})`.as('total_size'),
     })
     .from(snapshots)
-    .groupBy(snapshots.hostname)
+    .leftJoin(backupJobs, eq(backupJobs.id, snapshots.jobId))
+    .where(eq(snapshots.hostname, hostname))
+    .groupBy(snapshots.jobId, backupJobs.name)
     .orderBy(desc(sql`max(${snapshots.createdAt})`))
     .all()
 
-  const totalCount = rows.reduce((acc, r) => acc + Number(r.snapshotCount), 0)
-
   return (
     <div style={{ padding: '32px 40px' }}>
-      <div style={{ marginBottom: 24, display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 16 }}>
-        <div>
-          <PageHeader title="Snapshots" />
-          {totalCount > 0 && (
-            <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>
-              {totalCount} snapshot{totalCount === 1 ? '' : 's'} across {rows.length} host{rows.length === 1 ? '' : 's'}
-            </div>
-          )}
+      <div style={{ marginBottom: 24 }}>
+        <PageHeader title={hostname} />
+        <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>
+          {rows.length} job{rows.length === 1 ? '' : 's'} on this host
         </div>
-        <Link
-          href="/snapshots?view=all"
-          style={{
-            fontSize: 12, color: 'var(--fg-dim)', textDecoration: 'none',
-            padding: '6px 10px', borderRadius: 'var(--radius-sm)',
-            border: '1px solid var(--border)',
-          }}
-        >
-          Show all snapshots →
-        </Link>
       </div>
 
       {rows.length === 0 ? (
         <div style={{ fontSize: 13, color: 'var(--fg-dim)', padding: '40px 0', textAlign: 'center' }}>
-          No snapshots yet. Run a backup job to create the first snapshot.
+          No snapshots found for host <strong>{hostname}</strong>.
         </div>
       ) : (
         <div style={{ border: '1px solid var(--border)', borderRadius: 'var(--radius)', overflow: 'hidden' }}>
           <table style={{ width: '100%', borderCollapse: 'collapse' }}>
             <thead>
               <tr style={{ backgroundColor: 'var(--surf2)', borderBottom: '1px solid var(--border)' }}>
-                {['Host', 'Snapshots', 'Most recent', ''].map(h => (
+                {['Job', 'Snapshots', 'Most recent', 'Total size', ''].map(h => (
                   <th key={h} style={{ padding: '10px 16px', fontSize: 11, fontWeight: 500, color: 'var(--fg-dim)', textAlign: 'left', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{h}</th>
                 ))}
               </tr>
             </thead>
             <tbody>
               {rows.map((r, i) => {
-                const hostname = r.hostname ?? '(unknown)'
+                const jobId = r.jobId ?? '(no job)'
+                const jobName = r.jobName ?? '(deleted job)'
                 const mostRecent = r.mostRecent ? new Date(Number(r.mostRecent)) : null
+                const href = r.jobId ? `/snapshots/host/${encodeURIComponent(hostname)}/job/${encodeURIComponent(r.jobId)}` : '#'
                 return (
-                  <tr key={hostname} style={{ borderTop: i === 0 ? 'none' : '1px solid var(--border)', backgroundColor: 'var(--surf)' }}>
+                  <tr key={jobId} style={{ borderTop: i === 0 ? 'none' : '1px solid var(--border)', backgroundColor: 'var(--surf)' }}>
                     <td style={{ padding: '12px 16px', fontSize: 13, fontWeight: 500, color: 'var(--fg)' }}>
-                      <Link
-                        href={`/snapshots/host/${encodeURIComponent(hostname)}`}
-                        style={{ color: 'inherit', textDecoration: 'none' }}
-                      >
-                        {hostname}
-                      </Link>
+                      {r.jobId ? <Link href={href} style={{ color: 'inherit', textDecoration: 'none' }}>{jobName}</Link> : jobName}
                     </td>
                     <td style={{ padding: '12px 16px', fontSize: 13, color: 'var(--fg-mute)' }}>
                       {Number(r.snapshotCount)}
@@ -93,10 +75,11 @@ export default async function SnapshotsPage({ searchParams }: PageProps) {
                     <td style={{ padding: '12px 16px', fontSize: 13, color: 'var(--fg-mute)', whiteSpace: 'nowrap' }}>
                       {mostRecent ? mostRecent.toLocaleDateString() : '—'}
                     </td>
+                    <td style={{ padding: '12px 16px', fontSize: 13, color: 'var(--fg-mute)', whiteSpace: 'nowrap' }}>
+                      {fmtBytes(Number(r.totalSize))}
+                    </td>
                     <td style={{ padding: '12px 16px', textAlign: 'right' }}>
-                      <Link href={`/snapshots/host/${encodeURIComponent(hostname)}`} style={{ color: 'var(--fg-dim)' }}>
-                        <ChevronRight size={14} />
-                      </Link>
+                      {r.jobId && <Link href={href} style={{ color: 'var(--fg-dim)' }}><ChevronRight size={14} /></Link>}
                     </td>
                   </tr>
                 )

--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, eq, desc } from '@backupos/db'
-import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult } from '@backupos/restore'
+import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult, type ParsedRestoreSpec, type FilesystemRestoreStep } from '@backupos/restore'
 import { requireAdmin } from '@/lib/user'
 
 export async function validateSpec(yaml: string): Promise<{ ok: true } | { ok: false; error: string }> {
@@ -144,4 +144,80 @@ export async function runSpecWithSnapshot(
     }
     return { error: err instanceof Error ? err.message : String(err) }
   }
+}
+
+interface RestoreFromSnapshotInput {
+  snapshotId:  string
+  sourcePath:  string
+  targetType:  'temp' | 'inplace' | 'custom'
+  customPath?: string
+}
+
+export async function restoreFromSnapshot(
+  input: RestoreFromSnapshotInput,
+): Promise<{ ok: true; runId: string } | { ok: false; error: string }> {
+  await requireAdmin()
+
+  const { snapshotId, sourcePath, targetType, customPath } = input
+
+  let targetPath: string
+  switch (targetType) {
+    case 'temp':
+      targetPath = `/tmp/backupos-restore-${snapshotId.slice(0, 8)}-${Date.now()}`
+      break
+    case 'inplace':
+      targetPath = sourcePath
+      break
+    case 'custom':
+      if (!customPath || !customPath.startsWith('/')) {
+        return { ok: false, error: 'Custom path must be an absolute path starting with /' }
+      }
+      targetPath = customPath
+      break
+  }
+
+  const fsStep: FilesystemRestoreStep = {
+    name:         `Ad-hoc restore of ${sourcePath}`,
+    type:         'filesystem_restore',
+    snapshotPath: sourcePath,
+    targetPath,
+    onFailure:    'abort',
+  }
+  const adhocSpec: ParsedRestoreSpec = {
+    name:        'ad-hoc',
+    description: `Ad-hoc filesystem restore from snapshot ${snapshotId}`,
+    version:     '1',
+    repository:  'adhoc',
+    steps:       [fsStep],
+  }
+
+  const db    = getDb()
+  const runId = crypto.randomUUID()
+
+  await db.insert(restoreRuns).values({
+    id: runId,
+    specId: null,
+    snapshotId,
+    status: 'running',
+    trigger: 'manual',
+    startedAt: new Date(),
+  })
+
+  executeRestoreSpec(adhocSpec, snapshotId, 'local').then(async (result: RestoreRunResult) => {
+    await db
+      .update(restoreRuns)
+      .set({
+        status:      result.success ? 'success' : 'failed',
+        log:         JSON.stringify(result.steps),
+        completedAt: result.completedAt ?? result.abortedAt ?? new Date(),
+      })
+      .where(eq(restoreRuns.id, runId))
+  }).catch(async (err: unknown) => {
+    await db.update(restoreRuns).set({
+      status: 'failed', completedAt: new Date(),
+    }).where(eq(restoreRuns.id, runId))
+    console.error('[restore] restoreFromSnapshot failed:', err)
+  })
+
+  return { ok: true, runId }
 }

--- a/apps/web/components/restore-from-snapshot-modal.tsx
+++ b/apps/web/components/restore-from-snapshot-modal.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { History, Database, AlertTriangle, X } from 'lucide-react'
+import Link from 'next/link'
+import { restoreFromSnapshot } from '@/app/actions/restore'
+
+interface Props {
+  snapshotId:    string
+  snapshotPaths: string[]
+  triggerLabel?: string
+}
+
+const DB_PATH_HINTS = [
+  '.sql', '.dump', '.rdb', '.bson',
+  'mongodump', 'pg_dump',
+  '/var/lib/postgresql', '/var/lib/mysql', '/var/lib/mongodb', '/var/lib/redis',
+]
+
+function looksLikeDatabaseSnapshot(paths: string[]): boolean {
+  return paths.some(p => DB_PATH_HINTS.some(hint => p.toLowerCase().includes(hint)))
+}
+
+export function RestoreFromSnapshotButton({ snapshotId, snapshotPaths, triggerLabel = 'Restore' }: Props) {
+  const [open, setOpen] = useState(false)
+  const [sourcePath, setSourcePath] = useState(snapshotPaths[0] ?? '/')
+  const [targetType, setTargetType] = useState<'temp' | 'inplace' | 'custom'>('temp')
+  const [customPath, setCustomPath] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+  const router = useRouter()
+
+  const isDb = looksLikeDatabaseSnapshot(snapshotPaths)
+
+  function close() {
+    setOpen(false)
+    setError(null)
+  }
+
+  function submit() {
+    setError(null)
+    startTransition(async () => {
+      const result = await restoreFromSnapshot({
+        snapshotId,
+        sourcePath,
+        targetType,
+        customPath: targetType === 'custom' ? customPath : undefined,
+      })
+      if (result.ok) {
+        router.push('/restore/runs')
+      } else {
+        setError(result.error)
+      }
+    })
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        style={{
+          padding: '4px 10px', fontSize: 12, cursor: 'pointer',
+          borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+          background: 'none', color: 'var(--fg)',
+          display: 'inline-flex', alignItems: 'center', gap: 4,
+        }}
+      >
+        <History size={12} />
+        {triggerLabel}
+      </button>
+
+      {open && (
+        <div
+          onClick={close}
+          style={{
+            position: 'fixed', inset: 0, zIndex: 200,
+            backgroundColor: 'rgba(0,0,0,0.5)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}
+        >
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{
+              backgroundColor: 'var(--bg)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              padding: '28px 32px',
+              width: 520, maxWidth: '90vw',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 24 }}>
+              <History size={18} color="var(--accent)" />
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--fg)' }}>Restore from snapshot</div>
+                <div style={{ fontSize: 12, color: 'var(--fg-mute)', fontFamily: 'var(--font-mono)' }}>{snapshotId}</div>
+              </div>
+              <button
+                onClick={close}
+                style={{ fontSize: 18, color: 'var(--fg-dim)', background: 'none', border: 'none', cursor: 'pointer', lineHeight: 1 }}
+              >
+                <X size={16} />
+              </button>
+            </div>
+
+            {isDb && (
+              <div style={{
+                marginBottom: 20, padding: '10px 14px',
+                borderRadius: 'var(--radius-sm)',
+                backgroundColor: 'color-mix(in srgb, var(--surf2) 80%, var(--warn) 10%)',
+                border: '1px solid var(--warn)',
+                display: 'flex', gap: 10, alignItems: 'flex-start',
+              }}>
+                <Database size={14} color="var(--warn)" style={{ marginTop: 2, flexShrink: 0 }} />
+                <div style={{ fontSize: 12, color: 'var(--fg)', lineHeight: 1.5 }}>
+                  This looks like a database snapshot. The ad-hoc restore below performs a raw filesystem
+                  restore only — for proper database recovery (with engine-aware handling),{' '}
+                  <Link href={`/restore/new?fromSnapshot=${snapshotId}`} style={{ color: 'var(--accent)', textDecoration: 'underline' }}>
+                    use the database restore wizard
+                  </Link>.
+                </div>
+              </div>
+            )}
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+              <div>
+                <label style={{ fontSize: 12, fontWeight: 500, color: 'var(--fg-mute)', display: 'block', marginBottom: 4 }}>
+                  Source path inside snapshot
+                </label>
+                <select
+                  value={sourcePath}
+                  onChange={e => setSourcePath(e.target.value)}
+                  style={{
+                    width: '100%', padding: '6px 10px', fontSize: 13,
+                    backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+                    borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none',
+                    fontFamily: 'var(--font-mono)',
+                  }}
+                >
+                  {snapshotPaths.map(p => <option key={p} value={p}>{p}</option>)}
+                </select>
+              </div>
+
+              <div>
+                <label style={{ fontSize: 12, fontWeight: 500, color: 'var(--fg-mute)', display: 'block', marginBottom: 4 }}>
+                  Target
+                </label>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  {([
+                    { v: 'temp',    label: 'Temp directory', hint: 'Restore to /tmp/backupos-restore-<id> for inspection' },
+                    { v: 'inplace', label: 'In-place',       hint: 'Restore to the original path (overwrites existing files)' },
+                    { v: 'custom',  label: 'Custom path',    hint: 'Specify an absolute path' },
+                  ] as const).map(opt => (
+                    <label
+                      key={opt.v}
+                      style={{
+                        display: 'flex', gap: 8, padding: '8px 10px',
+                        border: `1px solid ${targetType === opt.v ? 'var(--accent)' : 'var(--border)'}`,
+                        borderRadius: 'var(--radius-sm)', cursor: 'pointer',
+                        backgroundColor: targetType === opt.v ? 'color-mix(in srgb, var(--surf) 70%, var(--accent) 10%)' : 'var(--surf)',
+                      }}
+                    >
+                      <input
+                        type="radio"
+                        name="targetType"
+                        value={opt.v}
+                        checked={targetType === opt.v}
+                        onChange={() => setTargetType(opt.v)}
+                        style={{ marginTop: 2 }}
+                      />
+                      <div style={{ flex: 1 }}>
+                        <div style={{ fontSize: 13, color: 'var(--fg)', fontWeight: 500 }}>{opt.label}</div>
+                        <div style={{ fontSize: 11, color: 'var(--fg-dim)' }}>{opt.hint}</div>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              {targetType === 'custom' && (
+                <div>
+                  <input
+                    type="text"
+                    placeholder="/var/restore/example"
+                    value={customPath}
+                    onChange={e => setCustomPath(e.target.value)}
+                    style={{
+                      width: '100%', padding: '6px 10px', fontSize: 13,
+                      backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+                      borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none',
+                      fontFamily: 'var(--font-mono)',
+                    }}
+                  />
+                </div>
+              )}
+            </div>
+
+            {error && (
+              <div style={{
+                marginTop: 16, padding: '8px 12px',
+                borderRadius: 'var(--radius-sm)',
+                backgroundColor: 'var(--err-dim)',
+                border: '1px solid var(--err)',
+                fontSize: 12, color: 'var(--err)',
+                display: 'flex', alignItems: 'center', gap: 6,
+              }}>
+                <AlertTriangle size={12} />
+                {error}
+              </div>
+            )}
+
+            <div style={{ marginTop: 24, display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+              <button
+                onClick={close}
+                disabled={isPending}
+                style={{
+                  padding: '6px 14px', fontSize: 13, cursor: isPending ? 'not-allowed' : 'pointer',
+                  borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+                  background: 'none', color: 'var(--fg)',
+                  opacity: isPending ? 0.5 : 1,
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={submit}
+                disabled={isPending || (targetType === 'custom' && !customPath)}
+                style={{
+                  padding: '6px 14px', fontSize: 13, cursor: isPending ? 'not-allowed' : 'pointer',
+                  borderRadius: 'var(--radius-sm)', border: 'none',
+                  background: 'var(--accent)', color: 'var(--accent-fg)',
+                  opacity: isPending ? 0.5 : 1,
+                }}
+              >
+                {isPending ? 'Starting…' : 'Restore now'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/web/components/topbar.tsx
+++ b/apps/web/components/topbar.tsx
@@ -23,6 +23,8 @@ const LABELS: Record<string, string> = {
   new:          'New',
   verification: 'Verification',
   docs:         'Docs',
+  host:         'Host',
+  job:          'Job',
 }
 
 function buildBreadcrumb(pathname: string): { label: string; href: string }[] {


### PR DESCRIPTION
Closes #152 and #153.

## What this does

### #152 — Drill-down navigation
Replaces the flat /snapshots list with a three-level drill-down:
- /snapshots → host summary (count + most recent per host)
- /snapshots/host/<hostname> → jobs on that host
- /snapshots/host/<host>/job/<jobId> → snapshots for that job

The existing flat view is preserved at /snapshots?view=all with all existing filters (repo, filter, tag) still working. Topbar breadcrumb gets new LABELS entries for host and job.

### #153 — Per-row Restore button
Filesystem restore only in V1. Modal lives on the per-job snapshot list. Targets: temp dir, in-place, custom path. DB-snapshot heuristic warns and routes to #149's V2 wizard.

## Scope notes

- Database/app restore from a snapshot is OUT OF SCOPE — routes to #149 which is the V2 database restore wizard. The ad-hoc modal warns the user when paths look like a DB and offers the wizard link.
- The synthesized ParsedRestoreSpec uses agentId='local' (matches existing runSpec behavior). Restoring to the originating remote agent is a separate concern; the snapshots schema doesn't carry agent FK.

## Testing
- /snapshots loads with host summary
- Click a host → jobs list scoped to that host
- Click a job → snapshot list scoped to that job
- Click 'Show all snapshots' → existing flat view with filters still works
- Click 'Restore' on a snapshot → modal opens with paths + target type pickers
- Submit a temp-dir restore → redirected to /restore/runs, restore_runs row inserted with specId=null
- Trigger a DB-path snapshot (e.g. one with /var/lib/postgresql in paths) → modal shows the database wizard banner

## Out of scope
- DB-aware restore from snapshot → #149
- Restore to originating remote agent (snapshots lack agent FK) → follow-up
- Saving the ad-hoc restore as a reusable spec → follow-up if requested