### PR TITLE
fix(restore): apply host prefix to paths (#203)

### DIFF
--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -239,6 +239,8 @@ export async function restoreFromSnapshot(
     startedAt: new Date(),
   })
 
+  const targetIsAgentLocal = targetType === 'temp' || targetType === 'custom'
+
   // 8. Dispatch to agent and await started ack
   const dispatchResult = await requestFilesystemRestore(agentId, {
     restoreId:    runId,
@@ -248,6 +250,7 @@ export async function restoreFromSnapshot(
     snapshotId,
     targetPath,
     sourcePath,
+    targetIsAgentLocal,
   })
 
   if (!dispatchResult.ok) {

--- a/apps/web/lib/ws-state.ts
+++ b/apps/web/lib/ws-state.ts
@@ -218,13 +218,14 @@ export function resolveListCompose(requestId: string, project: ComposeProjectLis
 export function requestFilesystemRestore(
   agentId: string,
   payload: {
-    restoreId:    string
-    repoUrl:      string
-    repoPassword: string
-    envVars?:     Record<string, string>
-    snapshotId:   string
-    targetPath:   string
-    sourcePath:   string
+    restoreId:          string
+    repoUrl:            string
+    repoPassword:       string
+    envVars?:           Record<string, string>
+    snapshotId:         string
+    targetPath:         string
+    sourcePath:         string
+    targetIsAgentLocal: boolean
   },
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   return new Promise((resolve) => {

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -172,4 +172,4 @@ export type ServerMessage =
   | { type: 'run_compose_restore'; jobId: string; runId: string; repoId: string; config: ComposeRestoreConfig; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
   | { type: 'mount_repository'; requestId: string; repoId: string; nfsServer: string; nfsExport: string; nfsOptions: string }
   | { type: 'run_verification'; verificationRunId: string; repoId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory'; validationHook?: string | null }
-  | { type: 'run_filesystem_restore'; requestId: string; restoreId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; targetPath: string; sourcePath: string }
+  | { type: 'run_filesystem_restore'; requestId: string; restoreId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; targetPath: string; sourcePath: string; targetIsAgentLocal: boolean }

--- a/packages/agent/src/handlers/filesystemRestore.ts
+++ b/packages/agent/src/handlers/filesystemRestore.ts
@@ -1,5 +1,6 @@
 import { ResticEngine } from '@backupos/engine'
 import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
+import { resolveHostPrefix, applyHostPrefix } from '../lib/host-prefix'
 
 type SendFn = (msg: AgentMessage) => void
 type RunFilesystemRestoreMsg = Extract<ServerMessage, { type: 'run_filesystem_restore' }>
@@ -11,7 +12,11 @@ export async function handleFilesystemRestore(
 ): Promise<void> {
   const { requestId, restoreId, repoUrl, repoPassword, envVars, snapshotId, targetPath, sourcePath } = msg
 
-  console.log(`[agent] run_filesystem_restore received: restoreId=${restoreId} snapshotId=${snapshotId.slice(0, 8)} sourcePath=${sourcePath} targetPath=${targetPath} repoUrl=${repoUrl}`)
+  const hostPrefix = resolveHostPrefix()
+  const prefixedSourcePath = applyHostPrefix(sourcePath, hostPrefix)
+  const prefixedTargetPath = msg.targetIsAgentLocal ? targetPath : applyHostPrefix(targetPath, hostPrefix)
+
+  console.log(`[agent] run_filesystem_restore received: restoreId=${restoreId} snapshotId=${snapshotId.slice(0, 8)} sourcePath=${sourcePath}→${prefixedSourcePath} targetPath=${targetPath}→${prefixedTargetPath} targetIsAgentLocal=${msg.targetIsAgentLocal} repoUrl=${repoUrl}`)
 
   send({ type: 'filesystem_restore_started', requestId, restoreId })
 
@@ -24,7 +29,7 @@ export async function handleFilesystemRestore(
       binaryPath,
     })
     const shortId = snapshotId.slice(0, 8)
-    const result = await engine.restore(shortId, targetPath, [sourcePath])
+    const result = await engine.restore(shortId, prefixedTargetPath, [prefixedSourcePath])
     console.log(`[agent] engine.restore returned: filesRestored=${result.filesRestored} duration=${result.duration} totalSize=${result.totalSize}`)
     send({
       type:          'filesystem_restore_complete',


### PR DESCRIPTION
Closes #203. Agent rewrites host paths with /host prefix during backup, but restore did not mirror this. Restic --include /etc matched zero entries in the /host/etc snapshot tree.

Adds targetIsAgentLocal flag to the protocol message so the agent knows when to prefix the target path (in-place restores) vs leave it alone (temp / custom).