### PR TITLE
feat(restore): cancel ad-hoc filesystem restores (#56)

### DIFF
--- a/apps/web/app/(dashboard)/restore/[id]/runs/CancelRunButton.tsx
+++ b/apps/web/app/(dashboard)/restore/[id]/runs/CancelRunButton.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { cancelRestore } from '@/app/actions/restore'
+
+export function CancelRunButton({ runId }: { runId: string }) {
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle')
+  const [errorMessage, setErrorMessage] = useState<string>('')
+  const [isPending, startTransition] = useTransition()
+
+  function handleCancel() {
+    if (!confirm('Cancel this restore? The running operation will be aborted.')) return
+    startTransition(async () => {
+      const result = await cancelRestore(runId)
+      if (result.ok) {
+        setStatus('success')
+      } else {
+        setStatus('error')
+        setErrorMessage(result.error ?? 'Unknown error')
+      }
+    })
+  }
+
+  if (status === 'success') {
+    return <span style={{ fontSize: 12, color: 'var(--ok)' }}>Cancel sent</span>
+  }
+  if (status === 'error') {
+    return <span style={{ fontSize: 12, color: 'var(--err)' }} title={errorMessage}>Failed</span>
+  }
+  return (
+    <button
+      type="button"
+      onClick={handleCancel}
+      disabled={isPending}
+      style={{
+        fontSize: 12, padding: '4px 10px',
+        backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+        borderRadius: 'var(--radius-sm)', color: 'var(--fg)', cursor: 'pointer',
+      }}
+    >
+      {isPending ? 'Cancelling…' : 'Cancel'}
+    </button>
+  )
+}

--- a/apps/web/app/(dashboard)/restore/[id]/runs/page.tsx
+++ b/apps/web/app/(dashboard)/restore/[id]/runs/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { Badge } from '@/components/ui/badge'
 import { EmptyState } from '@/components/ui/empty-state'
 import { PollWrapper } from './poll-wrapper'
+import { CancelRunButton } from './CancelRunButton'
 
 type BadgeStatus = ComponentProps<typeof Badge>['status']
 
@@ -46,6 +47,7 @@ export default async function RestoreRunsPage({ params }: { params: Promise<{ id
                 <th style={{ padding: '10px 20px', textAlign: 'left', fontWeight: 500 }}>Status</th>
                 <th style={{ padding: '10px 20px', textAlign: 'left', fontWeight: 500 }}>Trigger</th>
                 <th style={{ padding: '10px 20px', textAlign: 'left', fontWeight: 500 }}>Snapshot</th>
+                <th style={{ padding: '10px 20px', textAlign: 'left', fontWeight: 500 }}></th>
               </tr>
             </thead>
             <tbody>
@@ -85,6 +87,9 @@ export default async function RestoreRunsPage({ params }: { params: Promise<{ id
                     >
                       {run.snapshotId?.slice(0, 8) ?? '—'}
                     </Link>
+                  </td>
+                  <td style={{ padding: '12px 20px' }}>
+                    {run.status === 'running' && <CancelRunButton runId={run.id} />}
                   </td>
                 </tr>
               ))}

--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -8,7 +8,7 @@ import { requireAdmin } from '@/lib/user'
 import { dispatchToChannel } from '@/lib/alerts'
 import type { AlertType, AlertPayload } from '@/lib/alerts'
 import { decryptField } from '@/lib/repo-crypto'
-import { connectedAgentIds, requestFilesystemRestore } from '@/lib/ws-state'
+import { connectedAgentIds, requestFilesystemRestore, dispatch } from '@/lib/ws-state'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 import { appendLog } from '@/lib/logger'
 
@@ -318,4 +318,20 @@ export async function restoreFromSnapshot(
   }
 
   return { ok: true, runId }
+}
+
+export async function cancelRestore(restoreId: string): Promise<{ ok: boolean; error?: string }> {
+  await requireAdmin()
+  if (!restoreId) return { ok: false, error: 'restoreId required' }
+
+  const db = getDb()
+  const [run] = await db.select().from(restoreRuns).where(eq(restoreRuns.id, restoreId)).limit(1)
+  if (!run) return { ok: false, error: 'Restore run not found' }
+  if (run.status !== 'running') return { ok: false, error: `Restore is ${run.status}, not running` }
+
+  for (const agentId of connectedAgentIds()) {
+    dispatch(agentId, { type: 'cancel_filesystem_restore', restoreId })
+  }
+
+  return { ok: true }
 }

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -782,6 +782,15 @@ void app.prepare().then(() => {
             actor: agentId, createdAt: new Date(),
           })
 
+        } else if (msg.type === 'filesystem_restore_cancelled' && agentId) {
+          console.log(`[restore] filesystem_restore_cancelled restoreId=${msg.restoreId} agentId=${agentId} reason=${msg.reason}`)
+          await db.update(restoreRuns).set({
+            status:      'cancelled',
+            completedAt: new Date(),
+            log:         JSON.stringify({ cancelled: true, reason: msg.reason }),
+          }).where(eq(restoreRuns.id, msg.restoreId))
+          try { appendLog({ level: 'info', component: 'web', message: `Filesystem restore cancelled (${msg.reason})`, entityType: 'restore_run', entityId: msg.restoreId }) } catch (err) { console.error('[logger]', err) }
+
         } else if (msg.type === 'filesystem_restore_started' && agentId) {
           console.log(`[restore] filesystem_restore_started restoreId=${msg.restoreId} agentId=${agentId}`)
           resolveFilesystemRestoreStarted(msg.requestId)

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -150,6 +150,7 @@ export type AgentMessage =
   | { type: 'mount_failed'; requestId: string; repoId: string; error: string }
   | { type: 'filesystem_restore_started'; requestId: string; restoreId: string }
   | { type: 'filesystem_restore_complete'; restoreId: string; success: boolean; filesRestored?: number; durationSec?: number; error?: string; targetPath?: string; sourcePath?: string }
+  | { type: 'filesystem_restore_cancelled'; restoreId: string; reason: 'user_requested' | 'not_running' }
 
 export interface DetectedResources {
   dockerVolumes?: string[]
@@ -174,3 +175,4 @@ export type ServerMessage =
   | { type: 'mount_repository'; requestId: string; repoId: string; nfsServer: string; nfsExport: string; nfsOptions: string }
   | { type: 'run_verification'; verificationRunId: string; repoId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory'; validationHook?: string | null }
   | { type: 'run_filesystem_restore'; requestId: string; restoreId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; targetPath: string; sourcePath: string; targetIsAgentLocal: boolean }
+  | { type: 'cancel_filesystem_restore'; restoreId: string }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -147,6 +147,10 @@ interface ActiveJob { ctrl: AbortController; runId: string; phase: string; lastR
 // Active jobs — keyed by jobId
 const activeJobs = new Map<string, ActiveJob>()
 
+interface ActiveRestore { ctrl: AbortController; cancelled: boolean }
+// Active ad-hoc filesystem restores — keyed by restoreId
+const activeRestores = new Map<string, ActiveRestore>()
+
 // Emit a heartbeat for every in-flight backup every 5 seconds
 setInterval(() => {
   for (const [jobId, job] of activeJobs) {
@@ -248,8 +252,20 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
       await runComposeRestore(msg, send, activeJobs, BINARY)
     })()
 
+  } else if (msg.type === 'cancel_filesystem_restore') {
+    const restore = activeRestores.get(msg.restoreId)
+    if (!restore) {
+      console.warn(`[agent] cancel_filesystem_restore: no active restore for restoreId=${msg.restoreId}`)
+      send({ type: 'filesystem_restore_cancelled', restoreId: msg.restoreId, reason: 'not_running' })
+    } else {
+      console.log(`[agent] cancel_filesystem_restore restoreId=${msg.restoreId} — aborting`)
+      restore.cancelled = true
+      restore.ctrl.abort()
+      send({ type: 'filesystem_restore_cancelled', restoreId: msg.restoreId, reason: 'user_requested' })
+    }
+
   } else if (msg.type === 'run_filesystem_restore') {
-    void handleFilesystemRestore(msg, send, BINARY)
+    void handleFilesystemRestore(msg, send, activeRestores, BINARY)
 
   } else if (msg.type === 'mount_repository') {
     void runMountRepository(msg, send)

--- a/packages/agent/src/handlers/filesystemRestore.ts
+++ b/packages/agent/src/handlers/filesystemRestore.ts
@@ -5,9 +5,15 @@ import { resolveHostPrefix, applyHostPrefix } from '../lib/host-prefix'
 type SendFn = (msg: AgentMessage) => void
 type RunFilesystemRestoreMsg = Extract<ServerMessage, { type: 'run_filesystem_restore' }>
 
+export interface ActiveRestore {
+  ctrl:      AbortController
+  cancelled: boolean
+}
+
 export async function handleFilesystemRestore(
   msg: RunFilesystemRestoreMsg,
   send: SendFn,
+  activeRestores: Map<string, ActiveRestore>,
   binaryPath?: string,
 ): Promise<void> {
   const { requestId, restoreId, repoUrl, repoPassword, envVars, snapshotId, targetPath, sourcePath } = msg
@@ -20,6 +26,9 @@ export async function handleFilesystemRestore(
 
   send({ type: 'filesystem_restore_started', requestId, restoreId })
 
+  const ctrl = new AbortController()
+  activeRestores.set(restoreId, { ctrl, cancelled: false })
+
   const startedAt = Date.now()
   try {
     const engine = new ResticEngine({
@@ -29,7 +38,7 @@ export async function handleFilesystemRestore(
       binaryPath,
     })
     const shortId = snapshotId.slice(0, 8)
-    const result = await engine.restore(shortId, prefixedTargetPath, [prefixedSourcePath])
+    const result = await engine.restore(shortId, prefixedTargetPath, [prefixedSourcePath], ctrl.signal)
     console.log(`[agent] engine.restore returned: filesRestored=${result.filesRestored} duration=${result.duration} totalSize=${result.totalSize}`)
     send({
       type:          'filesystem_restore_complete',
@@ -41,8 +50,9 @@ export async function handleFilesystemRestore(
       sourcePath,
     })
   } catch (err) {
-    const error = err instanceof Error ? err.message : String(err)
-    console.error(`[agent] filesystem_restore failed: restoreId=${restoreId} error=${error}`)
+    const wasCancelled = activeRestores.get(restoreId)?.cancelled === true
+    const error = wasCancelled ? 'cancelled by user' : (err instanceof Error ? err.message : String(err))
+    console.error(`[agent] filesystem_restore ${wasCancelled ? 'cancelled' : 'failed'}: restoreId=${restoreId} error=${error}`)
     send({
       type:        'filesystem_restore_complete',
       restoreId,
@@ -52,5 +62,7 @@ export async function handleFilesystemRestore(
       targetPath,
       sourcePath,
     })
+  } finally {
+    activeRestores.delete(restoreId)
   }
 }


### PR DESCRIPTION
## Summary
- **Protocol**: adds `cancel_filesystem_restore` (server→agent) and `filesystem_restore_cancelled` (agent→server) message types
- **Agent**: `activeRestores` Map registers an `AbortController` per in-flight restore; `cancel_filesystem_restore` handler aborts it; handler plumbs `ctrl.signal` into `engine.restore`
- **Server**: `filesystem_restore_cancelled` handler sets `restore_runs.status='cancelled'` and logs via `appendLog`
- **Action**: `cancelRestore(restoreId)` admin server action broadcasts cancel to all connected agents (V1 — targeted dispatch deferred until `agentId` is stored on `restore_runs`)
- **UI**: `CancelRunButton` client component on the restore runs list, shown only for `status='running'` rows

Closes #56

## Test plan
- [ ] Start an ad-hoc restore, click Cancel — status updates to `cancelled`
- [ ] Cancel a non-running restore — action returns error `Restore is <status>, not running`
- [ ] No running restore on agent — agent sends `reason: 'not_running'`, server still marks cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)