### PR TITLE
fix(icon): derive width from id (#212)

### DIFF
--- a/apps/web/app/icon.tsx
+++ b/apps/web/app/icon.tsx
@@ -26,6 +26,7 @@ function GridShield({ size }: { size: number }) {
   )
 }
 
-export default function Icon({ id, size: { width } }: { id: string; size: { width: number; height: number } }) {
+export default function Icon({ id }: { id: string }) {
+  const width = id === '512' ? 512 : 192
   return new ImageResponse(<GridShield size={width} />, { width, height: width })
 }


### PR DESCRIPTION
Closes #212. The icon default export destructured size.width but Next.js doesn't always pass size. Derive width from id ('192' or '512') instead.