### PR TITLE
feat(alerts): Test button for channels (#82)

### DIFF
--- a/apps/web/app/(dashboard)/settings/alerts/AddChannelForm.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/AddChannelForm.tsx
@@ -1,7 +1,45 @@
 'use client'
 
-import { useState } from 'react'
-import { createAlertChannel } from '@/app/actions/alerts'
+import { useState, useRef, useTransition } from 'react'
+import { createAlertChannel, testAlertChannel } from '@/app/actions/alerts'
+
+function buildConfigFromForm(type: string, fd: FormData): Record<string, string> | null {
+  const get = (k: string) => { const v = fd.get(k); return typeof v === 'string' ? v.trim() : '' }
+  if (type === 'discord' || type === 'slack' || type === 'webhook') {
+    const url = get('url'); if (!url) return null; return { url }
+  }
+  if (type === 'zulip') {
+    const url = get('url'), email = get('email'), apiKey = get('apiKey'), stream = get('stream')
+    if (!url || !email || !apiKey || !stream) return null
+    const cfg: Record<string, string> = { url, email, apiKey, stream }
+    const topic = get('topic'); if (topic) cfg.topic = topic
+    return cfg
+  }
+  if (type === 'telegram') {
+    const botToken = get('botToken'), chatId = get('chatId')
+    if (!botToken || !chatId) return null
+    return { botToken, chatId }
+  }
+  if (type === 'pagerduty') {
+    const integrationKey = get('integrationKey'); if (!integrationKey) return null; return { integrationKey }
+  }
+  if (type === 'ntfy') {
+    const url = get('url'), topic = get('topic')
+    if (!url || !topic) return null
+    const cfg: Record<string, string> = { url, topic }
+    const auth = get('auth'); if (auth) cfg.auth = auth
+    return cfg
+  }
+  if (type === 'gotify') {
+    const url = get('url'), appToken = get('appToken')
+    if (!url || !appToken) return null; return { url, appToken }
+  }
+  if (type === 'pushover') {
+    const apiToken = get('apiToken'), userKey = get('userKey')
+    if (!apiToken || !userKey) return null; return { apiToken, userKey }
+  }
+  return null
+}
 
 const inputStyle: React.CSSProperties = {
   width: '100%', padding: '7px 10px', fontSize: 13, boxSizing: 'border-box',
@@ -26,9 +64,31 @@ function Field({ label, name, type = 'text', placeholder, required }: {
 
 export function AddChannelForm() {
   const [type, setType] = useState('discord')
+  const [testStatus, setTestStatus] = useState<{ kind: 'idle' | 'sending' | 'success' | 'error'; message?: string }>({ kind: 'idle' })
+  const [isPending, startTransition] = useTransition()
+  const formRef = useRef<HTMLFormElement | null>(null)
+
+  function handleTest() {
+    if (!formRef.current) return
+    const fd = new FormData(formRef.current)
+    const config = buildConfigFromForm(type, fd)
+    if (!config) {
+      setTestStatus({ kind: 'error', message: 'Fill in the required fields before testing.' })
+      return
+    }
+    setTestStatus({ kind: 'sending' })
+    startTransition(async () => {
+      const result = await testAlertChannel({ kind: 'unsaved', type, config })
+      if (result.ok) {
+        setTestStatus({ kind: 'success' })
+      } else {
+        setTestStatus({ kind: 'error', message: result.error })
+      }
+    })
+  }
 
   return (
-    <form action={createAlertChannel} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+    <form ref={formRef} action={createAlertChannel} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
       <div>
         <label style={labelStyle}>Name</label>
         <input name="name" required placeholder="e.g. Ops Discord" style={inputStyle} />
@@ -95,16 +155,36 @@ export function AddChannelForm() {
         <Field label="User key" name="userKey" placeholder="Pushover user/group key" required />
       </>}
 
-      <button
-        type="submit"
-        style={{
-          alignSelf: 'flex-start', padding: '7px 18px', fontSize: 13, fontWeight: 500,
-          borderRadius: 'var(--radius-sm)', border: 'none',
-          background: 'var(--accent)', color: '#fff', cursor: 'pointer',
-        }}
-      >
-        Add channel
-      </button>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <button
+          type="submit"
+          style={{
+            padding: '7px 18px', fontSize: 13, fontWeight: 500,
+            borderRadius: 'var(--radius-sm)', border: 'none',
+            background: 'var(--accent)', color: '#fff', cursor: 'pointer',
+          }}
+        >
+          Add channel
+        </button>
+        <button
+          type="button"
+          onClick={handleTest}
+          disabled={isPending}
+          style={{
+            padding: '7px 14px', fontSize: 13,
+            borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+            background: 'var(--surf2)', color: 'var(--fg)', cursor: 'pointer',
+          }}
+        >
+          {isPending ? 'Sending…' : 'Test'}
+        </button>
+        {testStatus.kind === 'success' && (
+          <span style={{ fontSize: 12, color: 'var(--ok)' }}>Test message delivered</span>
+        )}
+        {testStatus.kind === 'error' && (
+          <span style={{ fontSize: 12, color: 'var(--err)' }}>{testStatus.message}</span>
+        )}
+      </div>
     </form>
   )
 }

--- a/apps/web/app/(dashboard)/settings/alerts/TestChannelButton.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/TestChannelButton.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { testAlertChannel } from '@/app/actions/alerts'
+
+export function TestChannelButton({ channelId }: { channelId: string }) {
+  const [status, setStatus] = useState<{ kind: 'idle' | 'success' | 'error'; message?: string }>({ kind: 'idle' })
+  const [isPending, startTransition] = useTransition()
+
+  function handleTest() {
+    setStatus({ kind: 'idle' })
+    startTransition(async () => {
+      const result = await testAlertChannel({ kind: 'saved', channelId })
+      if (result.ok) {
+        setStatus({ kind: 'success' })
+        setTimeout(() => setStatus({ kind: 'idle' }), 4000)
+      } else {
+        setStatus({ kind: 'error', message: result.error })
+      }
+    })
+  }
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <button
+        type="button"
+        onClick={handleTest}
+        disabled={isPending}
+        style={{
+          fontSize: 12, padding: '4px 10px',
+          backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-sm)', color: 'var(--fg)', cursor: 'pointer',
+        }}
+      >
+        {isPending ? 'Sending…' : 'Test'}
+      </button>
+      {status.kind === 'success' && <span style={{ fontSize: 12, color: 'var(--ok)' }}>Delivered</span>}
+      {status.kind === 'error' && <span style={{ fontSize: 12, color: 'var(--err)' }} title={status.message}>Failed</span>}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/alerts/page.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/page.tsx
@@ -1,6 +1,7 @@
 import { getDb, alertChannels } from '@backupos/db'
 import { deleteAlertChannel } from '@/app/actions/alerts'
 import { AddChannelForm } from './AddChannelForm'
+import { TestChannelButton } from './TestChannelButton'
 
 const TYPE_LABELS: Record<string, string> = {
   discord:   'Discord',
@@ -59,18 +60,21 @@ export default async function AlertChannelsPage({ searchParams }: { searchParams
                     {TYPE_LABELS[ch.type] ?? ch.type}{subtitle ? ` · ${subtitle}` : ''}
                   </div>
                 </div>
-                <form action={deleteAction}>
-                  <button
-                    type="submit"
-                    style={{
-                      padding: '4px 12px', fontSize: 12, cursor: 'pointer',
-                      borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
-                      background: 'var(--surf2)', color: 'var(--err)',
-                    }}
-                  >
-                    Remove
-                  </button>
-                </form>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <TestChannelButton channelId={ch.id} />
+                  <form action={deleteAction}>
+                    <button
+                      type="submit"
+                      style={{
+                        padding: '4px 12px', fontSize: 12, cursor: 'pointer',
+                        borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+                        background: 'var(--surf2)', color: 'var(--err)',
+                      }}
+                    >
+                      Remove
+                    </button>
+                  </form>
+                </div>
               </div>
             )
           })}

--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -126,6 +126,46 @@ export async function deleteAlertChannelForType(channelId: string, integType: st
   redirect(`/settings/integrations/${integType}?saved=1`)
 }
 
+export type TestAlertChannelInput =
+  | { kind: 'saved'; channelId: string }
+  | { kind: 'unsaved'; type: string; config: Record<string, string> }
+
+export type TestAlertChannelResult =
+  | { ok: true }
+  | { ok: false; error: string }
+
+export async function testAlertChannel(input: TestAlertChannelInput): Promise<TestAlertChannelResult> {
+  await requireAdmin()
+
+  let testChannel: { id: string; type: string; config: string }
+
+  if (input.kind === 'saved') {
+    if (!input.channelId) return { ok: false, error: 'Channel id required' }
+    const db = getDb()
+    const [row] = await db.select().from(alertChannels).where(eq(alertChannels.id, input.channelId)).limit(1)
+    if (!row) return { ok: false, error: 'Channel not found' }
+    testChannel = { id: row.id, type: row.type, config: row.config }
+  } else {
+    if (!(VALID_CHANNEL_TYPES as readonly string[]).includes(input.type)) {
+      return { ok: false, error: 'Invalid channel type' }
+    }
+    if (!input.config || Object.keys(input.config).length === 0) {
+      return { ok: false, error: 'Missing configuration fields' }
+    }
+    testChannel = { id: 'test', type: input.type, config: JSON.stringify(input.config) }
+  }
+
+  const message = 'BackupOS test message — if you can read this, your channel is configured correctly.'
+  const testPayload = { jobId: 'test', jobName: 'Test alert', error: message }
+
+  try {
+    await dispatchToChannel(testChannel, 'backup_failed', message, 'info', testPayload)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
 export async function sendTestAlert(channelId: string): Promise<{ ok: boolean; error?: string }> {
   await requireAdmin()
   const db = getDb()


### PR DESCRIPTION
Closes #82. Reuses dispatchToChannel for both unsaved (form values) and saved (channel ID) test paths. Added Test buttons to AddChannelForm and the saved channel rows. Test message: 'BackupOS test message — if you can read this, your channel is configured correctly.'