### PR TITLE
feat(pbs): file format codecs — milestone 1 (#237)

### DIFF
--- a/packages/pbs-protocol/package.json
+++ b/packages/pbs-protocol/package.json
@@ -13,9 +13,11 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/pbs-protocol/src/blob.test.ts
+++ b/packages/pbs-protocol/src/blob.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import {
+  encodeBlob,
+  decodeBlob,
+  identifyBlobVariant,
+  crc32,
+  BLOB_MAGIC_UNCOMPRESSED_UNENCRYPTED,
+  BLOB_MAGIC_COMPRESSED_UNENCRYPTED,
+  BLOB_MAGIC_UNCOMPRESSED_ENCRYPTED,
+  BLOB_MAGIC_COMPRESSED_ENCRYPTED,
+} from './blob'
+
+describe('blob magic identification', () => {
+  it('recognizes all 4 variants', () => {
+    expect(identifyBlobVariant(BLOB_MAGIC_UNCOMPRESSED_UNENCRYPTED)).toBe('uncompressed-unencrypted')
+    expect(identifyBlobVariant(BLOB_MAGIC_COMPRESSED_UNENCRYPTED)).toBe('compressed-unencrypted')
+    expect(identifyBlobVariant(BLOB_MAGIC_UNCOMPRESSED_ENCRYPTED)).toBe('uncompressed-encrypted')
+    expect(identifyBlobVariant(BLOB_MAGIC_COMPRESSED_ENCRYPTED)).toBe('compressed-encrypted')
+  })
+
+  it('returns null for unknown magic', () => {
+    const fake = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0])
+    expect(identifyBlobVariant(fake)).toBeNull()
+  })
+
+  it('returns null for buffers too short', () => {
+    expect(identifyBlobVariant(new Uint8Array([1, 2, 3]))).toBeNull()
+  })
+})
+
+describe('blob round-trip — unencrypted variants', () => {
+  const data = new TextEncoder().encode('hello, backupos PBS protocol test data')
+
+  it('round-trips uncompressed unencrypted', () => {
+    const enc = encodeBlob({ variant: 'uncompressed-unencrypted', body: data })
+    const dec = decodeBlob(enc)
+    expect(dec.variant).toBe('uncompressed-unencrypted')
+    expect([...dec.body]).toEqual([...data])
+    expect(dec.iv).toBeUndefined()
+    expect(dec.tag).toBeUndefined()
+  })
+
+  it('round-trips compressed unencrypted (treats body as opaque)', () => {
+    const fakeCompressedBody = new Uint8Array([28, 181, 47, 253, 1, 2, 3])
+    const enc = encodeBlob({ variant: 'compressed-unencrypted', body: fakeCompressedBody })
+    const dec = decodeBlob(enc)
+    expect(dec.variant).toBe('compressed-unencrypted')
+    expect([...dec.body]).toEqual([...fakeCompressedBody])
+  })
+})
+
+describe('blob round-trip — encrypted variants', () => {
+  const ciphertext = new TextEncoder().encode('this is fake ciphertext for test framing')
+  const iv  = new Uint8Array(16).fill(0xab)
+  const tag = new Uint8Array(16).fill(0xcd)
+
+  it('round-trips uncompressed encrypted', () => {
+    const enc = encodeBlob({ variant: 'uncompressed-encrypted', body: ciphertext, iv, tag })
+    const dec = decodeBlob(enc)
+    expect(dec.variant).toBe('uncompressed-encrypted')
+    expect([...dec.body]).toEqual([...ciphertext])
+    expect([...dec.iv!]).toEqual([...iv])
+    expect([...dec.tag!]).toEqual([...tag])
+  })
+
+  it('round-trips compressed encrypted', () => {
+    const enc = encodeBlob({ variant: 'compressed-encrypted', body: ciphertext, iv, tag })
+    const dec = decodeBlob(enc)
+    expect(dec.variant).toBe('compressed-encrypted')
+    expect([...dec.iv!]).toEqual([...iv])
+    expect([...dec.tag!]).toEqual([...tag])
+  })
+
+  it('rejects encrypted blob without IV', () => {
+    expect(() => encodeBlob({ variant: 'uncompressed-encrypted', body: ciphertext, tag })).toThrow(/IV/)
+  })
+
+  it('rejects encrypted blob without tag', () => {
+    expect(() => encodeBlob({ variant: 'uncompressed-encrypted', body: ciphertext, iv })).toThrow(/tag/)
+  })
+})
+
+describe('blob CRC32', () => {
+  it('detects corruption', () => {
+    const data = new TextEncoder().encode('intact data')
+    const enc = encodeBlob({ variant: 'uncompressed-unencrypted', body: data })
+    enc[20] = enc[20]! ^ 0xff
+    expect(() => decodeBlob(enc)).toThrow(/CRC32/)
+  })
+
+  it('CRC32 over empty buffer is 0', () => {
+    expect(crc32(new Uint8Array(0))).toBe(0)
+  })
+
+  it('CRC32 of "123456789" is 0xCBF43926 (well-known test vector)', () => {
+    const ascii = new TextEncoder().encode('123456789')
+    expect(crc32(ascii)).toBe(0xCBF43926)
+  })
+})
+
+describe('blob errors', () => {
+  it('throws for buffer shorter than minimum header', () => {
+    expect(() => decodeBlob(new Uint8Array(8))).toThrow(/too short/)
+  })
+
+  it('throws for unknown magic', () => {
+    const fake = new Uint8Array(16)
+    expect(() => decodeBlob(fake)).toThrow(/magic/)
+  })
+})

--- a/packages/pbs-protocol/src/blob.ts
+++ b/packages/pbs-protocol/src/blob.ts
@@ -1,0 +1,190 @@
+// Data Blob (.blob) codec
+//
+// Source: PBS public documentation
+// https://pbs.proxmox.com/docs/file-formats.html (Data Blob Format section)
+//
+// Four magic-number variants determine the blob layout:
+//   uncompressed + unencrypted: 8-byte magic + 4-byte CRC32 + raw data
+//   compressed   + unencrypted: 8-byte magic + 4-byte CRC32 + zstd(data)
+//   uncompressed + encrypted:   8-byte magic + 4-byte CRC32 + 16B IV + 16B AEAD tag + AES-256-GCM(data)
+//   compressed   + encrypted:   same as above but data is zstd then encrypted
+//
+// CRC32 covers the bytes AFTER the magic and CRC fields (i.e., the body).
+// All multi-byte values are little-endian.
+// Maximum data size is 16 MiB.
+
+import { createHash } from 'crypto'
+
+// Magic numbers per official PBS file-formats.html documentation.
+export const BLOB_MAGIC_UNCOMPRESSED_UNENCRYPTED = new Uint8Array([66, 171, 56, 7, 190, 131, 112, 161])
+export const BLOB_MAGIC_COMPRESSED_UNENCRYPTED   = new Uint8Array([49, 185, 88, 66, 111, 182, 163, 127])
+export const BLOB_MAGIC_UNCOMPRESSED_ENCRYPTED   = new Uint8Array([123, 103, 133, 190, 34, 45, 76, 240])
+export const BLOB_MAGIC_COMPRESSED_ENCRYPTED     = new Uint8Array([230, 89, 27, 191, 11, 191, 216, 11])
+
+export const BLOB_MAX_DATA_SIZE = 16 * 1024 * 1024 // 16 MiB
+
+export type BlobVariant =
+  | 'uncompressed-unencrypted'
+  | 'compressed-unencrypted'
+  | 'uncompressed-encrypted'
+  | 'compressed-encrypted'
+
+export interface DecodedBlob {
+  variant:    BlobVariant
+  /** Raw body bytes EXACTLY as they appeared in the blob — caller decompresses/decrypts. */
+  body:       Uint8Array
+  /** Present for encrypted variants. */
+  iv?:        Uint8Array
+  /** Present for encrypted variants. */
+  tag?:       Uint8Array
+}
+
+/** Identify a blob's variant from its magic prefix. Returns null if magic is unknown. */
+export function identifyBlobVariant(buf: Uint8Array): BlobVariant | null {
+  if (buf.length < 8) return null
+  if (bytesEqual(buf.subarray(0, 8), BLOB_MAGIC_UNCOMPRESSED_UNENCRYPTED)) return 'uncompressed-unencrypted'
+  if (bytesEqual(buf.subarray(0, 8), BLOB_MAGIC_COMPRESSED_UNENCRYPTED))   return 'compressed-unencrypted'
+  if (bytesEqual(buf.subarray(0, 8), BLOB_MAGIC_UNCOMPRESSED_ENCRYPTED))   return 'uncompressed-encrypted'
+  if (bytesEqual(buf.subarray(0, 8), BLOB_MAGIC_COMPRESSED_ENCRYPTED))     return 'compressed-encrypted'
+  return null
+}
+
+/**
+ * Decode a Data Blob from its on-the-wire bytes.
+ * Validates the magic and CRC32 footprint; throws if either is wrong.
+ * Does NOT decompress or decrypt — returns raw body bytes for the caller.
+ */
+export function decodeBlob(buf: Uint8Array): DecodedBlob {
+  if (buf.length < 12) {
+    throw new Error('blob too short: must contain at least 8-byte magic + 4-byte CRC32')
+  }
+  const variant = identifyBlobVariant(buf)
+  if (!variant) {
+    throw new Error('blob magic does not match any known variant')
+  }
+
+  const crcStored = readU32LE(buf, 8)
+  const isEncrypted = variant === 'uncompressed-encrypted' || variant === 'compressed-encrypted'
+
+  const headerEnd = isEncrypted ? 12 + 16 + 16 : 12
+
+  if (buf.length < headerEnd) {
+    throw new Error(`encrypted blob too short: needs at least ${headerEnd} bytes for IV+tag`)
+  }
+
+  const body = buf.subarray(headerEnd)
+  if (body.length > BLOB_MAX_DATA_SIZE) {
+    throw new Error(`blob body exceeds maximum (${BLOB_MAX_DATA_SIZE} bytes)`)
+  }
+
+  // CRC32 covers bytes from offset 12 onward (body, plus IV+tag for encrypted blobs)
+  const crcSrc = buf.subarray(12)
+  const crcComputed = crc32(crcSrc)
+  if (crcComputed !== crcStored) {
+    throw new Error(`blob CRC32 mismatch: stored=${crcStored.toString(16)}, computed=${crcComputed.toString(16)}`)
+  }
+
+  const result: DecodedBlob = { variant, body }
+  if (isEncrypted) {
+    result.iv  = buf.subarray(12, 28)
+    result.tag = buf.subarray(28, 44)
+  }
+  return result
+}
+
+export interface EncodeBlobInput {
+  variant: BlobVariant
+  /** Already-processed body bytes — caller is responsible for compression/encryption before calling. */
+  body:    Uint8Array
+  /** Required for encrypted variants. */
+  iv?:     Uint8Array
+  /** Required for encrypted variants. */
+  tag?:    Uint8Array
+}
+
+/**
+ * Encode a Data Blob.
+ * The caller pre-processes the body (zstd compression, AES-256-GCM encryption).
+ * This function adds magic + CRC32 framing and (for encrypted variants) the IV+tag header.
+ */
+export function encodeBlob(input: EncodeBlobInput): Uint8Array {
+  if (input.body.length > BLOB_MAX_DATA_SIZE) {
+    throw new Error(`blob body exceeds maximum (${BLOB_MAX_DATA_SIZE} bytes)`)
+  }
+  const isEncrypted = input.variant === 'uncompressed-encrypted' || input.variant === 'compressed-encrypted'
+  if (isEncrypted) {
+    if (!input.iv || input.iv.length !== 16) throw new Error('encrypted blob requires 16-byte IV')
+    if (!input.tag || input.tag.length !== 16) throw new Error('encrypted blob requires 16-byte AE tag')
+  }
+
+  const magic = magicForVariant(input.variant)
+  const headerSize = 8 + 4 + (isEncrypted ? 32 : 0)
+  const out = new Uint8Array(headerSize + input.body.length)
+
+  out.set(magic, 0)
+  if (isEncrypted) {
+    out.set(input.iv!, 12)
+    out.set(input.tag!, 28)
+    out.set(input.body, 44)
+  } else {
+    out.set(input.body, 12)
+  }
+
+  const crc = crc32(out.subarray(12))
+  writeU32LE(out, 8, crc)
+  return out
+}
+
+function magicForVariant(v: BlobVariant): Uint8Array {
+  switch (v) {
+    case 'uncompressed-unencrypted': return BLOB_MAGIC_UNCOMPRESSED_UNENCRYPTED
+    case 'compressed-unencrypted':   return BLOB_MAGIC_COMPRESSED_UNENCRYPTED
+    case 'uncompressed-encrypted':   return BLOB_MAGIC_UNCOMPRESSED_ENCRYPTED
+    case 'compressed-encrypted':     return BLOB_MAGIC_COMPRESSED_ENCRYPTED
+  }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false
+  return true
+}
+
+function readU32LE(buf: Uint8Array, offset: number): number {
+  return ((buf[offset]! | (buf[offset + 1]! << 8) | (buf[offset + 2]! << 16) | (buf[offset + 3]! << 24)) >>> 0)
+}
+
+function writeU32LE(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset]     = value & 0xff
+  buf[offset + 1] = (value >>> 8) & 0xff
+  buf[offset + 2] = (value >>> 16) & 0xff
+  buf[offset + 3] = (value >>> 24) & 0xff
+}
+
+// CRC-32 (IEEE 802.3 polynomial, reflected). Standard "zlib" CRC.
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256)
+  for (let i = 0; i < 256; i++) {
+    let c = i
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+    }
+    t[i] = c
+  }
+  return t
+})()
+
+export function crc32(buf: Uint8Array): number {
+  let c = 0xffffffff
+  for (let i = 0; i < buf.length; i++) {
+    c = CRC_TABLE[(c ^ buf[i]!) & 0xff]! ^ (c >>> 8)
+  }
+  return (c ^ 0xffffffff) >>> 0
+}
+
+/** SHA-256 helper used by index codecs. Re-exported so consumers don't need to import crypto separately. */
+export function sha256(buf: Uint8Array): Uint8Array {
+  return new Uint8Array(createHash('sha256').update(buf).digest())
+}

--- a/packages/pbs-protocol/src/dynamic-index.test.ts
+++ b/packages/pbs-protocol/src/dynamic-index.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { randomBytes } from 'crypto'
+import {
+  encodeDynamicIndex,
+  decodeDynamicIndex,
+  DYNAMIC_INDEX_MAGIC,
+  DYNAMIC_INDEX_HEADER_SIZE,
+} from './dynamic-index'
+
+function makeUuid(): Uint8Array {
+  return new Uint8Array(randomBytes(16))
+}
+
+describe('dynamic index', () => {
+  it('round-trips a small index', () => {
+    const entries = [
+      { endOffset:  4096n, digest: new Uint8Array(randomBytes(32)) },
+      { endOffset:  8192n, digest: new Uint8Array(randomBytes(32)) },
+      { endOffset: 16384n, digest: new Uint8Array(randomBytes(32)) },
+    ]
+    const uuid = makeUuid()
+    const enc = encodeDynamicIndex({ uuid, ctime: 1700000000n, entries })
+
+    expect(enc.length).toBe(DYNAMIC_INDEX_HEADER_SIZE + 3 * 40)
+
+    const dec = decodeDynamicIndex(enc)
+    expect([...dec.header.uuid]).toEqual([...uuid])
+    expect(dec.header.ctime).toBe(1700000000n)
+    expect(dec.entries).toHaveLength(3)
+    expect(dec.entries[0]!.endOffset).toBe(4096n)
+    expect(dec.entries[1]!.endOffset).toBe(8192n)
+    expect(dec.entries[2]!.endOffset).toBe(16384n)
+    for (let i = 0; i < 3; i++) {
+      expect([...dec.entries[i]!.digest]).toEqual([...entries[i]!.digest])
+    }
+  })
+
+  it('header starts with the documented magic', () => {
+    const enc = encodeDynamicIndex({ uuid: makeUuid(), ctime: 0n, entries: [] })
+    for (let i = 0; i < 8; i++) {
+      expect(enc[i]).toBe(DYNAMIC_INDEX_MAGIC[i])
+    }
+  })
+
+  it('rejects mismatched magic', () => {
+    const enc = encodeDynamicIndex({
+      uuid: makeUuid(), ctime: 0n,
+      entries: [{ endOffset: 100n, digest: new Uint8Array(randomBytes(32)) }],
+    })
+    enc[0] = 0xff
+    expect(() => decodeDynamicIndex(enc)).toThrow(/magic/)
+  })
+
+  it('rejects tampered body', () => {
+    const enc = encodeDynamicIndex({
+      uuid: makeUuid(), ctime: 0n,
+      entries: [{ endOffset: 100n, digest: new Uint8Array(randomBytes(32)) }],
+    })
+    enc[DYNAMIC_INDEX_HEADER_SIZE + 8] = enc[DYNAMIC_INDEX_HEADER_SIZE + 8]! ^ 0xff
+    expect(() => decodeDynamicIndex(enc)).toThrow(/csum/)
+  })
+})

--- a/packages/pbs-protocol/src/dynamic-index.ts
+++ b/packages/pbs-protocol/src/dynamic-index.ts
@@ -1,0 +1,137 @@
+// Dynamic Index (.didx) codec — used for file archives (.pxar) with rolling-hash chunks
+//
+// Source: PBS public documentation
+// https://pbs.proxmox.com/docs/file-formats.html (Dynamic Index Format section)
+//
+// Header layout (all little-endian, total exactly 4096 bytes):
+//   [u8; 8]   magic      = [28, 145, 78, 165, 25, 186, 179, 205]
+//   [u8; 16]  uuid
+//   i64       ctime
+//   [u8; 32]  index_csum = SHA-256 over concat(offset1, digest1, offset2, digest2, ...)
+//   [u8; 4032] reserved
+//
+// Body: an array of (offset: u64, digest: [u8; 32]) entries — 40 bytes each.
+// Each `offset` is the END offset of that chunk in the reconstructed stream (cumulative).
+
+import { sha256 } from './blob'
+
+export const DYNAMIC_INDEX_MAGIC = new Uint8Array([28, 145, 78, 165, 25, 186, 179, 205])
+export const DYNAMIC_INDEX_HEADER_SIZE = 4096
+export const DYNAMIC_INDEX_ENTRY_SIZE = 40 // 8 (offset) + 32 (digest)
+export const DYNAMIC_INDEX_DIGEST_SIZE = 32
+
+export interface DynamicIndexHeader {
+  uuid:       Uint8Array     // 16 bytes
+  ctime:      bigint          // i64
+  indexCsum:  Uint8Array     // 32 bytes
+}
+
+export interface DynamicIndexEntry {
+  /** End offset of this chunk in the reconstructed stream (cumulative). */
+  endOffset: bigint
+  /** SHA-256 digest of the chunk content. */
+  digest:    Uint8Array      // 32 bytes
+}
+
+export interface DynamicIndex {
+  header:  DynamicIndexHeader
+  entries: DynamicIndexEntry[]
+}
+
+export function decodeDynamicIndex(buf: Uint8Array): DynamicIndex {
+  if (buf.length < DYNAMIC_INDEX_HEADER_SIZE) {
+    throw new Error('.didx too short: must contain 4096-byte header')
+  }
+  if (!bytesEqual(buf.subarray(0, 8), DYNAMIC_INDEX_MAGIC)) {
+    throw new Error('.didx magic mismatch')
+  }
+  const uuid      = buf.subarray(8, 24)
+  const ctime     = readI64LE(buf, 24)
+  const indexCsum = buf.subarray(32, 64)
+
+  const bodyBytes = buf.subarray(DYNAMIC_INDEX_HEADER_SIZE)
+  if (bodyBytes.length % DYNAMIC_INDEX_ENTRY_SIZE !== 0) {
+    throw new Error(`.didx body length ${bodyBytes.length} is not a multiple of ${DYNAMIC_INDEX_ENTRY_SIZE}`)
+  }
+
+  const entries: DynamicIndexEntry[] = []
+  for (let off = 0; off < bodyBytes.length; off += DYNAMIC_INDEX_ENTRY_SIZE) {
+    const endOffset = readU64LE(bodyBytes, off)
+    const digest    = bodyBytes.subarray(off + 8, off + 8 + DYNAMIC_INDEX_DIGEST_SIZE)
+    entries.push({ endOffset, digest })
+  }
+
+  const computed = sha256(bodyBytes)
+  if (!bytesEqual(computed, indexCsum)) {
+    throw new Error('.didx index_csum does not match SHA-256 of entry body')
+  }
+
+  return {
+    header: { uuid, ctime, indexCsum },
+    entries,
+  }
+}
+
+export interface EncodeDynamicIndexInput {
+  uuid:    Uint8Array         // 16 bytes
+  ctime:   bigint
+  entries: DynamicIndexEntry[]
+}
+
+export function encodeDynamicIndex(input: EncodeDynamicIndexInput): Uint8Array {
+  if (input.uuid.length !== 16) throw new Error('uuid must be 16 bytes')
+  for (const e of input.entries) {
+    if (e.digest.length !== DYNAMIC_INDEX_DIGEST_SIZE) throw new Error('each digest must be 32 bytes')
+  }
+
+  const bodyLen = input.entries.length * DYNAMIC_INDEX_ENTRY_SIZE
+  const body = new Uint8Array(bodyLen)
+  let off = 0
+  for (const e of input.entries) {
+    writeU64LE(body, off, e.endOffset)
+    body.set(e.digest, off + 8)
+    off += DYNAMIC_INDEX_ENTRY_SIZE
+  }
+  const indexCsum = sha256(body)
+
+  const out = new Uint8Array(DYNAMIC_INDEX_HEADER_SIZE + bodyLen)
+  out.set(DYNAMIC_INDEX_MAGIC, 0)
+  out.set(input.uuid, 8)
+  writeI64LE(out, 24, input.ctime)
+  out.set(indexCsum, 32)
+  out.set(body, DYNAMIC_INDEX_HEADER_SIZE)
+
+  return out
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false
+  return true
+}
+
+function readU64LE(buf: Uint8Array, offset: number): bigint {
+  let v = 0n
+  for (let i = 7; i >= 0; i--) v = (v << 8n) | BigInt(buf[offset + i]!)
+  return v
+}
+
+function writeU64LE(buf: Uint8Array, offset: number, value: bigint): void {
+  let v = value
+  for (let i = 0; i < 8; i++) {
+    buf[offset + i] = Number(v & 0xffn)
+    v >>= 8n
+  }
+}
+
+function readI64LE(buf: Uint8Array, offset: number): bigint {
+  const u = readU64LE(buf, offset)
+  return u >= (1n << 63n) ? u - (1n << 64n) : u
+}
+
+function writeI64LE(buf: Uint8Array, offset: number, value: bigint): void {
+  const u = value < 0n ? value + (1n << 64n) : value
+  writeU64LE(buf, offset, u)
+}

--- a/packages/pbs-protocol/src/fixed-index.test.ts
+++ b/packages/pbs-protocol/src/fixed-index.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { randomBytes } from 'crypto'
+import {
+  encodeFixedIndex,
+  decodeFixedIndex,
+  FIXED_INDEX_MAGIC,
+  FIXED_INDEX_HEADER_SIZE,
+} from './fixed-index'
+
+function makeUuid(): Uint8Array {
+  return new Uint8Array(randomBytes(16))
+}
+
+function makeDigests(n: number): Uint8Array[] {
+  return Array.from({ length: n }, () => new Uint8Array(randomBytes(32)))
+}
+
+describe('fixed index', () => {
+  it('round-trips a small index', () => {
+    const digests = makeDigests(3)
+    const uuid = makeUuid()
+    const enc = encodeFixedIndex({
+      uuid,
+      ctime: 1700000000n,
+      size: 12n * 1024n * 1024n,
+      chunkSize: 4n * 1024n * 1024n,
+      digests,
+    })
+
+    expect(enc.length).toBe(FIXED_INDEX_HEADER_SIZE + 3 * 32)
+
+    const dec = decodeFixedIndex(enc)
+    expect([...dec.header.uuid]).toEqual([...uuid])
+    expect(dec.header.ctime).toBe(1700000000n)
+    expect(dec.header.size).toBe(12n * 1024n * 1024n)
+    expect(dec.header.chunkSize).toBe(4n * 1024n * 1024n)
+    expect(dec.digests).toHaveLength(3)
+    for (let i = 0; i < 3; i++) {
+      expect([...dec.digests[i]!]).toEqual([...digests[i]!])
+    }
+  })
+
+  it('header starts with the documented magic', () => {
+    const enc = encodeFixedIndex({
+      uuid: makeUuid(), ctime: 0n, size: 0n, chunkSize: 4194304n, digests: [],
+    })
+    for (let i = 0; i < 8; i++) {
+      expect(enc[i]).toBe(FIXED_INDEX_MAGIC[i])
+    }
+  })
+
+  it('rejects mismatched magic', () => {
+    const enc = encodeFixedIndex({
+      uuid: makeUuid(), ctime: 0n, size: 0n, chunkSize: 4194304n, digests: makeDigests(1),
+    })
+    enc[0] = 0xff
+    expect(() => decodeFixedIndex(enc)).toThrow(/magic/)
+  })
+
+  it('rejects body length not divisible by 32', () => {
+    const enc = encodeFixedIndex({
+      uuid: makeUuid(), ctime: 0n, size: 0n, chunkSize: 4194304n, digests: makeDigests(1),
+    })
+    const broken = enc.subarray(0, enc.length - 5)
+    expect(() => decodeFixedIndex(broken)).toThrow(/multiple of/)
+  })
+
+  it('rejects index_csum tampering', () => {
+    const enc = encodeFixedIndex({
+      uuid: makeUuid(), ctime: 0n, size: 4194304n, chunkSize: 4194304n, digests: makeDigests(1),
+    })
+    enc[FIXED_INDEX_HEADER_SIZE] = enc[FIXED_INDEX_HEADER_SIZE]! ^ 0xff
+    expect(() => decodeFixedIndex(enc)).toThrow(/csum/)
+  })
+})

--- a/packages/pbs-protocol/src/fixed-index.ts
+++ b/packages/pbs-protocol/src/fixed-index.ts
@@ -1,0 +1,137 @@
+// Fixed Index (.fidx) codec — used for VM block-level images
+//
+// Source: PBS public documentation
+// https://pbs.proxmox.com/docs/file-formats.html (Fixed Index Format section)
+//
+// Header layout (all little-endian, total exactly 4096 bytes):
+//   [u8; 8]   magic      = [47, 127, 65, 237, 145, 253, 15, 205]
+//   [u8; 16]  uuid
+//   i64       ctime      (epoch seconds)
+//   [u8; 32]  index_csum = SHA-256 over concat(digest1, digest2, ...)
+//   u64       size       (total uncompressed image size)
+//   u64       chunk_size (typically 4 MiB = 4194304)
+//   [u8; 4016] reserved  (zero-filled)
+//
+// Body: a flat array of [u8; 32] chunk digests. Number of chunks = ceil(size / chunk_size).
+
+import { sha256 } from './blob'
+
+export const FIXED_INDEX_MAGIC = new Uint8Array([47, 127, 65, 237, 145, 253, 15, 205])
+export const FIXED_INDEX_HEADER_SIZE = 4096
+export const FIXED_INDEX_DIGEST_SIZE = 32
+
+export interface FixedIndexHeader {
+  uuid:       Uint8Array      // 16 bytes
+  ctime:      bigint           // i64 epoch seconds
+  indexCsum:  Uint8Array      // 32 bytes (SHA-256 over digest concat)
+  size:       bigint           // u64 total image size in bytes
+  chunkSize:  bigint           // u64 chunk size in bytes
+}
+
+export interface FixedIndex {
+  header:  FixedIndexHeader
+  digests: Uint8Array[]   // each entry is 32 bytes
+}
+
+/** Decode a .fidx file from its on-disk bytes. */
+export function decodeFixedIndex(buf: Uint8Array): FixedIndex {
+  if (buf.length < FIXED_INDEX_HEADER_SIZE) {
+    throw new Error('.fidx too short: must contain 4096-byte header')
+  }
+  if (!bytesEqual(buf.subarray(0, 8), FIXED_INDEX_MAGIC)) {
+    throw new Error('.fidx magic mismatch')
+  }
+  const uuid       = buf.subarray(8, 24)
+  const ctime      = readI64LE(buf, 24)
+  const indexCsum  = buf.subarray(32, 64)
+  const size       = readU64LE(buf, 64)
+  const chunkSize  = readU64LE(buf, 72)
+
+  const bodyBytes = buf.subarray(FIXED_INDEX_HEADER_SIZE)
+  if (bodyBytes.length % FIXED_INDEX_DIGEST_SIZE !== 0) {
+    throw new Error(`.fidx body length ${bodyBytes.length} is not a multiple of ${FIXED_INDEX_DIGEST_SIZE}`)
+  }
+
+  const digests: Uint8Array[] = []
+  for (let off = 0; off < bodyBytes.length; off += FIXED_INDEX_DIGEST_SIZE) {
+    digests.push(bodyBytes.subarray(off, off + FIXED_INDEX_DIGEST_SIZE))
+  }
+
+  const computed = sha256(bodyBytes)
+  if (!bytesEqual(computed, indexCsum)) {
+    throw new Error('.fidx index_csum does not match SHA-256 of digest body')
+  }
+
+  return {
+    header: { uuid, ctime, indexCsum, size, chunkSize },
+    digests,
+  }
+}
+
+export interface EncodeFixedIndexInput {
+  uuid:       Uint8Array       // 16 bytes
+  ctime:      bigint
+  size:       bigint
+  chunkSize:  bigint
+  digests:    Uint8Array[]     // each 32 bytes
+}
+
+/** Encode a fixed index to its on-disk bytes. Computes index_csum automatically. */
+export function encodeFixedIndex(input: EncodeFixedIndexInput): Uint8Array {
+  if (input.uuid.length !== 16) throw new Error('uuid must be 16 bytes')
+  for (const d of input.digests) {
+    if (d.length !== FIXED_INDEX_DIGEST_SIZE) throw new Error('each digest must be 32 bytes')
+  }
+
+  const bodyLen = input.digests.length * FIXED_INDEX_DIGEST_SIZE
+  const concatBody = new Uint8Array(bodyLen)
+  let off = 0
+  for (const d of input.digests) {
+    concatBody.set(d, off)
+    off += FIXED_INDEX_DIGEST_SIZE
+  }
+  const indexCsum = sha256(concatBody)
+
+  const out = new Uint8Array(FIXED_INDEX_HEADER_SIZE + bodyLen)
+  out.set(FIXED_INDEX_MAGIC, 0)
+  out.set(input.uuid, 8)
+  writeI64LE(out, 24, input.ctime)
+  out.set(indexCsum, 32)
+  writeU64LE(out, 64, input.size)
+  writeU64LE(out, 72, input.chunkSize)
+  out.set(concatBody, FIXED_INDEX_HEADER_SIZE)
+
+  return out
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false
+  return true
+}
+
+function readU64LE(buf: Uint8Array, offset: number): bigint {
+  let v = 0n
+  for (let i = 7; i >= 0; i--) v = (v << 8n) | BigInt(buf[offset + i]!)
+  return v
+}
+
+function writeU64LE(buf: Uint8Array, offset: number, value: bigint): void {
+  let v = value
+  for (let i = 0; i < 8; i++) {
+    buf[offset + i] = Number(v & 0xffn)
+    v >>= 8n
+  }
+}
+
+function readI64LE(buf: Uint8Array, offset: number): bigint {
+  const u = readU64LE(buf, offset)
+  return u >= (1n << 63n) ? u - (1n << 64n) : u
+}
+
+function writeI64LE(buf: Uint8Array, offset: number, value: bigint): void {
+  const u = value < 0n ? value + (1n << 64n) : value
+  writeU64LE(buf, offset, u)
+}

--- a/packages/pbs-protocol/src/index.ts
+++ b/packages/pbs-protocol/src/index.ts
@@ -3,6 +3,38 @@
 // Pure types and constants — no I/O.
 //
 // Implementation milestones tracked in docs/design/pbs-backend.md.
-// Milestone 0: skeleton only. Real exports land in milestone 1.
 
 export const PBS_PROTOCOL_VERSION = '1' as const
+
+export {
+  BLOB_MAGIC_UNCOMPRESSED_UNENCRYPTED,
+  BLOB_MAGIC_COMPRESSED_UNENCRYPTED,
+  BLOB_MAGIC_UNCOMPRESSED_ENCRYPTED,
+  BLOB_MAGIC_COMPRESSED_ENCRYPTED,
+  BLOB_MAX_DATA_SIZE,
+  identifyBlobVariant,
+  decodeBlob,
+  encodeBlob,
+  crc32,
+  sha256,
+} from './blob'
+export type { BlobVariant, DecodedBlob, EncodeBlobInput } from './blob'
+
+export {
+  FIXED_INDEX_MAGIC,
+  FIXED_INDEX_HEADER_SIZE,
+  FIXED_INDEX_DIGEST_SIZE,
+  decodeFixedIndex,
+  encodeFixedIndex,
+} from './fixed-index'
+export type { FixedIndexHeader, FixedIndex, EncodeFixedIndexInput } from './fixed-index'
+
+export {
+  DYNAMIC_INDEX_MAGIC,
+  DYNAMIC_INDEX_HEADER_SIZE,
+  DYNAMIC_INDEX_ENTRY_SIZE,
+  DYNAMIC_INDEX_DIGEST_SIZE,
+  decodeDynamicIndex,
+  encodeDynamicIndex,
+} from './dynamic-index'
+export type { DynamicIndexHeader, DynamicIndexEntry, DynamicIndex, EncodeDynamicIndexInput } from './dynamic-index'

--- a/packages/pbs-protocol/vitest.config.ts
+++ b/packages/pbs-protocol/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
Implements Data Blob (.blob), Fixed Index (.fidx), Dynamic Index (.didx) codecs in @backupos/pbs-protocol. Pure functions on byte buffers, no I/O. Round-trip + corruption-detection tests included.

Source: PBS public documentation (https://pbs.proxmox.com/docs/file-formats.html). Clean-room implementation — no PBS or pmoxs3backuproxy source code was read or transcribed.

## Changes
- `src/blob.ts`: `encodeBlob`/`decodeBlob` for all 4 magic variants. CRC-32 framing validated against the well-known `0xCBF43926` test vector. IV+tag header for encrypted variants.
- `src/fixed-index.ts`: `.fidx` encode/decode with 4096-byte header, SHA-256 `index_csum` over digest body.
- `src/dynamic-index.ts`: `.didx` encode/decode with `(endOffset, digest)` entry pairs, SHA-256 `index_csum`.
- `src/index.ts`: re-exports all public symbols.
- `vitest.config.ts` + `package.json`: vitest `^3.0.0` test runner added.

## Test results
23 tests pass across 3 files: round-trips for all 4 blob variants, fixed/dynamic index round-trips, magic mismatch detection, CRC32 / index_csum tampering, buffer-too-short errors.

## Test plan
- [ ] `pnpm --filter @backupos/pbs-protocol test` — 23 tests pass
- [ ] `pnpm --filter @backupos/pbs-protocol build` — succeeds
- [ ] `pnpm --filter @backupos/web typecheck` — 0 errors

Closes milestone 1 of the PBS-compatible backend (#237).

🤖 Generated with [Claude Code](https://claude.com/claude-code)