### PR TITLE
fix(monitors): insert monitor_results row on failed sync (#159)

### DIFF
--- a/apps/web/lib/monitors.ts
+++ b/apps/web/lib/monitors.ts
@@ -42,6 +42,25 @@ export async function performMonitorSync(
     } else {
       msg = String(err)
     }
+
+    try {
+      await db.insert(monitorResults).values({
+        id:               crypto.randomUUID(),
+        monitorId,
+        status:           'failed',
+        lastBackupAt:     null,
+        lastBackupStatus: null,
+        sizeBytes:        null,
+        details:          JSON.stringify({ error: msg || 'Sync failed' }),
+        checkedAt:        new Date(),
+      })
+      await db.update(backupMonitors)
+        .set({ lastSyncedAt: new Date(), status: 'failed' })
+        .where(eq(backupMonitors.id, monitorId))
+    } catch (insertErr) {
+      console.error('[monitors] failed to record sync failure:', insertErr)
+    }
+
     return { ok: false, error: msg || 'Sync failed' }
   }
 }


### PR DESCRIPTION
## Summary
- Catch block in `performMonitorSync` now inserts a `monitor_results` row with `status='failed'`, null backup fields, and the error message in `details`
- Also updates `backupMonitors.status` to `'failed'` and bumps `lastSyncedAt` so the parent row reflects the attempt
- Insert is wrapped in a nested try/catch so a DB error during failure-recording doesn't mask the original sync error

Closes #159

## Test plan
- [ ] Trigger a sync failure (e.g. wrong credentials) — confirm a `failed` row appears in `/monitors/<id>` history
- [ ] Confirm `backupMonitors.status` is set to `'failed'` and `lastSyncedAt` is updated
- [ ] Simulate a DB error during the catch inserts — confirm original error is still returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)