### PR TITLE
feat(breadcrumb): per-page override for dynamic route segments

### DIFF
--- a/apps/web/app/(dashboard)/agents/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/agents/[id]/page.tsx
@@ -11,6 +11,7 @@ import { getLogsPage } from '@/app/actions/logs'
 import { setAgentChannelFromForm } from '@/app/actions/agents'
 import { AutoRefresh } from '@/components/ui/auto-refresh'
 import { UpdateAgentButton } from './update-button'
+import { BreadcrumbOverride } from '@/components/breadcrumb-override'
 
 type BadgeStatus = ComponentProps<typeof Badge>['status']
 
@@ -96,6 +97,7 @@ export default async function AgentDetailPage({ params }: { params: Promise<{ id
 
   return (
     <div>
+      <BreadcrumbOverride segment={id} label={agent.name} />
       <AutoRefresh intervalMs={5_000} />
       <div style={{ marginBottom: 24 }}>
         <Link href="/agents" style={{ fontSize: 13, color: 'var(--fg-mute)', textDecoration: 'none' }}>← Agents</Link>

--- a/apps/web/app/(dashboard)/jobs/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/[id]/page.tsx
@@ -12,6 +12,7 @@ import { togglePreflight } from '@/app/actions/preflight'
 import { PreflightToggle } from '@/components/preflight-toggle'
 import { triggerJob, saveJobRetention, cancelJob, retryRun } from '@/app/actions/jobs'
 import { validateCron } from '@/lib/cron-validate'
+import { BreadcrumbOverride } from '@/components/breadcrumb-override'
 
 type BadgeStatus = ComponentProps<typeof Badge>['status']
 
@@ -70,6 +71,7 @@ export default async function JobDetailPage({ params }: { params: Promise<{ id: 
 
   return (
     <div>
+      <BreadcrumbOverride segment={id} label={job.name} />
       <AutoRefresh intervalMs={activeRun ? 3_000 : 10_000} />
       <div style={{ marginBottom: 24 }}>
         <Link href="/jobs" style={{ fontSize: 13, color: 'var(--fg-mute)', textDecoration: 'none' }}>← Jobs</Link>

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -7,6 +7,7 @@ import { DrModeOverlay }          from '@/components/dr-mode-overlay'
 import { CommandPaletteProvider } from '@/components/command-palette-provider'
 import { CommandPalette }         from '@/components/command-palette'
 import { FaviconManager }         from '@/components/favicon-manager'
+import { BreadcrumbProvider }     from '@/components/breadcrumb-provider'
 import { unstable_cache }         from 'next/cache'
 import {
   getDb, backupJobs, backupRuns,
@@ -52,17 +53,19 @@ export default async function DashboardLayout({ children }: { children: React.Re
       <DrModeProvider hasFailed24h={hasFailed24h}>
         <div style={{ display: 'flex', height: '100vh', overflow: 'hidden', backgroundColor: 'var(--bg)' }}>
           <Sidebar user={sidebarUser} />
-          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minWidth: 0 }}>
-            <Topbar />
-            <main style={{
-              flex: 1,
-              overflowY: 'auto',
-              padding: 24,
-              backgroundColor: 'var(--bg)',
-            }}>
-              {children}
-            </main>
-          </div>
+          <BreadcrumbProvider>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minWidth: 0 }}>
+              <Topbar />
+              <main style={{
+                flex: 1,
+                overflowY: 'auto',
+                padding: 24,
+                backgroundColor: 'var(--bg)',
+              }}>
+                {children}
+              </main>
+            </div>
+          </BreadcrumbProvider>
         </div>
         <DrModeOverlay jobs={jobs} />
         <CommandPalette />

--- a/apps/web/app/(dashboard)/repositories/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/repositories/[id]/page.tsx
@@ -19,6 +19,7 @@ import type { ReplicaEntry }          from '@/app/actions/repositories'
 import { setEscrowAction, clearEscrow } from '@/app/actions/escrow'
 import { TrendingUp, AlertTriangle, Info, ShieldCheck, ShieldAlert } from 'lucide-react'
 import { DedupBar, fmtBytes } from '../dedup-bar'
+import { BreadcrumbOverride } from '@/components/breadcrumb-override'
 
 function bytes(n: number | null | undefined): string {
   if (n == null) return '—'
@@ -80,6 +81,7 @@ export default async function RepoDetailPage({ params }: { params: Promise<{ id:
 
   return (
     <div>
+      <BreadcrumbOverride segment={id} label={repo.name} />
       <div style={{ marginBottom: 24 }}>
         <Link href="/repositories" style={{ fontSize: 13, color: 'var(--fg-mute)', textDecoration: 'none' }}>← Repositories</Link>
         <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginTop: 8 }}>{repo.name}</h1>

--- a/apps/web/app/(dashboard)/restore/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/restore/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { RunSplitButton } from './run-split-button'
 import { EditSpecButton } from './edit-button'
+import { BreadcrumbOverride } from '@/components/breadcrumb-override'
 
 type BadgeStatus = ComponentProps<typeof Badge>['status']
 
@@ -31,6 +32,7 @@ export default async function RestoreSpecPage({ params }: { params: Promise<{ id
 
   return (
     <div>
+      <BreadcrumbOverride segment={id} label={spec.name} />
       <div style={{ marginBottom: 24 }}>
         <Link href="/restore" style={{ fontSize: 13, color: 'var(--fg-mute)', textDecoration: 'none' }}>← Restore</Link>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginTop: 8 }}>

--- a/apps/web/app/(dashboard)/snapshots/host/[hostname]/job/[jobId]/page.tsx
+++ b/apps/web/app/(dashboard)/snapshots/host/[hostname]/job/[jobId]/page.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from '@/components/ui/page-header'
 import { SnapshotActions } from '@/components/snapshot-actions'
 import { RestoreFromSnapshotButton } from '@/components/restore-from-snapshot-modal'
 import { connectedAgentIds } from '@/lib/ws-state'
+import { BreadcrumbOverride } from '@/components/breadcrumb-override'
 
 interface PageProps {
   params: Promise<{ hostname: string; jobId: string }>
@@ -47,6 +48,8 @@ export default async function JobSnapshotsPage({ params }: PageProps) {
 
   return (
     <div style={{ padding: '32px 40px' }}>
+      <BreadcrumbOverride segment={encodeURIComponent(hostname)} label={hostname} />
+      <BreadcrumbOverride segment={jobId} label={job.name} />
       <div style={{ marginBottom: 24 }}>
         <PageHeader title={job.name} />
         <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>

--- a/apps/web/components/breadcrumb-override.tsx
+++ b/apps/web/components/breadcrumb-override.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useBreadcrumb } from './breadcrumb-provider'
+
+interface Props {
+  segment: string
+  label:   string
+}
+
+export function BreadcrumbOverride({ segment, label }: Props) {
+  const { setOverride } = useBreadcrumb()
+  useEffect(() => {
+    if (!segment || !label) return
+    setOverride(segment, label)
+  }, [segment, label, setOverride])
+  return null
+}

--- a/apps/web/components/breadcrumb-provider.tsx
+++ b/apps/web/components/breadcrumb-provider.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
+
+interface BreadcrumbContextValue {
+  overrides: Record<string, string>
+  setOverride: (segment: string, label: string) => void
+}
+
+const BreadcrumbContext = createContext<BreadcrumbContextValue | null>(null)
+
+export function BreadcrumbProvider({ children }: { children: ReactNode }) {
+  const [overrides, setOverrides] = useState<Record<string, string>>({})
+
+  const setOverride = useCallback((segment: string, label: string) => {
+    setOverrides(prev => {
+      if (prev[segment] === label) return prev
+      return { ...prev, [segment]: label }
+    })
+  }, [])
+
+  return (
+    <BreadcrumbContext.Provider value={{ overrides, setOverride }}>
+      {children}
+    </BreadcrumbContext.Provider>
+  )
+}
+
+export function useBreadcrumb(): BreadcrumbContextValue {
+  const ctx = useContext(BreadcrumbContext)
+  if (!ctx) {
+    return { overrides: {}, setOverride: () => {} }
+  }
+  return ctx
+}

--- a/apps/web/components/topbar.tsx
+++ b/apps/web/components/topbar.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation'
 import { Search, Bell, ShieldAlert } from 'lucide-react'
 import { useDrMode } from '@/components/dr-mode-provider'
 import { useCommandPalette } from '@/components/command-palette-provider'
+import { useBreadcrumb } from '@/components/breadcrumb-provider'
 
 const LABELS: Record<string, string> = {
   dashboard:    'Dashboard',
@@ -27,13 +28,16 @@ const LABELS: Record<string, string> = {
   job:          'Job',
 }
 
-function buildBreadcrumb(pathname: string): { label: string; href: string }[] {
+function buildBreadcrumb(
+  pathname: string,
+  overrides: Record<string, string>,
+): { label: string; href: string }[] {
   const segments = pathname.replace(/^\//, '').split('/').filter(Boolean)
   const crumbs: { label: string; href: string }[] = []
   let path = ''
   for (const seg of segments) {
     path += `/${seg}`
-    const label = LABELS[seg] ?? seg.charAt(0).toUpperCase() + seg.slice(1).replace(/-/g, ' ')
+    const label = overrides[seg] ?? LABELS[seg] ?? seg.charAt(0).toUpperCase() + seg.slice(1).replace(/-/g, ' ')
     crumbs.push({ label, href: path })
   }
   return crumbs
@@ -41,7 +45,8 @@ function buildBreadcrumb(pathname: string): { label: string; href: string }[] {
 
 export function Topbar() {
   const pathname                         = usePathname()
-  const crumbs                           = buildBreadcrumb(pathname)
+  const { overrides }                    = useBreadcrumb()
+  const crumbs                           = buildBreadcrumb(pathname, overrides)
   const { active, toggle, hasFailed24h } = useDrMode()
   const { openPalette }                  = useCommandPalette()
 


### PR DESCRIPTION
## Summary
- Add `BreadcrumbProvider` (React context) and `BreadcrumbOverride` (side-effect client component) to allow any page to register a human-readable label for its dynamic URL segment
- Update `Topbar` to call `useBreadcrumb()` and apply overrides before the static `LABELS` fallback in `buildBreadcrumb`
- Add `<BreadcrumbOverride>` to five detail pages: jobs/[id], agents/[id], repositories/[id], restore/[id], snapshots/host/[hostname]/job/[jobId]

## Test plan
- [ ] Navigate to a job detail page — breadcrumb shows job name instead of UUID
- [ ] Navigate to an agent detail page — breadcrumb shows agent name
- [ ] Navigate to a repository detail page — breadcrumb shows repo name
- [ ] Navigate to a restore spec detail page — breadcrumb shows spec name
- [ ] Navigate to snapshots/host/[hostname]/job/[jobId] — breadcrumb shows decoded hostname and job name
- [ ] Static breadcrumb segments (e.g. `/jobs`, `/agents`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)