### PR TITLE
feat(restore): agent-side filesystem restore via WebSocket dispatch

### DIFF
--- a/apps/web/app/(dashboard)/snapshots/host/[hostname]/job/[jobId]/page.tsx
+++ b/apps/web/app/(dashboard)/snapshots/host/[hostname]/job/[jobId]/page.tsx
@@ -5,6 +5,7 @@ import { Pin, Lock } from 'lucide-react'
 import { PageHeader } from '@/components/ui/page-header'
 import { SnapshotActions } from '@/components/snapshot-actions'
 import { RestoreFromSnapshotButton } from '@/components/restore-from-snapshot-modal'
+import { connectedAgentIds } from '@/lib/ws-state'
 
 interface PageProps {
   params: Promise<{ hostname: string; jobId: string }>
@@ -32,6 +33,7 @@ export default async function JobSnapshotsPage({ params }: PageProps) {
   const hostname = decodeURIComponent(rawHostname)
   const jobId = decodeURIComponent(rawJobId)
   const db = getDb()
+  const agentConnected = connectedAgentIds().length > 0
 
   const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, jobId)).limit(1)
   if (!job) notFound()
@@ -100,6 +102,7 @@ export default async function JobSnapshotsPage({ params }: PageProps) {
                       <RestoreFromSnapshotButton
                         snapshotId={snap.id}
                         snapshotPaths={snapshotPaths}
+                        agentConnected={agentConnected}
                       />
                     </td>
                     <td style={{ padding: '12px 16px' }}>

--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -2,11 +2,11 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, eq, desc } from '@backupos/db'
+import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, backupJobs, eq, desc } from '@backupos/db'
 import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult } from '@backupos/restore'
-import { ResticEngine } from '@backupos/engine'
 import { requireAdmin } from '@/lib/user'
 import { decryptField } from '@/lib/repo-crypto'
+import { connectedAgentIds, dispatch } from '@/lib/ws-state'
 
 export async function validateSpec(yaml: string): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
@@ -167,7 +167,6 @@ export async function restoreFromSnapshot(
   await requireAdmin()
 
   const { snapshotId, sourcePath, targetType, customPath } = input
-
   const db = getDb()
 
   // 1. Look up the snapshot
@@ -205,7 +204,17 @@ export async function restoreFromSnapshot(
       break
   }
 
-  // 5. Insert the restore_runs row in 'running' state
+  // 5. Find a connected agent for this repository
+  const connected = connectedAgentIds()
+  if (connected.length === 0) {
+    return { ok: false, error: 'No agent connected. Install the BackupOS agent on the machine that can reach the repository.' }
+  }
+  const repoJobs = await db.select({ agentId: backupJobs.agentId })
+    .from(backupJobs).where(eq(backupJobs.repositoryId, snap.repositoryId)).all()
+  const agentId = repoJobs.map(j => j.agentId).find(aid => aid && connected.includes(aid))
+    ?? connected[0]!
+
+  // 6. Insert the restore_runs row in 'running' state
   const runId = crypto.randomUUID()
   await db.insert(restoreRuns).values({
     id: runId,
@@ -216,43 +225,24 @@ export async function restoreFromSnapshot(
     startedAt: new Date(),
   })
 
-  // 6. Fire-and-forget the actual restore
-  void (async () => {
-    const startedAt = Date.now()
-    try {
-      const engine = new ResticEngine({
-        repositoryUrl: repoConfig.repositoryUrl,
-        password,
-        envVars:       repoConfig.envVars ?? {},
-        binaryPath:    process.env['RESTIC_BINARY_PATH'],
-      })
-      const result = await engine.restore(snapshotId, targetPath, [sourcePath])
-      await db.update(restoreRuns).set({
-        status:      'success',
-        log:         JSON.stringify({
-          filesRestored: result.filesRestored,
-          totalSize:     result.totalSize,
-          durationSec:   result.duration,
-          targetPath,
-          sourcePath,
-        }),
-        completedAt: new Date(),
-      }).where(eq(restoreRuns.id, runId))
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err)
-      await db.update(restoreRuns).set({
-        status:      'failed',
-        log:         JSON.stringify({
-          error:      errMsg,
-          targetPath,
-          sourcePath,
-          durationMs: Date.now() - startedAt,
-        }),
-        completedAt: new Date(),
-      }).where(eq(restoreRuns.id, runId))
-      console.error('[restore] restoreFromSnapshot failed:', errMsg)
-    }
-  })()
+  // 7. Dispatch to agent — agent sends filesystem_restore_complete when done
+  const sent = dispatch(agentId, {
+    type:         'run_filesystem_restore',
+    requestId:    crypto.randomUUID(),
+    restoreId:    runId,
+    repoUrl:      repoConfig.repositoryUrl,
+    repoPassword: password,
+    envVars:      repoConfig.envVars ?? {},
+    snapshotId,
+    targetPath,
+    sourcePath,
+  })
+
+  if (!sent) {
+    await db.update(restoreRuns).set({ status: 'failed', completedAt: new Date() })
+      .where(eq(restoreRuns.id, runId))
+    return { ok: false, error: 'Agent disconnected before restore could be dispatched' }
+  }
 
   return { ok: true, runId }
 }

--- a/apps/web/components/restore-from-snapshot-modal.tsx
+++ b/apps/web/components/restore-from-snapshot-modal.tsx
@@ -7,9 +7,10 @@ import Link from 'next/link'
 import { restoreFromSnapshot } from '@/app/actions/restore'
 
 interface Props {
-  snapshotId:    string
-  snapshotPaths: string[]
-  triggerLabel?: string
+  snapshotId:     string
+  snapshotPaths:  string[]
+  agentConnected: boolean
+  triggerLabel?:  string
 }
 
 const DB_PATH_HINTS = [
@@ -22,7 +23,7 @@ function looksLikeDatabaseSnapshot(paths: string[]): boolean {
   return paths.some(p => DB_PATH_HINTS.some(hint => p.toLowerCase().includes(hint)))
 }
 
-export function RestoreFromSnapshotButton({ snapshotId, snapshotPaths, triggerLabel = 'Restore' }: Props) {
+export function RestoreFromSnapshotButton({ snapshotId, snapshotPaths, agentConnected, triggerLabel = 'Restore' }: Props) {
   const [open, setOpen] = useState(false)
   const [sourcePath, setSourcePath] = useState(snapshotPaths[0] ?? '/')
   const [targetType, setTargetType] = useState<'temp' | 'inplace' | 'custom'>('temp')
@@ -59,11 +60,14 @@ export function RestoreFromSnapshotButton({ snapshotId, snapshotPaths, triggerLa
     <>
       <button
         onClick={() => setOpen(true)}
+        disabled={!agentConnected}
+        title={agentConnected ? undefined : 'No agent connected — install the BackupOS agent to restore'}
         style={{
-          padding: '4px 10px', fontSize: 12, cursor: 'pointer',
+          padding: '4px 10px', fontSize: 12, cursor: agentConnected ? 'pointer' : 'not-allowed',
           borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
           background: 'none', color: 'var(--fg)',
           display: 'inline-flex', alignItems: 'center', gap: 4,
+          opacity: agentConnected ? 1 : 0.4,
         }}
       >
         <History size={12} />

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -688,6 +688,27 @@ void app.prepare().then(() => {
             resourceType: 'restore_run', resourceId: msg.restoreId,
             actor: agentId, createdAt: new Date(),
           })
+
+        } else if (msg.type === 'filesystem_restore_started' && agentId) {
+          console.log(`[restore] filesystem_restore_started restoreId=${msg.restoreId} agentId=${agentId}`)
+
+        } else if (msg.type === 'filesystem_restore_complete' && agentId) {
+          await db.update(restoreRuns).set({
+            status:      msg.success ? 'success' : 'failed',
+            completedAt: new Date(),
+            log:         JSON.stringify({
+              ...(msg.filesRestored != null ? { filesRestored: msg.filesRestored } : {}),
+              ...(msg.durationSec   != null ? { durationSec:   msg.durationSec   } : {}),
+              ...(msg.error         != null ? { error:         msg.error         } : {}),
+            }),
+          }).where(eq(restoreRuns.id, msg.restoreId))
+          try { appendLog({ level: msg.success ? 'info' : 'error', component: 'web', message: msg.success ? 'Filesystem restore succeeded' : `Filesystem restore failed: ${msg.error ?? ''}`, entityType: 'restore_run', entityId: msg.restoreId }) } catch (err) { console.error('[logger]', err) }
+          await db.insert(auditLog).values({
+            id: crypto.randomUUID(),
+            action: msg.success ? 'restore_completed' : 'restore_failed',
+            resourceType: 'restore_run', resourceId: msg.restoreId,
+            actor: agentId, createdAt: new Date(),
+          })
         }
       })()
     })

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -147,6 +147,8 @@ export type AgentMessage =
   | { type: 'compose_project_listing'; requestId: string; project: ComposeProjectListing }
   | { type: 'mount_complete'; requestId: string; repoId: string }
   | { type: 'mount_failed'; requestId: string; repoId: string; error: string }
+  | { type: 'filesystem_restore_started'; requestId: string; restoreId: string }
+  | { type: 'filesystem_restore_complete'; restoreId: string; success: boolean; filesRestored?: number; durationSec?: number; error?: string }
 
 export interface DetectedResources {
   dockerVolumes?: string[]
@@ -170,3 +172,4 @@ export type ServerMessage =
   | { type: 'run_compose_restore'; jobId: string; runId: string; repoId: string; config: ComposeRestoreConfig; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
   | { type: 'mount_repository'; requestId: string; repoId: string; nfsServer: string; nfsExport: string; nfsOptions: string }
   | { type: 'run_verification'; verificationRunId: string; repoId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory'; validationHook?: string | null }
+  | { type: 'run_filesystem_restore'; requestId: string; restoreId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; targetPath: string; sourcePath: string }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -9,6 +9,7 @@ import { getSystemUptimeSeconds } from './system-uptime'
 import { detectCapabilities } from './capabilities'
 import { resolveHostPrefix, applyHostPrefixAll } from './lib/host-prefix'
 import { runMountRepository } from './handlers/mountRepository'
+import { handleFilesystemRestore } from './handlers/filesystemRestore'
 
 function requireEnv(name: string): string {
   const v = process.env[name]
@@ -246,6 +247,9 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
       const { runComposeRestore } = await import('./handlers/composeRestore')
       await runComposeRestore(msg, send, activeJobs, BINARY)
     })()
+
+  } else if (msg.type === 'run_filesystem_restore') {
+    void handleFilesystemRestore(msg, send, BINARY)
 
   } else if (msg.type === 'mount_repository') {
     void runMountRepository(msg, send)

--- a/packages/agent/src/handlers/filesystemRestore.ts
+++ b/packages/agent/src/handlers/filesystemRestore.ts
@@ -1,0 +1,43 @@
+import { ResticEngine } from '@backupos/engine'
+import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
+
+type SendFn = (msg: AgentMessage) => void
+type RunFilesystemRestoreMsg = Extract<ServerMessage, { type: 'run_filesystem_restore' }>
+
+export async function handleFilesystemRestore(
+  msg: RunFilesystemRestoreMsg,
+  send: SendFn,
+  binaryPath?: string,
+): Promise<void> {
+  const { requestId, restoreId, repoUrl, repoPassword, envVars, snapshotId, targetPath, sourcePath } = msg
+
+  send({ type: 'filesystem_restore_started', requestId, restoreId })
+
+  const startedAt = Date.now()
+  try {
+    const engine = new ResticEngine({
+      repositoryUrl: repoUrl,
+      password:      repoPassword,
+      envVars:       envVars ?? {},
+      binaryPath,
+    })
+    const result = await engine.restore(snapshotId, targetPath, [sourcePath])
+    send({
+      type:          'filesystem_restore_complete',
+      restoreId,
+      success:       true,
+      filesRestored: result.filesRestored,
+      durationSec:   result.duration,
+    })
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    console.error(`[agent] filesystem restore failed restoreId=${restoreId}:`, error)
+    send({
+      type:        'filesystem_restore_complete',
+      restoreId,
+      success:     false,
+      durationSec: (Date.now() - startedAt) / 1000,
+      error,
+    })
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces local `ResticEngine` fire-and-forget in `restoreFromSnapshot` with agent-side dispatch: action picks a connected agent (preferring one linked to the repo), inserts the `restoreRuns` row, and sends `run_filesystem_restore` over WebSocket
- New agent handler `filesystemRestore.ts` runs restic restore on the agent host, sends `filesystem_restore_started` immediately then `filesystem_restore_complete` with success/failure detail
- Snapshot restore button is disabled (with tooltip) when no agent is connected

## Test plan

- [ ] With an agent connected: open Snapshots → drill into a job → click Restore on a snapshot; confirm the modal opens and submitting redirects to `/restore/runs` with status `running`
- [ ] Agent-side: confirm `filesystem_restore_started` log appears in server console; confirm `filesystem_restore_complete` updates the run to `success`/`failed`
- [ ] With no agent connected: confirm the Restore button is greyed out and shows the no-agent tooltip
- [ ] `pnpm typecheck` passes in `apps/web` and `packages/agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)