### PR TITLE
feat(verification): docker_volume target type (#138)

### DIFF
--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -175,7 +175,7 @@ export type ServerMessage =
   | { type: 'run_compose_backup'; jobId: string; runId: string; config: ComposeProjectConfig; repoId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; bandwidthLimitKbps?: number | null }
   | { type: 'run_compose_restore'; jobId: string; runId: string; repoId: string; config: ComposeRestoreConfig; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
   | { type: 'mount_repository'; requestId: string; repoId: string; nfsServer: string; nfsExport: string; nfsOptions: string }
-  | { type: 'run_verification'; verificationRunId: string; repoId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory'; validationHook?: string | null }
+  | { type: 'run_verification'; verificationRunId: string; repoId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory' | 'docker_volume'; validationHook?: string | null }
   | { type: 'run_filesystem_restore'; requestId: string; restoreId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; targetPath: string; sourcePath: string; targetIsAgentLocal: boolean }
   | { type: 'cancel_filesystem_restore'; restoreId: string }
   | { type: 'run_database_restore'; requestId: string; restoreId: string; app: 'postgres' | 'mysql' | 'mariadb'; dumpFilePath: string; targetContainer?: string; targetDatabase?: string; targetUsername?: string; targetHost?: string; targetPort?: number; passwordEnv?: string }

--- a/packages/agent/src/handlers/runVerification.ts
+++ b/packages/agent/src/handlers/runVerification.ts
@@ -3,6 +3,7 @@ import * as os from 'os'
 import * as path from 'path'
 import { spawn } from 'child_process'
 import { ResticEngine } from '@backupos/engine'
+import { spawnAllowed } from '../exec-allowed'
 import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
 
 type SendFn = (msg: AgentMessage) => void
@@ -27,6 +28,13 @@ function runHook(cmd: string, cwd: string, restoreTarget: string): Promise<strin
 }
 
 export async function runVerificationHandler(msg: RunMsg, send: SendFn, binaryPath: string | undefined): Promise<void> {
+  if (msg.targetType === 'docker_volume') {
+    return runVerificationDockerVolume(msg, send, binaryPath)
+  }
+  return runVerificationTempDirectory(msg, send, binaryPath)
+}
+
+async function runVerificationTempDirectory(msg: RunMsg, send: SendFn, binaryPath: string | undefined): Promise<void> {
   const { verificationRunId, snapshotId, repoUrl, repoPassword, envVars, validationHook } = msg
   const tmpDir = path.join(os.tmpdir(), 'backupos-verify', verificationRunId)
   const logLines: string[] = []
@@ -64,5 +72,59 @@ export async function runVerificationHandler(msg: RunMsg, send: SendFn, binaryPa
     send({ type: 'verification_complete', verificationRunId, success: false, log: logLines.join('\n'), errorMessage })
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+async function runVerificationDockerVolume(msg: RunMsg, send: SendFn, binaryPath: string | undefined): Promise<void> {
+  const { verificationRunId, snapshotId, repoUrl, repoPassword, envVars, validationHook } = msg
+  const volumeName = `backupos-verify-${verificationRunId}`
+  const logLines: string[] = []
+  let volumeCreated = false
+
+  const progress = (step: string): void => {
+    logLines.push(step)
+    send({ type: 'verification_progress', verificationRunId, step })
+  }
+
+  try {
+    progress(`Creating scratch Docker volume ${volumeName}`)
+    await spawnAllowed('docker', ['volume', 'create', volumeName])
+    volumeCreated = true
+
+    progress('Resolving volume mount point')
+    const mountResult = await spawnAllowed('docker', ['volume', 'inspect', '--format', '{{.Mountpoint}}', volumeName])
+    const mountPoint = mountResult.stdout.trim()
+    if (!mountPoint) throw new Error(`Could not resolve mount point for volume ${volumeName}`)
+
+    progress(`Restoring snapshot ${snapshotId} into ${mountPoint}`)
+    const engine = new ResticEngine({
+      repositoryUrl: repoUrl,
+      password:      repoPassword,
+      envVars:       envVars ?? {},
+      binaryPath,
+    })
+    await engine.restore(snapshotId, mountPoint)
+    progress('Restore complete')
+
+    if (validationHook) {
+      progress(`Running validation hook: ${validationHook}`)
+      const hookOut = await runHook(validationHook, mountPoint, mountPoint)
+      if (hookOut.trim()) logLines.push(hookOut.trim())
+      progress('Validation hook passed')
+    }
+
+    send({ type: 'verification_complete', verificationRunId, success: true, log: logLines.join('\n') })
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    logLines.push(`ERROR: ${errorMessage}`)
+    send({ type: 'verification_complete', verificationRunId, success: false, log: logLines.join('\n'), errorMessage })
+  } finally {
+    if (volumeCreated) {
+      try {
+        await spawnAllowed('docker', ['volume', 'rm', '-f', volumeName])
+      } catch (err) {
+        console.warn(`[agent] failed to remove scratch volume ${volumeName}:`, err instanceof Error ? err.message : err)
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Widens `run_verification` protocol's `targetType` to `'temp_directory' | 'docker_volume'`
- `runVerificationHandler` becomes a thin dispatcher
- `runVerificationTempDirectory`: existing logic unchanged
- `runVerificationDockerVolume`: creates scratch volume `backupos-verify-<runId>`, resolves mount point via `docker volume inspect`, restores snapshot into it, runs validation hook with `cwd=mountPoint`, always removes the volume in `finally`

Closes #138

## Test plan
- [ ] `targetType: 'temp_directory'` — existing behavior unchanged
- [ ] `targetType: 'docker_volume'` — volume created, snapshot restored, hook runs, volume removed on success
- [ ] `docker_volume` path with hook failure — volume still removed in `finally`
- [ ] Volume removal failure logged as warning, does not override the verification result

🤖 Generated with [Claude Code](https://claude.com/claude-code)