### PR TITLE
fix(restore): use 8-char short snapshot ID for restic

### DIFF
--- a/packages/agent/src/handlers/filesystemRestore.ts
+++ b/packages/agent/src/handlers/filesystemRestore.ts
@@ -21,7 +21,8 @@ export async function handleFilesystemRestore(
       envVars:       envVars ?? {},
       binaryPath,
     })
-    const result = await engine.restore(snapshotId, targetPath, [sourcePath])
+    const shortId = snapshotId.slice(0, 8)
+    const result = await engine.restore(shortId, targetPath, [sourcePath])
     send({
       type:          'filesystem_restore_complete',
       restoreId,


### PR DESCRIPTION
DB stores 64-char snapshot IDs; restic restores by 8-char short prefix. The mismatch caused every ad-hoc restore to silently match nothing — restic returned 0 (success) without restoring any files.

One-line fix: truncate the snapshot ID to 8 chars before passing to engine.restore.

After this lands, ad-hoc restores from snapshots will actually write files to disk.