### PR TITLE
fix(build): unblock next build (P0)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,8 +34,7 @@
     "react-qr-code": "^2.0.18",
     "resend": "^4.0.0",
     "tsx": "^4.19.0",
-    "ws": "^8.18.0",
-    "zod": "^4.3.6"
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@backupos/agent": "workspace:*",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -24,7 +24,9 @@
     "noEmit": true,
     "allowJs": true,
     "incremental": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "declaration": false,
+    "declarationMap": false
   },
   "include": [
     "next-env.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,9 +145,6 @@ importers:
       ws:
         specifier: ^8.18.0
         version: 8.20.0
-      zod:
-        specifier: ^4.3.6
-        version: 4.3.6
     devDependencies:
       '@backupos/agent':
         specifier: workspace:*


### PR DESCRIPTION
## Problem

\`next build\` fails on every clone with:
\`\`\`
./lib/auth.ts:10:14
Type error: The inferred type of 'auth' cannot be named without a reference to '.pnpm/zod@4.3.6/node_modules/zod/v4/core'. This is likely not portable.
\`\`\`

This was masked by stale .next caches earlier today; surfaced when we cleaned them during the dashboard troubleshooting. Production is currently running a binary built before this regression became fatal — any restart will fail.

## Cause

\`apps/web/tsconfig.json\` inherits \`declaration: true\` + \`declarationMap: true\` from the workspace root. Combined with better-auth's transitive zod v4, this trips TS2742. Better-auth issue #1861 documents this and recommends \`declaration: false\` for non-emitting apps.

## Fix

1. Set \`declaration: false\` and \`declarationMap: false\` in \`apps/web/tsconfig.json\` — overrides the inherited workspace defaults. apps/web has \`noEmit: true\` so these settings were already dead anyway.
2. Remove the redundant \`zod\` direct dep from \`apps/web/package.json\` — never imported, just creates drift risk.

## Verification

- \`pnpm --filter @backupos/web build\` succeeds (route table printed, no TS errors)
- \`pnpm --filter @backupos/web typecheck\` returns 0 errors
- \`packages/db/dist/index.d.ts\` still exists — workspace packages unaffected

## Out of scope

- The pre-existing typecheck errors in \`server.ts\` (tracked in #191)
- Migrating better-auth or zod versions

## Order with #193

This must merge BEFORE PR #193 (snapshots drill-down). #193's typecheck noise is downstream of this issue.