### PR TITLE
debug(restore): add observability to filesystem restore handler

### DIFF
--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -701,6 +701,8 @@ void app.prepare().then(() => {
               ...(msg.filesRestored != null ? { filesRestored: msg.filesRestored } : {}),
               ...(msg.durationSec   != null ? { durationSec:   msg.durationSec   } : {}),
               ...(msg.error         != null ? { error:         msg.error         } : {}),
+              ...(msg.targetPath    != null ? { targetPath:    msg.targetPath    } : {}),
+              ...(msg.sourcePath    != null ? { sourcePath:    msg.sourcePath    } : {}),
             }),
           }).where(eq(restoreRuns.id, msg.restoreId))
           try { appendLog({ level: msg.success ? 'info' : 'error', component: 'web', message: msg.success ? 'Filesystem restore succeeded' : `Filesystem restore failed: ${msg.error ?? ''}`, entityType: 'restore_run', entityId: msg.restoreId }) } catch (err) { console.error('[logger]', err) }

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -148,7 +148,7 @@ export type AgentMessage =
   | { type: 'mount_complete'; requestId: string; repoId: string }
   | { type: 'mount_failed'; requestId: string; repoId: string; error: string }
   | { type: 'filesystem_restore_started'; requestId: string; restoreId: string }
-  | { type: 'filesystem_restore_complete'; restoreId: string; success: boolean; filesRestored?: number; durationSec?: number; error?: string }
+  | { type: 'filesystem_restore_complete'; restoreId: string; success: boolean; filesRestored?: number; durationSec?: number; error?: string; targetPath?: string; sourcePath?: string }
 
 export interface DetectedResources {
   dockerVolumes?: string[]

--- a/packages/agent/src/handlers/filesystemRestore.ts
+++ b/packages/agent/src/handlers/filesystemRestore.ts
@@ -11,6 +11,8 @@ export async function handleFilesystemRestore(
 ): Promise<void> {
   const { requestId, restoreId, repoUrl, repoPassword, envVars, snapshotId, targetPath, sourcePath } = msg
 
+  console.log(`[agent] run_filesystem_restore received: restoreId=${restoreId} snapshotId=${snapshotId.slice(0, 8)} sourcePath=${sourcePath} targetPath=${targetPath} repoUrl=${repoUrl}`)
+
   send({ type: 'filesystem_restore_started', requestId, restoreId })
 
   const startedAt = Date.now()
@@ -23,22 +25,27 @@ export async function handleFilesystemRestore(
     })
     const shortId = snapshotId.slice(0, 8)
     const result = await engine.restore(shortId, targetPath, [sourcePath])
+    console.log(`[agent] engine.restore returned: filesRestored=${result.filesRestored} duration=${result.duration} totalSize=${result.totalSize}`)
     send({
       type:          'filesystem_restore_complete',
       restoreId,
       success:       true,
       filesRestored: result.filesRestored,
       durationSec:   result.duration,
+      targetPath,
+      sourcePath,
     })
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err)
-    console.error(`[agent] filesystem restore failed restoreId=${restoreId}:`, error)
+    console.error(`[agent] filesystem_restore failed: restoreId=${restoreId} error=${error}`)
     send({
       type:        'filesystem_restore_complete',
       restoreId,
       success:     false,
       durationSec: (Date.now() - startedAt) / 1000,
       error,
+      targetPath,
+      sourcePath,
     })
   }
 }


### PR DESCRIPTION
Diagnostic for #203. Adds console.log to agent handler + targetPath/sourcePath to filesystem_restore_complete message + log persistence. Lets us see what restic actually receives and returns.