### PR TITLE
fix(restore): wait for agent dispatch ack on filesystem restore

### DIFF
--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -6,7 +6,7 @@ import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, backupJobs, 
 import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult } from '@backupos/restore'
 import { requireAdmin } from '@/lib/user'
 import { decryptField } from '@/lib/repo-crypto'
-import { connectedAgentIds, dispatch } from '@/lib/ws-state'
+import { connectedAgentIds, requestFilesystemRestore } from '@/lib/ws-state'
 
 export async function validateSpec(yaml: string): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
@@ -225,23 +225,24 @@ export async function restoreFromSnapshot(
     startedAt: new Date(),
   })
 
-  // 7. Dispatch to agent — agent sends filesystem_restore_complete when done
-  const sent = dispatch(agentId, {
-    type:         'run_filesystem_restore',
-    requestId:    crypto.randomUUID(),
+  // 7. Dispatch to agent and await started ack
+  const dispatchResult = await requestFilesystemRestore(agentId, {
     restoreId:    runId,
     repoUrl:      repoConfig.repositoryUrl,
     repoPassword: password,
-    envVars:      repoConfig.envVars ?? {},
+    envVars:      repoConfig.envVars,
     snapshotId,
     targetPath,
     sourcePath,
   })
 
-  if (!sent) {
-    await db.update(restoreRuns).set({ status: 'failed', completedAt: new Date() })
-      .where(eq(restoreRuns.id, runId))
-    return { ok: false, error: 'Agent disconnected before restore could be dispatched' }
+  if (!dispatchResult.ok) {
+    await db.update(restoreRuns).set({
+      status:      'failed',
+      log:         JSON.stringify({ error: dispatchResult.error }),
+      completedAt: new Date(),
+    }).where(eq(restoreRuns.id, runId))
+    return { ok: false, error: dispatchResult.error }
   }
 
   return { ok: true, runId }

--- a/apps/web/lib/ws-state.ts
+++ b/apps/web/lib/ws-state.ts
@@ -14,6 +14,8 @@ declare global {
   var __bkp_pending_repo_tests: Map<string, (r: RepoTestResult) => void> | undefined
   // eslint-disable-next-line no-var
   var __bkp_pending_mount_tests: Map<string, (r: MountTestResult) => void> | undefined
+  // eslint-disable-next-line no-var
+  var __bkp_pending_fs_restores: Map<string, (r: { ok: boolean; error?: string }) => void> | undefined
 }
 
 const connections: Map<string, WebSocket> =
@@ -27,6 +29,9 @@ const pendingRepoTests: Map<string, (r: RepoTestResult) => void> =
 
 const pendingMountTests: Map<string, (r: MountTestResult) => void> =
   (globalThis.__bkp_pending_mount_tests ??= new Map())
+
+const pendingFsRestores: Map<string, (r: { ok: boolean; error?: string }) => void> =
+  (globalThis.__bkp_pending_fs_restores ??= new Map())
 
 export function registerAgent(agentId: string, ws: WebSocket): void {
   connections.set(agentId, ws)
@@ -208,4 +213,41 @@ export function requestListCompose(agentId: string, projectName: string): Promis
 
 export function resolveListCompose(requestId: string, project: ComposeProjectListing): void {
   pendingComposeLists.get(requestId)?.(project)
+}
+
+export function requestFilesystemRestore(
+  agentId: string,
+  payload: {
+    restoreId:    string
+    repoUrl:      string
+    repoPassword: string
+    envVars?:     Record<string, string>
+    snapshotId:   string
+    targetPath:   string
+    sourcePath:   string
+  },
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  return new Promise((resolve) => {
+    const requestId = crypto.randomUUID()
+    const timer = setTimeout(() => {
+      pendingFsRestores.delete(requestId)
+      resolve({ ok: false, error: 'Agent did not acknowledge dispatch within 30s' })
+    }, 30_000)
+    pendingFsRestores.set(requestId, (r) => {
+      clearTimeout(timer)
+      pendingFsRestores.delete(requestId)
+      if (r.ok) resolve({ ok: true })
+      else resolve({ ok: false, error: r.error ?? 'unknown dispatch error' })
+    })
+    const sent = dispatch(agentId, { type: 'run_filesystem_restore', requestId, ...payload })
+    if (!sent) {
+      clearTimeout(timer)
+      pendingFsRestores.delete(requestId)
+      resolve({ ok: false, error: 'Agent not connected' })
+    }
+  })
+}
+
+export function resolveFilesystemRestoreStarted(requestId: string): void {
+  pendingFsRestores.get(requestId)?.({ ok: true })
 }

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -10,7 +10,7 @@ import type { WebSocket } from 'ws'
 import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, verificationRuns, verificationTests, snapshots, eq, and, desc } from '@backupos/db'
 import { ResticEngine } from '@backupos/engine'
 import { parseExpression } from 'cron-parser'
-import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository } from './lib/ws-state'
+import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository, resolveFilesystemRestoreStarted } from './lib/ws-state'
 import { loadOrCreateInternalToken } from './lib/internal-token'
 import { decryptField } from './lib/repo-crypto'
 import { sendAlert } from './lib/alerts'
@@ -691,6 +691,7 @@ void app.prepare().then(() => {
 
         } else if (msg.type === 'filesystem_restore_started' && agentId) {
           console.log(`[restore] filesystem_restore_started restoreId=${msg.restoreId} agentId=${agentId}`)
+          resolveFilesystemRestoreStarted(msg.requestId)
 
         } else if (msg.type === 'filesystem_restore_complete' && agentId) {
           await db.update(restoreRuns).set({


### PR DESCRIPTION
Adds the dispatch-ack pattern that was missed in #198. Mirrors requestTestRepo. 30s timeout on ack. Surfaces dispatch failures (agent crashed mid-receive, etc) to the user instead of leaving the row in 'running'.