### PR TITLE
feat(compose): env-file backup with secret redaction (#21)

### DIFF
--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -103,6 +103,7 @@ export interface ComposeServiceConfig {
   apphookConfig?: ComposeApphookConfig
   includedVolumes: string[]
   includedBindMounts: string[]
+  envFiles: string[]
 }
 
 export interface ComposeProjectConfig {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -14,9 +14,11 @@
   "dependencies": {
     "@backupos/agent-protocol": "workspace:*",
     "@backupos/engine": "workspace:*",
+    "js-yaml": "^4.1.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.13",
     "esbuild": "^0.25.0",

--- a/packages/agent/src/handlers/composeBackup.ts
+++ b/packages/agent/src/handlers/composeBackup.ts
@@ -1,6 +1,9 @@
 import * as fs from 'fs/promises'
+import { readFile, writeFile, mkdir } from 'fs/promises'
+import { join, basename } from 'path'
 import * as os from 'os'
 import * as path from 'path'
+import { redactEnvFile } from '../lib/redact-env'
 import { ResticEngine } from '@backupos/engine'
 import type { AgentMessage, ServerMessage, ComposeServiceConfig } from '@backupos/agent-protocol'
 import {
@@ -202,9 +205,48 @@ export async function runComposeBackup(
       }
     }
 
-    // TODO(env-files): when ComposeServiceConfig.envFiles is populated by handleListCompose,
-    // read each path, redact secret keys, write to tmpDir, append to restic paths.
-    // See follow-on task: env-file backup + redaction (GitHub issue).
+    // ── Env-file backup with redaction ─────────────────────────────────────
+    if (config.includeEnvFiles) {
+      try {
+        const seenFiles = new Set<string>()
+        const envDir = join(tmpDir, 'env-files')
+        let envCount = 0
+        for (const service of config.services) {
+          if (!service.included) continue
+          for (const envFile of service.envFiles) {
+            if (seenFiles.has(envFile)) continue
+            seenFiles.add(envFile)
+            try {
+              const original = await readFile(envFile, 'utf8')
+              const output = config.redactSecretsInEnvFiles ? redactEnvFile(original) : original
+              if (envCount === 0) await mkdir(envDir, { recursive: true })
+              const safeName = `${service.serviceName}__${basename(envFile)}`
+              await writeFile(join(envDir, safeName), output, 'utf8')
+              envCount++
+            } catch (err) {
+              logLines.push(`[compose] WARN: env-file ${envFile} could not be backed up → ${err instanceof Error ? err.message : String(err)}`)
+            }
+          }
+        }
+
+        if (envCount > 0) {
+          try {
+            const result = await makeEngine().backup({
+              paths: [envDir],
+              tags:  [`job:${jobId}`, `compose:${config.projectName}`, 'meta:env-files'],
+              signal: ctrl.signal,
+            })
+            snapshotIds.push(result.snapshotId)
+            logLines.push(result.log)
+            logLines.push(`[compose] backed up ${envCount} env-file(s)${config.redactSecretsInEnvFiles ? ' (secrets redacted)' : ''}`)
+          } catch (err) {
+            logLines.push(`[compose] WARN: env-files backup failed → ${err instanceof Error ? err.message : String(err)}`)
+          }
+        }
+      } catch (err) {
+        logLines.push(`[compose] WARN: env-files block failed → ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }
 
     setPhase('finalizing')
     send({

--- a/packages/agent/src/handlers/listCompose.ts
+++ b/packages/agent/src/handlers/listCompose.ts
@@ -1,5 +1,39 @@
+import { readFile } from 'fs/promises'
+import { dirname, isAbsolute, resolve as resolvePath } from 'path'
+import yaml from 'js-yaml'
 import { listComposeContainers } from '../docker-client'
 import type { ComposeProjectListing, ComposeServiceListing, ComposeServiceVolume } from '@backupos/agent-protocol'
+
+interface ParsedComposeService {
+  env_file?: string | string[]
+}
+interface ParsedCompose {
+  services?: Record<string, ParsedComposeService>
+}
+
+/**
+ * Reads the compose file and returns a map of serviceName → resolved env_file paths.
+ * Returns empty map on any failure (compose file unreadable, YAML invalid).
+ */
+async function discoverEnvFilesPerService(composeFilePath: string): Promise<Map<string, string[]>> {
+  const result = new Map<string, string[]>()
+  try {
+    const content = await readFile(composeFilePath, 'utf8')
+    const parsed = yaml.load(content) as ParsedCompose | null
+    if (!parsed || typeof parsed !== 'object' || !parsed.services) return result
+
+    const baseDir = dirname(composeFilePath)
+    for (const [svcName, svcCfg] of Object.entries(parsed.services)) {
+      if (!svcCfg.env_file) continue
+      const raw = Array.isArray(svcCfg.env_file) ? svcCfg.env_file : [svcCfg.env_file]
+      const resolved = raw.map(p => isAbsolute(p) ? p : resolvePath(baseDir, p))
+      result.set(svcName, resolved)
+    }
+  } catch {
+    // Failed to read or parse compose file — return empty map silently
+  }
+  return result
+}
 
 function defaultQuiescence(image: string): { quiescence: string; apphookType?: string } {
   const img = image.toLowerCase()
@@ -18,6 +52,12 @@ export async function handleListCompose(projectName: string): Promise<ComposePro
 
   const composeFilePath = containers[0]?.Labels['com.docker.compose.project.config_files'] ?? undefined
 
+  // The label can be comma-separated for multi-file compose projects. Take the first.
+  const primaryComposeFile = composeFilePath?.split(',')[0]?.trim()
+  const envFilesPerService = primaryComposeFile
+    ? await discoverEnvFilesPerService(primaryComposeFile)
+    : new Map<string, string[]>()
+
   const services: (ComposeServiceListing & { defaultQuiescence?: string; defaultApphookType?: string })[] =
     containers.map(c => {
       const serviceName = c.Labels['com.docker.compose.service'] ?? c.Names[0]?.replace(/^\//, '') ?? 'unknown'
@@ -35,7 +75,7 @@ export async function handleListCompose(projectName: string): Promise<ComposePro
         containerStatus: c.Status,
         volumes,
         binds,
-        envFiles: [],
+        envFiles: envFilesPerService.get(serviceName) ?? [],
         networks: Object.keys(c.NetworkSettings?.Networks ?? {}),
         labels: c.Labels,
         defaultQuiescence: dq.quiescence,

--- a/packages/agent/src/lib/redact-env.ts
+++ b/packages/agent/src/lib/redact-env.ts
@@ -1,0 +1,33 @@
+/**
+ * Pattern matchers for env keys whose VALUES should be redacted.
+ * Matches the key name (case-insensitive) — e.g. PASSWORD, DB_PASS, AUTH_TOKEN, ApiKey.
+ */
+const SECRET_KEY_RE = /(password|secret|token|apikey|api_key|auth|credential|private_key|cert|encryption_key)/i
+
+const REDACTION = '***REDACTED***'
+
+/**
+ * Redacts an env-file's secret values while preserving file structure
+ * (comments, blank lines, formatting). Each `KEY=VALUE` line whose KEY
+ * matches the secret regex has VALUE replaced with REDACTION. Lines
+ * that aren't valid env declarations are kept verbatim.
+ */
+export function redactEnvFile(content: string): string {
+  const lines = content.split('\n')
+  return lines.map(rawLine => {
+    const line = rawLine
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) return line
+
+    const eq = line.indexOf('=')
+    if (eq === -1) return line
+
+    const before = line.slice(0, eq)
+    const key = before.replace(/^export\s+/, '').trim()
+
+    if (SECRET_KEY_RE.test(key)) {
+      return `${before}=${REDACTION}`
+    }
+    return line
+  }).join('\n')
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,10 +216,16 @@ importers:
       '@backupos/engine':
         specifier: workspace:*
         version: link:../engine
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.1
       ws:
         specifier: ^8.18.0
         version: 8.20.0
     devDependencies:
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17


### PR DESCRIPTION
Closes #21. Wires the three pieces from the issue: protocol field, listCompose populating envFiles via YAML parse, composeBackup reading and redacting via new redactEnvFile util. js-yaml added as dependency. ~50KB bundle impact.