### PR TITLE
fix(snapshots+ui): backfill paths + poll global restore runs

### DIFF
--- a/apps/web/app/(dashboard)/restore/runs/page.tsx
+++ b/apps/web/app/(dashboard)/restore/runs/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { getDb, restoreRuns, restoreSpecs, eq, desc } from '@backupos/db'
 import { Badge } from '@/components/ui/badge'
 import { EmptyState } from '@/components/ui/empty-state'
+import { PollWrapper } from './poll-wrapper'
 
 type BadgeStatus = ComponentProps<typeof Badge>['status']
 
@@ -32,8 +33,11 @@ export default async function RestoreRunsPage() {
     .limit(50)
     .all()
 
+  const anyRunning = runs.some(r => r.status === 'running')
+
   return (
     <div>
+      <PollWrapper initialStatus={anyRunning ? 'running' : 'idle'} />
       <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginBottom: 24 }}>Restore runs</h1>
 
       <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)' }}>

--- a/apps/web/app/(dashboard)/restore/runs/poll-wrapper.tsx
+++ b/apps/web/app/(dashboard)/restore/runs/poll-wrapper.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+export function PollWrapper({ initialStatus }: { initialStatus: string }) {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (initialStatus !== 'running') return
+    const id = setInterval(() => { router.refresh() }, 3_000)
+    return () => clearInterval(id)
+  }, [initialStatus, router])
+
+  return null
+}

--- a/packages/db/scripts/backfill-snapshot-paths.ts
+++ b/packages/db/scripts/backfill-snapshot-paths.ts
@@ -1,0 +1,79 @@
+import { getDb, snapshots, backupJobs, eq } from '../src/index'
+
+interface SourceConfigShape {
+  paths?: string[]
+  volumes?: string[]
+  services?: { includedVolumes?: string[] }[]
+}
+
+async function main(): Promise<void> {
+  const db = getDb()
+
+  const rows = await db.select().from(snapshots).all()
+  const broken = rows.filter(s => !s.paths || s.paths === '' || s.paths === '[]')
+  console.log(`[backfill] found ${rows.length} snapshots, ${broken.length} need backfill`)
+
+  let fixed = 0
+  let skipped = 0
+
+  for (const snap of broken) {
+    if (!snap.jobId) {
+      console.warn(`[backfill] snapshot ${snap.id} has no jobId — skipping`)
+      skipped++
+      continue
+    }
+
+    const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, snap.jobId)).limit(1)
+    if (!job) {
+      console.warn(`[backfill] snapshot ${snap.id} has jobId ${snap.jobId} but job not found — skipping`)
+      skipped++
+      continue
+    }
+
+    if (!job.sourceConfig) {
+      console.warn(`[backfill] job ${job.id} has no sourceConfig — skipping snapshot ${snap.id}`)
+      skipped++
+      continue
+    }
+
+    let paths: string[] = []
+    try {
+      const cfg = JSON.parse(job.sourceConfig) as SourceConfigShape
+      if (job.sourceType === 'docker_volume') {
+        paths = (cfg.volumes ?? []).map(v => `/var/lib/docker/volumes/${v}/_data`)
+      } else if (job.sourceType === 'compose_project') {
+        const allVolumes: string[] = []
+        for (const svc of cfg.services ?? []) {
+          for (const v of svc.includedVolumes ?? []) allVolumes.push(`/var/lib/docker/volumes/${v}/_data`)
+        }
+        paths = allVolumes
+      } else {
+        paths = cfg.paths ?? []
+      }
+    } catch {
+      console.warn(`[backfill] job ${job.id} sourceConfig parse failed — skipping snapshot ${snap.id}`)
+      skipped++
+      continue
+    }
+
+    if (paths.length === 0) {
+      console.warn(`[backfill] derived paths empty for snapshot ${snap.id} (job ${job.name}) — skipping`)
+      skipped++
+      continue
+    }
+
+    await db.update(snapshots)
+      .set({ paths: JSON.stringify(paths) })
+      .where(eq(snapshots.id, snap.id))
+
+    console.log(`[backfill] snapshot ${snap.id.slice(0, 12)} (job ${job.name}) → ${JSON.stringify(paths)}`)
+    fixed++
+  }
+
+  console.log(`[backfill] done. fixed=${fixed} skipped=${skipped}`)
+}
+
+main().then(() => process.exit(0)).catch(err => {
+  console.error('[backfill] failed:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
Two commits. Both unblock ad-hoc restore UX:

## Commit 1: backfill snapshot.paths

22 of 24 existing snapshots have null/empty paths because they were inserted before PR #71 added path extraction to backup_complete handling. The Restore button defaults to / when paths is empty, restoring everything and failing on read-only paths.

Adds a one-shot script at packages/db/scripts/backfill-snapshot-paths.ts. Run:
```
cd packages/db && pnpm tsx scripts/backfill-snapshot-paths.ts
```

## Commit 2: poll global restore runs

Mirrors the existing poll-wrapper at restore/[id]/runs/. Page now refreshes every 3s.

## Out of scope

- Restoring docker volume snapshots back to the agent's docker volumes — current behavior writes them to a literal /var/lib/docker/volumes/<name>/_data path inside the agent container, which is bind-mounted; works only for in-place. We may want a smarter target for compose-project restores. Separate ticket.