### PR TITLE
feat(restore): database_restore for postgres + mysql (#80, #149)

### DIFF
--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -3,12 +3,12 @@
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, backupJobs, alertChannels, eq, desc } from '@backupos/db'
-import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult, type NotifyDelivery } from '@backupos/restore'
+import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult, type NotifyDelivery, type DatabaseRestoreDelivery } from '@backupos/restore'
 import { requireAdmin } from '@/lib/user'
 import { dispatchToChannel } from '@/lib/alerts'
 import type { AlertType, AlertPayload } from '@/lib/alerts'
 import { decryptField } from '@/lib/repo-crypto'
-import { connectedAgentIds, requestFilesystemRestore, dispatch } from '@/lib/ws-state'
+import { connectedAgentIds, requestFilesystemRestore, requestDatabaseRestore, dispatch } from '@/lib/ws-state'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 import { appendLog } from '@/lib/logger'
 
@@ -74,6 +74,21 @@ export async function forkSpec(name: string, yamlContent: string): Promise<void>
   redirect(`/restore/${id}`)
 }
 
+const deliverDatabaseRestore: DatabaseRestoreDelivery = async (step, _snapshotId, agentId) => {
+  if (step.app !== 'postgres' && step.app !== 'mysql' && step.app !== 'mariadb') {
+    return { success: false, error: `Unsupported database app: ${step.app}` }
+  }
+
+  return requestDatabaseRestore(agentId, {
+    restoreId:       crypto.randomUUID(),
+    app:             step.app,
+    dumpFilePath:    step.snapshotPath,
+    targetContainer: step.target.container,
+    targetDatabase:  step.target.database,
+    targetUsername:  step.target.username,
+  })
+}
+
 async function deliverRestoreNotification(channel: string, message: string): Promise<void> {
   const db       = getDb()
   const channels = await db.select().from(alertChannels).all()
@@ -112,7 +127,7 @@ export async function runSpec(specId: string, snapshotId = 'latest'): Promise<vo
     })
   } catch (err) { console.error('[logger]', err) }
 
-  executeRestoreSpec(parsed, snapshotId, 'local', deliverRestoreNotification).then(async (result: RestoreRunResult) => {
+  executeRestoreSpec(parsed, snapshotId, 'local', deliverRestoreNotification, deliverDatabaseRestore).then(async (result: RestoreRunResult) => {
     await db
       .update(restoreRuns)
       .set({

--- a/apps/web/lib/ws-state.ts
+++ b/apps/web/lib/ws-state.ts
@@ -252,3 +252,52 @@ export function requestFilesystemRestore(
 export function resolveFilesystemRestoreStarted(requestId: string): void {
   pendingFsRestores.get(requestId)?.({ ok: true })
 }
+
+type DbRestoreResult = { success: boolean; output?: string; error?: string; durationSec?: number }
+const pendingDbRestoreStarted  = new Map<string, () => void>()
+const pendingDbRestoreComplete = new Map<string, (r: DbRestoreResult) => void>()
+
+export function requestDatabaseRestore(
+  agentId: string,
+  payload: {
+    restoreId:       string
+    app:             'postgres' | 'mysql' | 'mariadb'
+    dumpFilePath:    string
+    targetContainer?: string
+    targetDatabase?:  string
+    targetUsername?:  string
+    targetHost?:      string
+    targetPort?:      number
+    passwordEnv?:     string
+  },
+): Promise<DbRestoreResult> {
+  const requestId = crypto.randomUUID()
+  const sent = dispatch(agentId, { type: 'run_database_restore', requestId, ...payload })
+  if (!sent) return Promise.reject(new Error(`Agent ${agentId} not connected`))
+
+  return new Promise((resolve, reject) => {
+    const startedTimeout = setTimeout(() => {
+      pendingDbRestoreStarted.delete(requestId)
+      pendingDbRestoreComplete.delete(payload.restoreId)
+      reject(new Error('Agent did not acknowledge database restore start within 30s'))
+    }, 30_000)
+
+    pendingDbRestoreStarted.set(requestId, () => {
+      clearTimeout(startedTimeout)
+    })
+
+    pendingDbRestoreComplete.set(payload.restoreId, (result) => {
+      pendingDbRestoreStarted.delete(requestId)
+      pendingDbRestoreComplete.delete(payload.restoreId)
+      resolve(result)
+    })
+  })
+}
+
+export function resolveDatabaseRestoreStarted(requestId: string): void {
+  pendingDbRestoreStarted.get(requestId)?.()
+}
+
+export function resolveDatabaseRestoreComplete(restoreId: string, result: DbRestoreResult): void {
+  pendingDbRestoreComplete.get(restoreId)?.(result)
+}

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -10,7 +10,7 @@ import type { WebSocket } from 'ws'
 import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, verificationRuns, verificationTests, snapshots, eq, and, desc } from '@backupos/db'
 import { ResticEngine } from '@backupos/engine'
 import { parseExpression } from 'cron-parser'
-import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository, resolveFilesystemRestoreStarted } from './lib/ws-state'
+import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository, resolveFilesystemRestoreStarted, resolveDatabaseRestoreStarted, resolveDatabaseRestoreComplete } from './lib/ws-state'
 import { ensureRepoMountedOnAgent } from './lib/repo-mount'
 import { loadOrCreateInternalToken } from './lib/internal-token'
 import { decryptField } from './lib/repo-crypto'
@@ -790,6 +790,19 @@ void app.prepare().then(() => {
             log:         JSON.stringify({ cancelled: true, reason: msg.reason }),
           }).where(eq(restoreRuns.id, msg.restoreId))
           try { appendLog({ level: 'info', component: 'web', message: `Filesystem restore cancelled (${msg.reason})`, entityType: 'restore_run', entityId: msg.restoreId }) } catch (err) { console.error('[logger]', err) }
+
+        } else if (msg.type === 'database_restore_started') {
+          console.log(`[restore] database_restore_started restoreId=${msg.restoreId}`)
+          resolveDatabaseRestoreStarted(msg.requestId)
+
+        } else if (msg.type === 'database_restore_complete' && agentId) {
+          console.log(`[restore] database_restore_complete restoreId=${msg.restoreId} success=${msg.success}`)
+          resolveDatabaseRestoreComplete(msg.restoreId, {
+            success:     msg.success,
+            output:      msg.output,
+            error:       msg.error,
+            durationSec: msg.durationSec,
+          })
 
         } else if (msg.type === 'filesystem_restore_started' && agentId) {
           console.log(`[restore] filesystem_restore_started restoreId=${msg.restoreId} agentId=${agentId}`)

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -151,6 +151,8 @@ export type AgentMessage =
   | { type: 'filesystem_restore_started'; requestId: string; restoreId: string }
   | { type: 'filesystem_restore_complete'; restoreId: string; success: boolean; filesRestored?: number; durationSec?: number; error?: string; targetPath?: string; sourcePath?: string }
   | { type: 'filesystem_restore_cancelled'; restoreId: string; reason: 'user_requested' | 'not_running' }
+  | { type: 'database_restore_started'; requestId: string; restoreId: string }
+  | { type: 'database_restore_complete'; restoreId: string; success: boolean; output?: string; error?: string; durationSec?: number }
 
 export interface DetectedResources {
   dockerVolumes?: string[]
@@ -176,3 +178,4 @@ export type ServerMessage =
   | { type: 'run_verification'; verificationRunId: string; repoId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory'; validationHook?: string | null }
   | { type: 'run_filesystem_restore'; requestId: string; restoreId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; targetPath: string; sourcePath: string; targetIsAgentLocal: boolean }
   | { type: 'cancel_filesystem_restore'; restoreId: string }
+  | { type: 'run_database_restore'; requestId: string; restoreId: string; app: 'postgres' | 'mysql' | 'mariadb'; dumpFilePath: string; targetContainer?: string; targetDatabase?: string; targetUsername?: string; targetHost?: string; targetPort?: number; passwordEnv?: string }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -10,6 +10,7 @@ import { detectCapabilities } from './capabilities'
 import { resolveHostPrefix, applyHostPrefixAll } from './lib/host-prefix'
 import { runMountRepository } from './handlers/mountRepository'
 import { handleFilesystemRestore } from './handlers/filesystemRestore'
+import { handleDatabaseRestore } from './handlers/databaseRestore'
 
 function requireEnv(name: string): string {
   const v = process.env[name]
@@ -263,6 +264,9 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
       restore.ctrl.abort()
       send({ type: 'filesystem_restore_cancelled', restoreId: msg.restoreId, reason: 'user_requested' })
     }
+
+  } else if (msg.type === 'run_database_restore') {
+    void handleDatabaseRestore(msg, send)
 
   } else if (msg.type === 'run_filesystem_restore') {
     void handleFilesystemRestore(msg, send, activeRestores, BINARY)

--- a/packages/agent/src/exec-allowed.ts
+++ b/packages/agent/src/exec-allowed.ts
@@ -3,7 +3,10 @@ import { spawn } from 'child_process'
 export const ALLOWED_COMMANDS = new Set([
   'restic',
   'pg_dump',
+  'pg_restore',
+  'psql',
   'mysqldump',
+  'mysql',
   'redis-cli',
   'sqlite3',
   'docker',

--- a/packages/agent/src/handlers/databaseRestore.ts
+++ b/packages/agent/src/handlers/databaseRestore.ts
@@ -1,0 +1,120 @@
+import { spawnAllowed } from '../exec-allowed'
+import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
+import { resolveHostPrefix, applyHostPrefix } from '../lib/host-prefix'
+
+type SendFn = (msg: AgentMessage) => void
+type RunDatabaseRestoreMsg = Extract<ServerMessage, { type: 'run_database_restore' }>
+
+export async function handleDatabaseRestore(
+  msg: RunDatabaseRestoreMsg,
+  send: SendFn,
+): Promise<void> {
+  const { requestId, restoreId, app, dumpFilePath, targetDatabase, targetUsername, targetHost, targetPort, passwordEnv } = msg
+
+  console.log(`[agent] run_database_restore received: restoreId=${restoreId} app=${app} dumpFile=${dumpFilePath}`)
+
+  send({ type: 'database_restore_started', requestId, restoreId })
+
+  const startedAt = Date.now()
+  const hostPrefix = resolveHostPrefix()
+  const resolvedDumpPath = applyHostPrefix(dumpFilePath, hostPrefix)
+
+  try {
+    const password = passwordEnv ? process.env[passwordEnv] : undefined
+
+    if (app === 'postgres') {
+      await runPostgresRestore({ dumpPath: resolvedDumpPath, host: targetHost, port: targetPort, database: targetDatabase, username: targetUsername, password })
+    } else if (app === 'mysql' || app === 'mariadb') {
+      await runMysqlRestore({ dumpPath: resolvedDumpPath, host: targetHost, port: targetPort, database: targetDatabase, username: targetUsername, password })
+    } else {
+      throw new Error(`Unsupported database app: ${app}`)
+    }
+
+    const duration = (Date.now() - startedAt) / 1000
+    send({
+      type:        'database_restore_complete',
+      restoreId,
+      success:     true,
+      durationSec: duration,
+      output:      `Restored ${app} from ${dumpFilePath}`,
+    })
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    console.error(`[agent] database_restore failed: restoreId=${restoreId} error=${error}`)
+    send({
+      type:        'database_restore_complete',
+      restoreId,
+      success:     false,
+      error,
+      durationSec: (Date.now() - startedAt) / 1000,
+    })
+  }
+}
+
+interface PgArgs {
+  dumpPath: string
+  host?: string
+  port?: number
+  database?: string
+  username?: string
+  password?: string
+}
+
+async function runPostgresRestore(opts: PgArgs): Promise<void> {
+  const { dumpPath, host, port, database, username, password } = opts
+  if (!database) throw new Error('postgres restore: target.database is required')
+
+  const isCustomFormat = /\.(dump|custom|pgdump)$/i.test(dumpPath)
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...(password ? { PGPASSWORD: password } : {}),
+  }
+
+  if (isCustomFormat) {
+    const args: string[] = [
+      ...(host     ? ['-h', host]         : []),
+      ...(port     ? ['-p', String(port)] : []),
+      ...(username ? ['-U', username]     : []),
+      '-d', database,
+      '--clean', '--if-exists',
+      dumpPath,
+    ]
+    await spawnAllowed('pg_restore', args, { env })
+  } else {
+    const args: string[] = [
+      ...(host     ? ['-h', host]         : []),
+      ...(port     ? ['-p', String(port)] : []),
+      ...(username ? ['-U', username]     : []),
+      '-d', database,
+      '-f', dumpPath,
+    ]
+    await spawnAllowed('psql', args, { env })
+  }
+}
+
+interface MysqlArgs {
+  dumpPath: string
+  host?: string
+  port?: number
+  database?: string
+  username?: string
+  password?: string
+}
+
+async function runMysqlRestore(opts: MysqlArgs): Promise<void> {
+  const { dumpPath, host, port, database, username, password } = opts
+  if (!database) throw new Error('mysql restore: target.database is required')
+
+  const args: string[] = [
+    ...(host     ? ['-h', host]         : []),
+    ...(port     ? ['-P', String(port)] : []),
+    ...(username ? ['-u', username]     : []),
+    database,
+    '-e', `source ${dumpPath}`,
+  ]
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...(password ? { MYSQL_PWD: password } : {}),
+  }
+  await spawnAllowed('mysql', args, { env })
+}

--- a/packages/restore/src/executor.ts
+++ b/packages/restore/src/executor.ts
@@ -21,6 +21,12 @@ import type {
  */
 export type NotifyDelivery = (channel: string, message: string) => Promise<void>
 
+export type DatabaseRestoreDelivery = (
+  step: DatabaseRestoreStep,
+  snapshotId: string,
+  agentId: string,
+) => Promise<{ success: boolean; output?: string; error?: string; durationSec?: number }>
+
 // ── Step executors ────────────────────────────────────────────────────────────
 
 async function execFilesystemRestore(
@@ -56,13 +62,35 @@ async function execFilesystemRestore(
 
 async function execDatabaseRestore(
   step: DatabaseRestoreStep,
-  _snapshotId: string,
-  _agentId: string,
+  snapshotId: string,
+  agentId: string,
+  databaseRestoreDelivery?: DatabaseRestoreDelivery,
 ): Promise<Omit<StepResult, 'step' | 'durationMs'>> {
-  // App-hook-aware database restore is agent-side; stub returns not-implemented
-  return {
-    success: false,
-    error:   `database_restore for ${step.app} requires a connected agent (V2)`,
+  if (step.app === 'sqlite' || step.app === 'redis' || step.app === 'mongodb') {
+    return {
+      success: false,
+      error:   `database_restore for ${step.app} is not yet implemented (only postgres + mysql/mariadb supported in V1)`,
+    }
+  }
+
+  if (!databaseRestoreDelivery) {
+    return {
+      success: false,
+      error:   `database_restore step requires server-side delivery wiring; no callback provided`,
+    }
+  }
+
+  try {
+    const result = await databaseRestoreDelivery(step, snapshotId, agentId)
+    if (!result.success) {
+      return { success: false, error: result.error ?? `database_restore for ${step.app} failed` }
+    }
+    return { success: true, output: result.output ?? `Restored ${step.app}` }
+  } catch (err) {
+    return {
+      success: false,
+      error:   err instanceof Error ? err.message : String(err),
+    }
   }
 }
 
@@ -190,6 +218,7 @@ async function executeStep(
   snapshotId: string,
   agentId: string,
   notifyDelivery?: NotifyDelivery,
+  databaseRestoreDelivery?: DatabaseRestoreDelivery,
 ): Promise<StepResult> {
   const start = Date.now()
   let result: Omit<StepResult, 'step' | 'durationMs'>
@@ -199,7 +228,7 @@ async function executeStep(
       result = await execFilesystemRestore(step, snapshotId, agentId)
       break
     case 'database_restore':
-      result = await execDatabaseRestore(step, snapshotId, agentId)
+      result = await execDatabaseRestore(step, snapshotId, agentId, databaseRestoreDelivery)
       break
     case 'shell':
       result = await execShell(step)
@@ -225,11 +254,12 @@ export async function executeRestoreSpec(
   snapshotId: string,
   agentId: string,
   notifyDelivery?: NotifyDelivery,
+  databaseRestoreDelivery?: DatabaseRestoreDelivery,
 ): Promise<RestoreRunResult> {
   const results: StepResult[] = []
 
   for (const step of spec.steps) {
-    const stepResult = await executeStep(step, snapshotId, agentId, notifyDelivery)
+    const stepResult = await executeStep(step, snapshotId, agentId, notifyDelivery, databaseRestoreDelivery)
     results.push(stepResult)
 
     if (!stepResult.success && step.onFailure === 'abort') {

--- a/packages/restore/src/index.ts
+++ b/packages/restore/src/index.ts
@@ -1,3 +1,3 @@
 export * from './types'
 export { parseRestoreSpec, RestoreSpecParseError } from './parser'
-export { executeRestoreSpec, type NotifyDelivery } from './executor'
+export { executeRestoreSpec, type NotifyDelivery, type DatabaseRestoreDelivery } from './executor'


### PR DESCRIPTION
## Summary
- **Protocol**: adds `run_database_restore` ServerMessage and `database_restore_started`/`database_restore_complete` AgentMessages
- **exec-allowed**: adds `pg_restore`, `psql`, `mysql`
- **Agent handler**: `handleDatabaseRestore` runs `psql`/`pg_restore` (postgres, picks by dump extension) or `mysql` (mysql/mariadb)
- **ws-state**: `requestDatabaseRestore` dispatches and awaits completion via two resolver maps; `resolveDatabaseRestoreStarted`/`resolveDatabaseRestoreComplete` exposed
- **server.ts**: handles both new ack message types
- **executor**: `DatabaseRestoreDelivery` callback type; stub replaced; threaded through `executeStep`/`executeRestoreSpec`
- **actions/restore.ts**: `deliverDatabaseRestore` wired into `executeRestoreSpec` call

sqlite/redis/mongodb return explicit not-implemented error. `target.container` docker exec deferred to V2.

Closes #80, #149

## Test plan
- [ ] Postgres `.sql` dump → step uses `psql`
- [ ] Postgres `.dump` → step uses `pg_restore --clean --if-exists`
- [ ] MySQL dump → step uses `mysql -e source`
- [ ] `sqlite`/`redis`/`mongodb` step → explicit not-implemented error returned
- [ ] No delivery callback (unit test) → returns error without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)