### PR TITLE
fix(restore): log restore dispatch (#145)

### DIFF
--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -101,6 +101,17 @@ export async function runSpec(specId: string, snapshotId = 'latest'): Promise<vo
     startedAt: new Date(),
   })
 
+  try {
+    appendLog({
+      level: 'info',
+      component: 'web',
+      message: `Restore dispatched for spec "${spec.name}"`,
+      entityType: 'restore_run',
+      entityId: runId,
+      payload: { specId, snapshotId },
+    })
+  } catch (err) { console.error('[logger]', err) }
+
   executeRestoreSpec(parsed, snapshotId, 'local', deliverRestoreNotification).then(async (result: RestoreRunResult) => {
     await db
       .update(restoreRuns)


### PR DESCRIPTION
## Summary
- Adds a single `appendLog` info call in `runSpec` after `db.insert(restoreRuns)` and before `executeRestoreSpec`
- Message: `Restore dispatched for spec "<name>"` with `specId` and `snapshotId` in payload
- Wrapped in `try/catch` consistent with other logger calls in the file

Closes #145

## Test plan
- [ ] Trigger a restore — confirm `Restore dispatched for spec "..."` appears in `/logs` before success/failure entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)