### PR TITLE
fix(ui): infra-os breadcrumb reads 'Coverage' (#179)

### DIFF
--- a/apps/web/components/topbar.tsx
+++ b/apps/web/components/topbar.tsx
@@ -26,6 +26,7 @@ const LABELS: Record<string, string> = {
   docs:         'Docs',
   host:         'Host',
   job:          'Job',
+  'infra-os':   'Coverage',
 }
 
 function buildBreadcrumb(


### PR DESCRIPTION
Closes #179. Adds 'infra-os': 'Coverage' to the breadcrumb LABELS map. Static segment override; complements #209's dynamic segment override mechanism.