### PR TITLE
feat(pbs): skeleton packages and DB schema (milestone 0)

### DIFF
--- a/packages/db/migrations/0041_pbs_scaffold.sql
+++ b/packages/db/migrations/0041_pbs_scaffold.sql
@@ -1,0 +1,83 @@
+CREATE TABLE `pbs_datastores` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`path` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`prune_schedule` text,
+	`gc_schedule` text,
+	`last_gc_at` integer,
+	`total_size_bytes` integer,
+	`unique_size_bytes` integer,
+	`chunk_count` integer
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `pbs_datastores_name_unique` ON `pbs_datastores` (`name`);
+--> statement-breakpoint
+CREATE TABLE `pbs_namespaces` (
+	`id` text PRIMARY KEY NOT NULL,
+	`datastore_id` text REFERENCES pbs_datastores(id),
+	`path` text NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `pbs_snapshots` (
+	`id` text PRIMARY KEY NOT NULL,
+	`datastore_id` text REFERENCES pbs_datastores(id),
+	`namespace_id` text REFERENCES pbs_namespaces(id),
+	`backup_type` text NOT NULL,
+	`backup_id` text NOT NULL,
+	`backup_time` integer NOT NULL,
+	`finished_at` integer,
+	`manifest` text,
+	`total_size_bytes` integer,
+	`unique_size_bytes` integer,
+	`protected` integer DEFAULT false,
+	`notes` text
+);
+--> statement-breakpoint
+CREATE TABLE `pbs_chunk_refs` (
+	`digest` text NOT NULL,
+	`snapshot_id` text REFERENCES pbs_snapshots(id),
+	`archive_name` text NOT NULL,
+	`ref_count` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `pbs_chunk_refs_digest_snapshot_idx` ON `pbs_chunk_refs` (`digest`,`snapshot_id`);
+--> statement-breakpoint
+CREATE INDEX `pbs_chunk_refs_digest_idx` ON `pbs_chunk_refs` (`digest`);
+--> statement-breakpoint
+CREATE TABLE `pbs_tokens` (
+	`id` text PRIMARY KEY NOT NULL,
+	`datastore_id` text REFERENCES pbs_datastores(id),
+	`user` text NOT NULL,
+	`realm` text NOT NULL,
+	`token_name` text NOT NULL,
+	`secret_hash` text NOT NULL,
+	`permissions` text NOT NULL,
+	`expires_at` integer,
+	`created_at` integer NOT NULL,
+	`last_used_at` integer
+);
+--> statement-breakpoint
+CREATE TABLE `pbs_active_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`token_id` text REFERENCES pbs_tokens(id),
+	`datastore_id` text REFERENCES pbs_datastores(id),
+	`backup_type` text NOT NULL,
+	`backup_id` text NOT NULL,
+	`backup_time` integer NOT NULL,
+	`started_at` integer NOT NULL,
+	`state` text NOT NULL,
+	`scratch_path` text
+);
+--> statement-breakpoint
+CREATE TABLE `pbs_active_writes` (
+	`wid` text PRIMARY KEY NOT NULL,
+	`session_id` text REFERENCES pbs_active_sessions(id),
+	`archive_name` text NOT NULL,
+	`index_type` text NOT NULL,
+	`chunk_size` integer,
+	`total_size` integer,
+	`digest_list` text,
+	`size_list` text
+);

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1747180800000,
       "tag": "0040_instance_id",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "6",
+      "when": 1746403200000,
+      "tag": "0041_pbs_scaffold",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -623,3 +623,90 @@ export const invite = sqliteTable('invite', {
   usedAt:    integer('used_at'),
   createdAt: integer('created_at').notNull(),
 })
+
+// ── PBS-compatible backend ──────────────────────────────────────────────
+// Tables for the Proxmox Backup Server protocol implementation.
+// Design: docs/design/pbs-backend.md.
+// Milestone 0 ships these tables as scaffolding; behavior lands in later
+// milestones (1 onward).
+
+export const pbsDatastores = sqliteTable('pbs_datastores', {
+  id:                text('id').primaryKey(),
+  name:              text('name').notNull().unique(),
+  path:              text('path').notNull(),
+  createdAt:         integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+  pruneSchedule:     text('prune_schedule'),
+  gcSchedule:        text('gc_schedule'),
+  lastGcAt:          integer('last_gc_at', { mode: 'timestamp_ms' }),
+  totalSizeBytes:    integer('total_size_bytes'),
+  uniqueSizeBytes:   integer('unique_size_bytes'),
+  chunkCount:        integer('chunk_count'),
+})
+
+export const pbsNamespaces = sqliteTable('pbs_namespaces', {
+  id:           text('id').primaryKey(),
+  datastoreId:  text('datastore_id').references(() => pbsDatastores.id),
+  path:         text('path').notNull(),
+  createdAt:    integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+})
+
+export const pbsSnapshots = sqliteTable('pbs_snapshots', {
+  id:                text('id').primaryKey(),
+  datastoreId:       text('datastore_id').references(() => pbsDatastores.id),
+  namespaceId:       text('namespace_id').references(() => pbsNamespaces.id),
+  backupType:        text('backup_type').notNull(),
+  backupId:          text('backup_id').notNull(),
+  backupTime:        integer('backup_time', { mode: 'timestamp_ms' }).notNull(),
+  finishedAt:        integer('finished_at', { mode: 'timestamp_ms' }),
+  manifest:          text('manifest'),
+  totalSizeBytes:    integer('total_size_bytes'),
+  uniqueSizeBytes:   integer('unique_size_bytes'),
+  protected:         integer('protected', { mode: 'boolean' }).default(false),
+  notes:             text('notes'),
+})
+
+export const pbsChunkRefs = sqliteTable('pbs_chunk_refs', {
+  digest:       text('digest').notNull(),
+  snapshotId:   text('snapshot_id').references(() => pbsSnapshots.id),
+  archiveName:  text('archive_name').notNull(),
+  refCount:     integer('ref_count').notNull(),
+}, t => ({
+  digestSnapshotIdx: index('pbs_chunk_refs_digest_snapshot_idx').on(t.digest, t.snapshotId),
+  digestIdx:         index('pbs_chunk_refs_digest_idx').on(t.digest),
+}))
+
+export const pbsTokens = sqliteTable('pbs_tokens', {
+  id:           text('id').primaryKey(),
+  datastoreId:  text('datastore_id').references(() => pbsDatastores.id),
+  user:         text('user').notNull(),
+  realm:        text('realm').notNull(),
+  tokenName:    text('token_name').notNull(),
+  secretHash:   text('secret_hash').notNull(),
+  permissions:  text('permissions').notNull(),
+  expiresAt:    integer('expires_at', { mode: 'timestamp_ms' }),
+  createdAt:    integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+  lastUsedAt:   integer('last_used_at', { mode: 'timestamp_ms' }),
+})
+
+export const pbsActiveSessions = sqliteTable('pbs_active_sessions', {
+  id:           text('id').primaryKey(),
+  tokenId:      text('token_id').references(() => pbsTokens.id),
+  datastoreId:  text('datastore_id').references(() => pbsDatastores.id),
+  backupType:   text('backup_type').notNull(),
+  backupId:     text('backup_id').notNull(),
+  backupTime:   integer('backup_time', { mode: 'timestamp_ms' }).notNull(),
+  startedAt:    integer('started_at', { mode: 'timestamp_ms' }).notNull(),
+  state:        text('state').notNull(),
+  scratchPath:  text('scratch_path'),
+})
+
+export const pbsActiveWrites = sqliteTable('pbs_active_writes', {
+  wid:          text('wid').primaryKey(),
+  sessionId:    text('session_id').references(() => pbsActiveSessions.id),
+  archiveName:  text('archive_name').notNull(),
+  indexType:    text('index_type').notNull(),
+  chunkSize:    integer('chunk_size'),
+  totalSize:    integer('total_size'),
+  digestList:   text('digest_list'),
+  sizeList:     text('size_list'),
+})

--- a/packages/pbs-protocol/package.json
+++ b/packages/pbs-protocol/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@backupos/pbs-protocol",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/pbs-protocol/src/index.ts
+++ b/packages/pbs-protocol/src/index.ts
@@ -1,0 +1,8 @@
+// @backupos/pbs-protocol
+// Wire types and format constants for the Proxmox Backup Server protocol.
+// Pure types and constants — no I/O.
+//
+// Implementation milestones tracked in docs/design/pbs-backend.md.
+// Milestone 0: skeleton only. Real exports land in milestone 1.
+
+export const PBS_PROTOCOL_VERSION = '1' as const

--- a/packages/pbs-protocol/tsconfig.json
+++ b/packages/pbs-protocol/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/pbs-server/package.json
+++ b/packages/pbs-server/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@backupos/pbs-server",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@backupos/pbs-protocol": "workspace:*",
+    "@backupos/pbs-storage": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/pbs-server/src/index.ts
+++ b/packages/pbs-server/src/index.ts
@@ -1,0 +1,18 @@
+// @backupos/pbs-server
+// HTTP/2 server implementing the Proxmox Backup Server protocol.
+//
+// Milestone 0: skeleton only. startPbsServer is a no-op stub that will
+// be wired in milestone 3.
+
+export interface StartPbsServerOptions {
+  port?: number
+  storageRoot?: string
+}
+
+export function startPbsServer(_opts: StartPbsServerOptions = {}): void {
+  // Stub — implemented in milestone 3.
+}
+
+export function stopPbsServer(): void {
+  // Stub — implemented in milestone 3.
+}

--- a/packages/pbs-server/tsconfig.json
+++ b/packages/pbs-server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/pbs-storage/package.json
+++ b/packages/pbs-storage/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@backupos/pbs-storage",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/pbs-storage/src/index.ts
+++ b/packages/pbs-storage/src/index.ts
@@ -1,0 +1,10 @@
+// @backupos/pbs-storage
+// Chunk storage backend for PBS-compatible datastores.
+// V1 will provide a filesystem-backed implementation.
+//
+// Milestone 0: skeleton only.
+
+export interface ChunkStore {
+  // Real interface lands in milestone 2.
+  readonly _placeholder: true
+}

--- a/packages/pbs-storage/tsconfig.json
+++ b/packages/pbs-storage/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
First PR of the PBS-compatible backend feature. Pure scaffolding — three new packages with placeholder exports, seven new DB tables, hand-written migration. No behavior, no endpoints, no UI. Sets the table for milestone 1 (file format implementations). See docs/design/pbs-backend.md for the full plan.

## New packages
- `@backupos/pbs-protocol` — wire types and format constants (M1+)
- `@backupos/pbs-storage` — chunk store abstraction (M2+)
- `@backupos/pbs-server` — HTTP/2 protocol server stub (M3+)

All three build cleanly with placeholder `index.ts` files.

## DB changes
Migration `0041_pbs_scaffold.sql` adds 7 tables: `pbs_datastores`, `pbs_namespaces`, `pbs_snapshots`, `pbs_chunk_refs` (with digest + composite indexes), `pbs_tokens`, `pbs_active_sessions`, `pbs_active_writes`. Additive only — no ALTER TABLE on existing tables.

## Test plan
- [ ] `pnpm --filter "./packages/*" build` succeeds
- [ ] `pnpm --filter @backupos/web typecheck` returns 0 errors
- [ ] Migration SQL contains only CREATE TABLE / CREATE INDEX — no ALTER TABLE on existing tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)