### PR TITLE
feat(verification): ssh_target with encrypted SSH key

### DIFF
--- a/apps/web/app/actions/verification.ts
+++ b/apps/web/app/actions/verification.ts
@@ -3,7 +3,8 @@
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { getDb, verificationTests, verificationRuns, backupRuns, backupJobs, repositories, eq, and, desc } from '@backupos/db'
-import { decryptField } from '@/lib/repo-crypto'
+import { encryptField, decryptField } from '@/lib/repo-crypto'
+import type { SshVerificationTargetConfig } from '@backupos/agent-protocol'
 import { dispatchToAgent } from '@/lib/internal-dispatch'
 import { connectedAgentIds } from '@/lib/ws-state'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
@@ -15,10 +16,24 @@ export async function createVerificationTest(data: {
   targetType: string
   validationHook: string
   schedule: string
+  sshConfig?: {
+    host: string
+    user: string
+    port?: number
+    remoteDir: string
+    sshKey: string
+    cleanupRemote?: boolean
+  }
 }): Promise<void> {
   await requireAdmin() // admin only
-  const { name, jobId, targetType, validationHook, schedule } = data
+  const { name, jobId, targetType, validationHook, schedule, sshConfig } = data
   if (!name || !jobId || !targetType || !schedule) return
+
+  let targetConfig: string | null = null
+  if (targetType === 'ssh_target' && sshConfig) {
+    const { sshKey, ...rest } = sshConfig
+    targetConfig = JSON.stringify({ ...rest, sshKey: encryptField(sshKey) })
+  }
 
   const db = getDb()
   const id = crypto.randomUUID()
@@ -27,6 +42,7 @@ export async function createVerificationTest(data: {
     name,
     jobId,
     targetType,
+    targetConfig,
     validationHook: validationHook || null,
     schedule,
     enabled:   true,
@@ -96,6 +112,15 @@ export async function runVerification(testId: string): Promise<void> {
     return
   }
 
+  let targetConfig: SshVerificationTargetConfig | undefined
+  if (test.targetType === 'ssh_target' && test.targetConfig) {
+    const stored = JSON.parse(test.targetConfig) as Record<string, unknown>
+    targetConfig = {
+      ...(stored as Omit<SshVerificationTargetConfig, 'sshKey'>),
+      sshKey: decryptField(stored['sshKey'] as string),
+    }
+  }
+
   const result = await dispatchToAgent(agentId, {
     type:              'run_verification',
     verificationRunId: runId,
@@ -104,7 +129,8 @@ export async function runVerification(testId: string): Promise<void> {
     repoUrl,
     repoPassword,
     envVars:           repoCfg,
-    targetType:        'temp_directory',
+    targetType:        test.targetType as 'temp_directory' | 'docker_volume' | 'ssh_target',
+    targetConfig,
     validationHook:    test.validationHook ?? null,
   })
 

--- a/apps/web/components/ui/verification-wizard.tsx
+++ b/apps/web/components/ui/verification-wizard.tsx
@@ -13,7 +13,8 @@ const TARGET_TYPES = [
   { value: 'ssh_target',        label: 'SSH target',         desc: 'Restore to a remote host via SSH' },
 ]
 
-const STEP_LABELS = ['Pick job', 'Sandbox target', 'Validation hook', 'Schedule']
+// Step 2 (SSH config) is only shown when targetType === 'ssh_target'
+const STEP_LABELS = ['Pick job', 'Sandbox target', 'SSH config', 'Validation hook', 'Schedule']
 
 interface Props { jobs: Job[] }
 
@@ -26,6 +27,32 @@ export function VerificationWizard({ jobs }: Props) {
   const [schedule,       setSchedule]       = useState('0 3 * * 0')
   const [submitting,     startSubmit]       = useTransition()
 
+  // SSH config state
+  const [sshHost,      setSshHost]      = useState('')
+  const [sshUser,      setSshUser]      = useState('root')
+  const [sshPort,      setSshPort]      = useState('22')
+  const [sshRemoteDir, setSshRemoteDir] = useState('')
+  const [sshKey,       setSshKey]       = useState('')
+  const [sshCleanup,   setSshCleanup]   = useState(true)
+
+  const isSsh = targetType === 'ssh_target'
+  const lastStep = 4
+
+  const handleNext = () => {
+    if (step === 1 && !isSsh) setStep(3)
+    else setStep(s => s + 1)
+  }
+
+  const handleBack = () => {
+    if (step === 3 && !isSsh) setStep(1)
+    else setStep(s => s - 1)
+  }
+
+  const continueDisabled =
+    (step === 0 && !jobId) ||
+    (step === 1 && !targetType) ||
+    (step === 2 && isSsh && (!sshHost || !sshUser || !sshRemoteDir || !sshKey))
+
   const inputStyle: React.CSSProperties = {
     width: '100%', padding: '8px 12px',
     backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
@@ -35,6 +62,16 @@ export function VerificationWizard({ jobs }: Props) {
 
   const labelStyle: React.CSSProperties = {
     display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6, fontWeight: 500,
+  }
+
+  const isStepActive = (i: number) => {
+    if (i === 2 && !isSsh) return false
+    return i === step
+  }
+
+  const isStepDone = (i: number) => {
+    if (i === 2 && !isSsh) return step > 2
+    return i < step
   }
 
   return (
@@ -48,17 +85,17 @@ export function VerificationWizard({ jobs }: Props) {
                 width: 28, height: 28, borderRadius: '50%',
                 display: 'flex', alignItems: 'center', justifyContent: 'center',
                 fontSize: 12, fontWeight: 600,
-                backgroundColor: i === step ? 'var(--accent)' : i < step ? 'var(--ok)' : 'var(--surf2)',
-                color: i <= step ? 'var(--bg)' : 'var(--fg-dim)',
+                backgroundColor: isStepActive(i) ? 'var(--accent)' : isStepDone(i) ? 'var(--ok)' : 'var(--surf2)',
+                color: isStepActive(i) || isStepDone(i) ? 'var(--bg)' : 'var(--fg-dim)',
               }}>
-                {i < step ? '✓' : i + 1}
+                {isStepDone(i) ? '✓' : i + 1}
               </div>
-              <span style={{ fontSize: 11, color: i === step ? 'var(--fg)' : 'var(--fg-dim)', whiteSpace: 'nowrap' }}>
+              <span style={{ fontSize: 11, color: isStepActive(i) ? 'var(--fg)' : 'var(--fg-dim)', whiteSpace: 'nowrap' }}>
                 {label}
               </span>
             </div>
             {i < STEP_LABELS.length - 1 && (
-              <div style={{ flex: 1, height: 1, backgroundColor: i < step ? 'var(--ok)' : 'var(--border)', margin: '0 8px', marginBottom: 22 }} />
+              <div style={{ flex: 1, height: 1, backgroundColor: isStepDone(i) ? 'var(--ok)' : 'var(--border)', margin: '0 8px', marginBottom: 22 }} />
             )}
           </div>
         ))}
@@ -123,8 +160,77 @@ export function VerificationWizard({ jobs }: Props) {
           </div>
         )}
 
-        {/* Step 2: Validation hook + name */}
+        {/* Step 2: SSH config (only for ssh_target) */}
         {step === 2 && (
+          <div>
+            <h2 style={{ fontSize: 16, fontWeight: 600, color: 'var(--fg)', marginBottom: 4 }}>SSH target configuration</h2>
+            <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginBottom: 20 }}>
+              BackupOS will restore the snapshot locally, then rsync it to this remote host. The SSH private key is encrypted at rest.
+            </p>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 80px', gap: 12, marginBottom: 12 }}>
+              <div>
+                <label style={labelStyle}>Host</label>
+                <input
+                  type="text"
+                  placeholder="192.168.1.50"
+                  value={sshHost}
+                  onChange={e => setSshHost(e.target.value)}
+                  style={inputStyle}
+                />
+              </div>
+              <div>
+                <label style={labelStyle}>Port</label>
+                <input
+                  type="number"
+                  value={sshPort}
+                  onChange={e => setSshPort(e.target.value)}
+                  style={inputStyle}
+                />
+              </div>
+            </div>
+            <div style={{ marginBottom: 12 }}>
+              <label style={labelStyle}>SSH user</label>
+              <input
+                type="text"
+                placeholder="root"
+                value={sshUser}
+                onChange={e => setSshUser(e.target.value)}
+                style={inputStyle}
+              />
+            </div>
+            <div style={{ marginBottom: 12 }}>
+              <label style={labelStyle}>Remote directory</label>
+              <input
+                type="text"
+                placeholder="/tmp/backupos-verify"
+                value={sshRemoteDir}
+                onChange={e => setSshRemoteDir(e.target.value)}
+                style={{ ...inputStyle, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+              />
+            </div>
+            <div style={{ marginBottom: 12 }}>
+              <label style={labelStyle}>Private key (PEM)</label>
+              <textarea
+                placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;..."
+                value={sshKey}
+                onChange={e => setSshKey(e.target.value)}
+                rows={6}
+                style={{ ...inputStyle, fontFamily: 'var(--font-mono)', fontSize: 12, resize: 'vertical' }}
+              />
+            </div>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={sshCleanup}
+                onChange={e => setSshCleanup(e.target.checked)}
+              />
+              <span style={{ fontSize: 13, color: 'var(--fg-mute)' }}>Remove remote directory after verification</span>
+            </label>
+          </div>
+        )}
+
+        {/* Step 3: Validation hook + name */}
+        {step === 3 && (
           <div>
             <h2 style={{ fontSize: 16, fontWeight: 600, color: 'var(--fg)', marginBottom: 4 }}>Validation hook</h2>
             <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginBottom: 20 }}>
@@ -156,8 +262,8 @@ export function VerificationWizard({ jobs }: Props) {
           </div>
         )}
 
-        {/* Step 3: Schedule */}
-        {step === 3 && (
+        {/* Step 4: Schedule */}
+        {step === 4 && (
           <div>
             <h2 style={{ fontSize: 16, fontWeight: 600, color: 'var(--fg)', marginBottom: 4 }}>Schedule</h2>
             <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginBottom: 20 }}>
@@ -181,6 +287,9 @@ export function VerificationWizard({ jobs }: Props) {
               <div style={{ fontSize: 13, color: 'var(--fg)', lineHeight: 1.7 }}>
                 <div><span style={{ color: 'var(--fg-mute)' }}>Name:</span> {testName || '—'}</div>
                 <div><span style={{ color: 'var(--fg-mute)' }}>Target:</span> {TARGET_TYPES.find(t => t.value === targetType)?.label ?? '—'}</div>
+                {isSsh && (
+                  <div><span style={{ color: 'var(--fg-mute)' }}>SSH host:</span> {sshUser}@{sshHost}:{sshPort} → {sshRemoteDir}</div>
+                )}
                 <div><span style={{ color: 'var(--fg-mute)' }}>Hook:</span> {validationHook || 'none'}</div>
                 <div><span style={{ color: 'var(--fg-mute)' }}>Schedule:</span> <code style={{ fontFamily: 'var(--font-mono)' }}>{schedule}</code></div>
               </div>
@@ -192,21 +301,18 @@ export function VerificationWizard({ jobs }: Props) {
         <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 28 }}>
           <div>
             {step > 0 && (
-              <Button variant="secondary" size="md" onClick={() => setStep(s => s - 1)}>
+              <Button variant="secondary" size="md" onClick={handleBack}>
                 Back
               </Button>
             )}
           </div>
           <div>
-            {step < 3 ? (
+            {step < lastStep ? (
               <Button
                 variant="primary"
                 size="md"
-                onClick={() => setStep(s => s + 1)}
-                disabled={
-                  (step === 0 && !jobId) ||
-                  (step === 1 && !targetType)
-                }
+                onClick={handleNext}
+                disabled={continueDisabled}
               >
                 Continue
               </Button>
@@ -217,6 +323,16 @@ export function VerificationWizard({ jobs }: Props) {
                 disabled={submitting || !testName}
                 onClick={() => startSubmit(() => createVerificationTest({
                   name: testName, jobId, targetType, validationHook, schedule,
+                  ...(isSsh ? {
+                    sshConfig: {
+                      host:          sshHost,
+                      user:          sshUser,
+                      port:          parseInt(sshPort) || 22,
+                      remoteDir:     sshRemoteDir,
+                      sshKey,
+                      cleanupRemote: sshCleanup,
+                    },
+                  } : {}),
                 }))}
               >
                 {submitting ? 'Creating…' : 'Create test'}

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -125,6 +125,17 @@ export interface ComposeRestoreConfig {
   sideBySideProjectName?: string     // required when mode === 'side_by_side'
 }
 
+// ── SSH verification target config ────────────────────────────────────────
+
+export interface SshVerificationTargetConfig {
+  host: string
+  user: string
+  port?: number
+  remoteDir: string
+  sshKey: string          // plaintext private key — decrypted by server before dispatch
+  cleanupRemote?: boolean
+}
+
 // ── Messages ──────────────────────────────────────────────────────────────
 
 export type AgentMessage =
@@ -175,7 +186,7 @@ export type ServerMessage =
   | { type: 'run_compose_backup'; jobId: string; runId: string; config: ComposeProjectConfig; repoId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; bandwidthLimitKbps?: number | null }
   | { type: 'run_compose_restore'; jobId: string; runId: string; repoId: string; config: ComposeRestoreConfig; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
   | { type: 'mount_repository'; requestId: string; repoId: string; nfsServer: string; nfsExport: string; nfsOptions: string }
-  | { type: 'run_verification'; verificationRunId: string; repoId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory' | 'docker_volume'; validationHook?: string | null }
+  | { type: 'run_verification'; verificationRunId: string; repoId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory' | 'docker_volume' | 'ssh_target'; targetConfig?: SshVerificationTargetConfig; validationHook?: string | null }
   | { type: 'run_filesystem_restore'; requestId: string; restoreId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; targetPath: string; sourcePath: string; targetIsAgentLocal: boolean }
   | { type: 'cancel_filesystem_restore'; restoreId: string }
   | { type: 'run_database_restore'; requestId: string; restoreId: string; app: 'postgres' | 'mysql' | 'mariadb'; dumpFilePath: string; targetContainer?: string; targetDatabase?: string; targetUsername?: string; targetHost?: string; targetPort?: number; passwordEnv?: string }

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -175,7 +175,7 @@ export type ServerMessage =
   | { type: 'run_compose_backup'; jobId: string; runId: string; config: ComposeProjectConfig; repoId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; bandwidthLimitKbps?: number | null }
   | { type: 'run_compose_restore'; jobId: string; runId: string; repoId: string; config: ComposeRestoreConfig; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
   | { type: 'mount_repository'; requestId: string; repoId: string; nfsServer: string; nfsExport: string; nfsOptions: string }
-  | { type: 'run_verification'; verificationRunId: string; repoId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory'; validationHook?: string | null }
+  | { type: 'run_verification'; verificationRunId: string; repoId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory' | 'docker_volume'; validationHook?: string | null }
   | { type: 'run_filesystem_restore'; requestId: string; restoreId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; targetPath: string; sourcePath: string; targetIsAgentLocal: boolean }
   | { type: 'cancel_filesystem_restore'; restoreId: string }
   | { type: 'run_database_restore'; requestId: string; restoreId: string; app: 'postgres' | 'mysql' | 'mariadb'; dumpFilePath: string; targetContainer?: string; targetDatabase?: string; targetUsername?: string; targetHost?: string; targetPort?: number; passwordEnv?: string }

--- a/packages/agent/src/exec-allowed.ts
+++ b/packages/agent/src/exec-allowed.ts
@@ -11,6 +11,8 @@ export const ALLOWED_COMMANDS = new Set([
   'sqlite3',
   'docker',
   'cp',
+  'rsync',
+  'ssh',
 ])
 
 export function spawnAllowed(

--- a/packages/agent/src/handlers/runVerification.ts
+++ b/packages/agent/src/handlers/runVerification.ts
@@ -31,6 +31,9 @@ export async function runVerificationHandler(msg: RunMsg, send: SendFn, binaryPa
   if (msg.targetType === 'docker_volume') {
     return runVerificationDockerVolume(msg, send, binaryPath)
   }
+  if (msg.targetType === 'ssh_target') {
+    return runVerificationSshTarget(msg, send, binaryPath)
+  }
   return runVerificationTempDirectory(msg, send, binaryPath)
 }
 
@@ -72,6 +75,82 @@ async function runVerificationTempDirectory(msg: RunMsg, send: SendFn, binaryPat
     send({ type: 'verification_complete', verificationRunId, success: false, log: logLines.join('\n'), errorMessage })
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+async function runVerificationSshTarget(msg: RunMsg, send: SendFn, binaryPath: string | undefined): Promise<void> {
+  const { verificationRunId, snapshotId, repoUrl, repoPassword, envVars, validationHook, targetConfig } = msg
+  if (!targetConfig) throw new Error('ssh_target requires targetConfig')
+  const { host, user, port = 22, remoteDir, sshKey, cleanupRemote = true } = targetConfig
+
+  const tmpDir  = path.join(os.tmpdir(), 'backupos-verify', verificationRunId)
+  const keyFile = path.join(os.tmpdir(), `backupos-ssh-key-${verificationRunId}`)
+  const logLines: string[] = []
+  let keyWritten = false
+
+  const progress = (step: string): void => {
+    logLines.push(step)
+    send({ type: 'verification_progress', verificationRunId, step })
+  }
+
+  const sshArgs = ['-i', keyFile, '-o', 'StrictHostKeyChecking=no', '-p', String(port)]
+
+  try {
+    progress('Writing SSH key')
+    await fs.writeFile(keyFile, sshKey, { mode: 0o600 })
+    keyWritten = true
+
+    progress('Creating temp directory')
+    await fs.mkdir(tmpDir, { recursive: true })
+
+    progress(`Restoring snapshot ${snapshotId}`)
+    const engine = new ResticEngine({
+      repositoryUrl: repoUrl,
+      password:      repoPassword,
+      envVars:       envVars ?? {},
+      binaryPath,
+    })
+    await engine.restore(snapshotId, tmpDir)
+    progress('Restore complete')
+
+    progress(`Syncing to ${user}@${host}:${remoteDir}`)
+    await spawnAllowed('rsync', [
+      '-a',
+      '-e', `ssh -i ${keyFile} -o StrictHostKeyChecking=no -p ${port}`,
+      `${tmpDir}/`,
+      `${user}@${host}:${remoteDir}/`,
+    ])
+    progress('Sync complete')
+
+    if (validationHook) {
+      progress(`Running validation hook on ${host}: ${validationHook}`)
+      const result = await spawnAllowed('ssh', [
+        ...sshArgs,
+        `${user}@${host}`,
+        `RESTORE_TARGET=${remoteDir} ${validationHook}`,
+      ])
+      const out = (result.stdout + result.stderr).trim()
+      if (out) logLines.push(out)
+      progress('Validation hook passed')
+    }
+
+    send({ type: 'verification_complete', verificationRunId, success: true, log: logLines.join('\n') })
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    logLines.push(`ERROR: ${errorMessage}`)
+    send({ type: 'verification_complete', verificationRunId, success: false, log: logLines.join('\n'), errorMessage })
+  } finally {
+    if (cleanupRemote && keyWritten) {
+      try {
+        await spawnAllowed('ssh', [...sshArgs, `${user}@${host}`, `rm -rf ${remoteDir}`])
+      } catch {
+        // best-effort remote cleanup
+      }
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+    if (keyWritten) {
+      await fs.rm(keyFile, { force: true }).catch(() => {})
+    }
   }
 }
 

--- a/packages/agent/src/handlers/runVerification.ts
+++ b/packages/agent/src/handlers/runVerification.ts
@@ -3,6 +3,7 @@ import * as os from 'os'
 import * as path from 'path'
 import { spawn } from 'child_process'
 import { ResticEngine } from '@backupos/engine'
+import { spawnAllowed } from '../exec-allowed'
 import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
 
 type SendFn = (msg: AgentMessage) => void
@@ -27,6 +28,13 @@ function runHook(cmd: string, cwd: string, restoreTarget: string): Promise<strin
 }
 
 export async function runVerificationHandler(msg: RunMsg, send: SendFn, binaryPath: string | undefined): Promise<void> {
+  if (msg.targetType === 'docker_volume') {
+    return runVerificationDockerVolume(msg, send, binaryPath)
+  }
+  return runVerificationTempDirectory(msg, send, binaryPath)
+}
+
+async function runVerificationTempDirectory(msg: RunMsg, send: SendFn, binaryPath: string | undefined): Promise<void> {
   const { verificationRunId, snapshotId, repoUrl, repoPassword, envVars, validationHook } = msg
   const tmpDir = path.join(os.tmpdir(), 'backupos-verify', verificationRunId)
   const logLines: string[] = []
@@ -64,5 +72,59 @@ export async function runVerificationHandler(msg: RunMsg, send: SendFn, binaryPa
     send({ type: 'verification_complete', verificationRunId, success: false, log: logLines.join('\n'), errorMessage })
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+async function runVerificationDockerVolume(msg: RunMsg, send: SendFn, binaryPath: string | undefined): Promise<void> {
+  const { verificationRunId, snapshotId, repoUrl, repoPassword, envVars, validationHook } = msg
+  const volumeName = `backupos-verify-${verificationRunId}`
+  const logLines: string[] = []
+  let volumeCreated = false
+
+  const progress = (step: string): void => {
+    logLines.push(step)
+    send({ type: 'verification_progress', verificationRunId, step })
+  }
+
+  try {
+    progress(`Creating scratch Docker volume ${volumeName}`)
+    await spawnAllowed('docker', ['volume', 'create', volumeName])
+    volumeCreated = true
+
+    progress('Resolving volume mount point')
+    const mountResult = await spawnAllowed('docker', ['volume', 'inspect', '--format', '{{.Mountpoint}}', volumeName])
+    const mountPoint = mountResult.stdout.trim()
+    if (!mountPoint) throw new Error(`Could not resolve mount point for volume ${volumeName}`)
+
+    progress(`Restoring snapshot ${snapshotId} into ${mountPoint}`)
+    const engine = new ResticEngine({
+      repositoryUrl: repoUrl,
+      password:      repoPassword,
+      envVars:       envVars ?? {},
+      binaryPath,
+    })
+    await engine.restore(snapshotId, mountPoint)
+    progress('Restore complete')
+
+    if (validationHook) {
+      progress(`Running validation hook: ${validationHook}`)
+      const hookOut = await runHook(validationHook, mountPoint, mountPoint)
+      if (hookOut.trim()) logLines.push(hookOut.trim())
+      progress('Validation hook passed')
+    }
+
+    send({ type: 'verification_complete', verificationRunId, success: true, log: logLines.join('\n') })
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    logLines.push(`ERROR: ${errorMessage}`)
+    send({ type: 'verification_complete', verificationRunId, success: false, log: logLines.join('\n'), errorMessage })
+  } finally {
+    if (volumeCreated) {
+      try {
+        await spawnAllowed('docker', ['volume', 'rm', '-f', volumeName])
+      } catch (err) {
+        console.warn(`[agent] failed to remove scratch volume ${volumeName}:`, err instanceof Error ? err.message : err)
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `ssh_target` as a third verification target type alongside `temp_directory` and `docker_volume`
- Agent restores snapshot locally, rsyncs to remote host over SSH, runs optional validation hook via `ssh`, then cleans up local temp dir and key file (remote dir cleanup is opt-out)
- SSH private key is encrypted at rest using the existing `encryptField`/`decryptField` pattern; decrypted only at dispatch time
- Wizard gains a 5th step (SSH config) that auto-skips for non-SSH target types

## Test plan
- [ ] Create a verification test with `ssh_target` — confirm SSH config step appears in wizard
- [ ] Create a verification test with `temp_directory` — confirm SSH config step is skipped
- [ ] Trigger a run: confirm snapshot restores locally, rsyncs to remote, validation hook executes on remote
- [ ] Confirm remote dir is removed after run when `cleanupRemote = true`
- [ ] Confirm key file is always cleaned up from agent temp dir (even on failure)
- [ ] TypeScript: `tsc --noEmit` passes on all three packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)