### PR TITLE
fix(restore): wire notify steps to real alert channel delivery

### DIFF
--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -2,9 +2,11 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, backupJobs, eq, desc } from '@backupos/db'
-import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult } from '@backupos/restore'
+import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, backupJobs, alertChannels, eq, desc } from '@backupos/db'
+import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult, type NotifyDelivery } from '@backupos/restore'
 import { requireAdmin } from '@/lib/user'
+import { dispatchToChannel } from '@/lib/alerts'
+import type { AlertType, AlertPayload } from '@/lib/alerts'
 import { decryptField } from '@/lib/repo-crypto'
 import { connectedAgentIds, requestFilesystemRestore } from '@/lib/ws-state'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
@@ -71,6 +73,16 @@ export async function forkSpec(name: string, yamlContent: string): Promise<void>
   redirect(`/restore/${id}`)
 }
 
+async function deliverRestoreNotification(channel: string, message: string): Promise<void> {
+  const db       = getDb()
+  const channels = await db.select().from(alertChannels).all()
+  const target   = channels.find(c => c.enabled && c.name === channel)
+  if (!target) throw new Error(`No enabled alert channel named '${channel}'`)
+  const type: AlertType    = 'backup_failed'
+  const payload: AlertPayload = { jobId: '', jobName: 'restore', error: message }
+  await dispatchToChannel(target, type, message, 'info', payload)
+}
+
 export async function runSpec(specId: string, snapshotId = 'latest'): Promise<void> {
   const db     = getDb()
   const [spec] = await db.select().from(restoreSpecs).where(eq(restoreSpecs.id, specId)).limit(1)
@@ -88,7 +100,7 @@ export async function runSpec(specId: string, snapshotId = 'latest'): Promise<vo
     startedAt: new Date(),
   })
 
-  executeRestoreSpec(parsed, snapshotId, 'local').then(async (result: RestoreRunResult) => {
+  executeRestoreSpec(parsed, snapshotId, 'local', deliverRestoreNotification).then(async (result: RestoreRunResult) => {
     await db
       .update(restoreRuns)
       .set({

--- a/packages/restore/src/executor.ts
+++ b/packages/restore/src/executor.ts
@@ -12,6 +12,15 @@ import type {
   StepResult,
 } from './types'
 
+/**
+ * Optional callback to actually deliver notify steps. Receives the channel
+ * identifier (free-form string from the spec — typically a channel NAME)
+ * plus the message. Should throw on delivery failure.
+ *
+ * If undefined, notify steps return failure with a clear error.
+ */
+export type NotifyDelivery = (channel: string, message: string) => Promise<void>
+
 // ── Step executors ────────────────────────────────────────────────────────────
 
 async function execFilesystemRestore(
@@ -157,10 +166,21 @@ async function execContainerRestart(step: ContainerRestartStep): Promise<Omit<St
   })
 }
 
-async function execNotify(step: NotifyStep): Promise<Omit<StepResult, 'step' | 'durationMs'>> {
-  // V1: log only — actual delivery wired in V2 via notification service
-  console.log(`[notify] channel=${step.channel} message=${step.message ?? '(none)'}`)
-  return { success: true, output: `Notification sent via ${step.channel}` }
+async function execNotify(
+  step: NotifyStep,
+  notifyDelivery?: NotifyDelivery,
+): Promise<Omit<StepResult, 'step' | 'durationMs'>> {
+  const message = step.message ?? `Restore step '${step.name}' completed`
+  if (!notifyDelivery) {
+    return { success: false, output: `Notify step skipped: no delivery callback configured (channel=${step.channel})` }
+  }
+  try {
+    await notifyDelivery(step.channel, message)
+    return { success: true, output: `Notification delivered to channel '${step.channel}'` }
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err)
+    return { success: false, output: `Notification delivery failed for channel '${step.channel}': ${errMsg}` }
+  }
 }
 
 // ── Step dispatcher ───────────────────────────────────────────────────────────
@@ -169,6 +189,7 @@ async function executeStep(
   step: RestoreStep,
   snapshotId: string,
   agentId: string,
+  notifyDelivery?: NotifyDelivery,
 ): Promise<StepResult> {
   const start = Date.now()
   let result: Omit<StepResult, 'step' | 'durationMs'>
@@ -190,7 +211,7 @@ async function executeStep(
       result = await execContainerRestart(step)
       break
     case 'notify':
-      result = await execNotify(step)
+      result = await execNotify(step, notifyDelivery)
       break
   }
 
@@ -203,11 +224,12 @@ export async function executeRestoreSpec(
   spec: ParsedRestoreSpec,
   snapshotId: string,
   agentId: string,
+  notifyDelivery?: NotifyDelivery,
 ): Promise<RestoreRunResult> {
   const results: StepResult[] = []
 
   for (const step of spec.steps) {
-    const stepResult = await executeStep(step, snapshotId, agentId)
+    const stepResult = await executeStep(step, snapshotId, agentId, notifyDelivery)
     results.push(stepResult)
 
     if (!stepResult.success && step.onFailure === 'abort') {

--- a/packages/restore/src/index.ts
+++ b/packages/restore/src/index.ts
@@ -1,3 +1,3 @@
 export * from './types'
 export { parseRestoreSpec, RestoreSpecParseError } from './parser'
-export { executeRestoreSpec } from './executor'
+export { executeRestoreSpec, type NotifyDelivery } from './executor'


### PR DESCRIPTION
## Summary
- `execNotify` now accepts an optional `NotifyDelivery` callback; without one it returns failure with a clear message instead of fake success
- `executeStep` and `executeRestoreSpec` thread the callback through the call chain
- Web `runSpec` action passes `deliverRestoreNotification` which resolves the channel name against enabled alert channels and calls `dispatchToChannel`

Closes #79

## Test plan
- [ ] Run a restore spec with a `notify` step pointing to a configured channel name — delivery should succeed
- [ ] Run with no matching channel name — step should fail with `No enabled alert channel named '...'`
- [ ] Run with `notifyDelivery` omitted (e.g. direct executor call) — step returns failure with skip message

🤖 Generated with [Claude Code](https://claude.com/claude-code)