### PR TITLE
feat(pbs): HTTP/2 listener + cert + version endpoint — milestone 3a (#237)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@backupos/agent-protocol": "workspace:*",
+    "@backupos/pbs-server": "workspace:*",
     "@backupos/api": "workspace:*",
     "@backupos/db": "workspace:*",
     "@backupos/docs-content": "workspace:*",

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -1,5 +1,6 @@
 import { createServer } from 'http'
 import { createHash } from 'crypto'
+import { startPbsServer } from '@backupos/pbs-server'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { parse } from 'url'
@@ -858,5 +859,26 @@ void app.prepare().then(() => {
   server.listen(port, '0.0.0.0', () => {
     console.log(`> Ready on http://0.0.0.0:${port}`)
     void import('./lib/scheduler').then(({ initScheduler }) => initScheduler())
+
+    // PBS-compatible protocol listener (port 8007).
+    // Boots after Next.js. Uses cert at /etc/backupos/pbs-cert.pem.
+    // Version endpoint only in M3a; auth and protocol endpoints land in M3b/M4/M5.
+    void (async () => {
+      try {
+        const pbsHandle = await startPbsServer({
+          port: Number(process.env['PBS_PORT'] ?? '8007'),
+          host: process.env['PBS_HOST'] ?? '0.0.0.0',
+          certPaths: {
+            certPath: process.env['PBS_TLS_CERT'] ?? '/etc/backupos/pbs-cert.pem',
+            keyPath:  process.env['PBS_TLS_KEY']  ?? '/etc/backupos/pbs-key.pem',
+          },
+          log: (msg) => console.log(`[pbs] ${msg}`),
+        })
+        console.log(`[pbs] cert fingerprint: ${pbsHandle.certFingerprint}`)
+      } catch (err) {
+        // PBS listener failure must not crash the main app — log and continue.
+        console.error(`[pbs] failed to start: ${(err as Error).message}`)
+      }
+    })()
   })
 })

--- a/packages/pbs-server/package.json
+++ b/packages/pbs-server/package.json
@@ -13,13 +13,16 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@backupos/pbs-protocol": "workspace:*",
     "@backupos/pbs-storage": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "^5.7.0"
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/pbs-server/src/cert.test.ts
+++ b/packages/pbs-server/src/cert.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm, stat } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { ensureSelfSignedCert, computeCertFingerprint, generateSelfSignedCert } from './cert'
+
+describe('cert', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'pbs-cert-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('generates cert and key when missing', { timeout: 30_000 }, () => {
+    const paths = { certPath: join(dir, 'cert.pem'), keyPath: join(dir, 'key.pem') }
+    const mat = ensureSelfSignedCert(paths)
+    expect(mat.cert.length).toBeGreaterThan(0)
+    expect(mat.key.length).toBeGreaterThan(0)
+    expect(mat.fingerprint).toMatch(/^[0-9A-F]{2}(:[0-9A-F]{2}){31}$/)
+  })
+
+  it('private key file is mode 0600', { timeout: 30_000 }, async () => {
+    const paths = { certPath: join(dir, 'cert.pem'), keyPath: join(dir, 'key.pem') }
+    ensureSelfSignedCert(paths)
+    const s = await stat(paths.keyPath)
+    expect(s.mode & 0o777).toBe(0o600)
+  })
+
+  it('reuses existing cert if both files exist', { timeout: 30_000 }, () => {
+    const paths = { certPath: join(dir, 'cert.pem'), keyPath: join(dir, 'key.pem') }
+    const first = ensureSelfSignedCert(paths)
+    const second = ensureSelfSignedCert(paths)
+    expect(second.fingerprint).toBe(first.fingerprint)
+  })
+
+  it('regenerates when forced', { timeout: 60_000 }, () => {
+    const paths = { certPath: join(dir, 'cert.pem'), keyPath: join(dir, 'key.pem') }
+    const first = ensureSelfSignedCert(paths)
+    generateSelfSignedCert(paths)
+    const second = ensureSelfSignedCert(paths)
+    expect(second.fingerprint).not.toBe(first.fingerprint)
+  })
+
+  it('fingerprint is colon-separated uppercase hex of SHA-256', { timeout: 30_000 }, () => {
+    const paths = { certPath: join(dir, 'cert.pem'), keyPath: join(dir, 'key.pem') }
+    const mat = ensureSelfSignedCert(paths)
+    const computedAgain = computeCertFingerprint(mat.cert)
+    expect(computedAgain).toBe(mat.fingerprint)
+    expect(mat.fingerprint).toMatch(/^[0-9A-F]{2}(:[0-9A-F]{2}){31}$/)
+  })
+})

--- a/packages/pbs-server/src/cert.ts
+++ b/packages/pbs-server/src/cert.ts
@@ -1,0 +1,88 @@
+// Self-signed TLS cert for the PBS protocol listener.
+//
+// PVE clients pin certificates by fingerprint, not CA chain — so a
+// long-lived self-signed cert is correct here. We generate once at
+// first boot, write to disk, and load it on every boot thereafter.
+//
+// Source: PVE PBS storage docs require a "fingerprint" parameter
+// (https://pve.proxmox.com/wiki/Storage:_Proxmox_Backup_Server),
+// confirming fingerprint-pinning rather than CA-validation.
+//
+// Clean-room. No PBS source code read.
+
+import { execFileSync } from 'child_process'
+import { existsSync, mkdirSync, readFileSync, chmodSync } from 'fs'
+import { dirname } from 'path'
+import { X509Certificate } from 'crypto'
+
+export interface CertPaths {
+  certPath: string
+  keyPath:  string
+}
+
+export interface CertMaterial {
+  cert:        Buffer
+  key:         Buffer
+  /** Colon-separated uppercase hex SHA-256 fingerprint, e.g. `AB:CD:...` */
+  fingerprint: string
+}
+
+const VALIDITY_DAYS = 3650 // 10 years
+const COMMON_NAME = 'BackupOS PBS-compatible endpoint'
+
+/**
+ * Ensure a self-signed cert+key exist at the given paths. Generate them if
+ * not. Returns the loaded material in either case. Idempotent.
+ */
+export function ensureSelfSignedCert(paths: CertPaths): CertMaterial {
+  if (!existsSync(paths.certPath) || !existsSync(paths.keyPath)) {
+    generateSelfSignedCert(paths)
+  }
+  return loadCert(paths)
+}
+
+/** Force re-generation. Overwrites existing cert/key. */
+export function generateSelfSignedCert(paths: CertPaths): void {
+  const certDir = dirname(paths.certPath)
+  if (!existsSync(certDir)) {
+    mkdirSync(certDir, { recursive: true, mode: 0o755 })
+  }
+
+  // openssl req: generate key + self-signed cert in one shot.
+  // -nodes      = no key passphrase (server reads on every boot, can't prompt)
+  // -newkey     = generate fresh RSA key
+  // -keyout/out = where to write
+  // -days       = validity period
+  // -subj       = no interactive prompt for DN fields
+  execFileSync('openssl', [
+    'req',
+    '-x509',
+    '-nodes',
+    '-newkey', 'rsa:4096',
+    '-keyout', paths.keyPath,
+    '-out',    paths.certPath,
+    '-days',   String(VALIDITY_DAYS),
+    '-subj',   `/CN=${COMMON_NAME}`,
+    '-sha256',
+  ], { stdio: 'pipe' })
+
+  // Lock down the private key — group/world readable would let any process
+  // on the box impersonate the BackupOS PBS endpoint.
+  chmodSync(paths.keyPath, 0o600)
+  chmodSync(paths.certPath, 0o644)
+}
+
+/** Load an existing cert+key from disk and compute its SHA-256 fingerprint. */
+export function loadCert(paths: CertPaths): CertMaterial {
+  const cert = readFileSync(paths.certPath)
+  const key  = readFileSync(paths.keyPath)
+  const fingerprint = computeCertFingerprint(cert)
+  return { cert, key, fingerprint }
+}
+
+/** Compute the colon-separated uppercase hex SHA-256 fingerprint of a PEM cert. */
+export function computeCertFingerprint(certPem: Buffer): string {
+  const x509 = new X509Certificate(certPem)
+  // Returns "AB:CD:..." (uppercase hex with colons), matching pvesm add pbs --fingerprint format.
+  return x509.fingerprint256
+}

--- a/packages/pbs-server/src/handlers/version.test.ts
+++ b/packages/pbs-server/src/handlers/version.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { handleVersion } from './version'
+
+describe('handleVersion', () => {
+  it('returns the documented PBS shape', () => {
+    const out = handleVersion({ version: '4.0.0', release: '1' })
+    expect(out).toEqual({
+      data: { version: '4.0.0', release: '1', repoid: 'backupos' },
+    })
+  })
+
+  it('passes through caller-supplied version/release', () => {
+    const out = handleVersion({ version: '9.9.9', release: 'beta' })
+    expect(out.data.version).toBe('9.9.9')
+    expect(out.data.release).toBe('beta')
+  })
+})

--- a/packages/pbs-server/src/handlers/version.ts
+++ b/packages/pbs-server/src/handlers/version.ts
@@ -1,0 +1,41 @@
+// GET /api2/json/version handler.
+//
+// PBS response shape (verified against real responses in
+// https://forum.proxmox.com/threads/version-3-2-2-api-access-via-cli.146516/):
+//
+//   {
+//     "data": {
+//       "version": "4.0.0",
+//       "release": "1",
+//       "repoid":  "backupos"
+//     }
+//   }
+//
+// PVE uses this endpoint as a liveness probe and to detect the protocol
+// version. We report a stable widely-supported PBS version string so PVE
+// accepts us; the actual implementation surfaces in subsequent endpoints.
+//
+// Clean-room.
+
+export interface VersionInput {
+  version: string
+  release: string
+}
+
+export interface VersionResponse {
+  data: {
+    version: string
+    release: string
+    repoid:  string
+  }
+}
+
+export function handleVersion(input: VersionInput): VersionResponse {
+  return {
+    data: {
+      version: input.version,
+      release: input.release,
+      repoid:  'backupos',
+    },
+  }
+}

--- a/packages/pbs-server/src/index.ts
+++ b/packages/pbs-server/src/index.ts
@@ -1,18 +1,17 @@
 // @backupos/pbs-server
 // HTTP/2 server implementing the Proxmox Backup Server protocol.
 //
-// Milestone 0: skeleton only. startPbsServer is a no-op stub that will
-// be wired in milestone 3.
+// V1 milestone 3a: listener boots, /api2/json/version answers, no auth.
+// Subsequent milestones add: token auth (M3b), backup endpoints (M4),
+// restore endpoints (M5), GC/retention (M6), UI (M7).
 
-export interface StartPbsServerOptions {
-  port?: number
-  storageRoot?: string
-}
+export { startPbsServer, stopPbsServer } from './server'
+export type { StartPbsServerOptions, PbsServerHandle } from './server'
 
-export function startPbsServer(_opts: StartPbsServerOptions = {}): void {
-  // Stub — implemented in milestone 3.
-}
-
-export function stopPbsServer(): void {
-  // Stub — implemented in milestone 3.
-}
+export {
+  ensureSelfSignedCert,
+  generateSelfSignedCert,
+  loadCert,
+  computeCertFingerprint,
+} from './cert'
+export type { CertPaths, CertMaterial } from './cert'

--- a/packages/pbs-server/src/server.test.ts
+++ b/packages/pbs-server/src/server.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { connect as h2connect, constants } from 'http2'
+import { startPbsServer, type PbsServerHandle } from './server'
+
+describe('PBS HTTP/2 server', () => {
+  let dir: string
+  let handle: PbsServerHandle
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'pbs-server-test-'))
+    handle = await startPbsServer({
+      port: 0, // ephemeral
+      host: '127.0.0.1',
+      certPaths: {
+        certPath: join(dir, 'cert.pem'),
+        keyPath:  join(dir, 'key.pem'),
+      },
+      log: () => { /* silence */ },
+    })
+  }, 30_000)
+
+  afterEach(async () => {
+    await handle.stop()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('responds to GET /api2/json/version over HTTP/2', async () => {
+    const url = `https://127.0.0.1:${handle.address.port}`
+    const session = h2connect(url, { rejectUnauthorized: false })
+    try {
+      const res = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+        const req = session.request({
+          [constants.HTTP2_HEADER_METHOD]: 'GET',
+          [constants.HTTP2_HEADER_PATH]:   '/api2/json/version',
+        })
+        let body = ''
+        let status = 0
+        req.on('response', (h) => { status = Number(h[constants.HTTP2_HEADER_STATUS]) })
+        req.setEncoding('utf8')
+        req.on('data', (chunk: string) => { body += chunk })
+        req.on('end', () => resolve({ status, body }))
+        req.on('error', reject)
+        req.end()
+      })
+
+      expect(res.status).toBe(200)
+      const parsed = JSON.parse(res.body) as { data: { version: string; repoid: string } }
+      expect(parsed.data.version).toBeTruthy()
+      expect(parsed.data.repoid).toBe('backupos')
+    } finally {
+      session.close()
+    }
+  })
+
+  it('returns 404 for unknown paths', async () => {
+    const url = `https://127.0.0.1:${handle.address.port}`
+    const session = h2connect(url, { rejectUnauthorized: false })
+    try {
+      const status = await new Promise<number>((resolve, reject) => {
+        const req = session.request({
+          [constants.HTTP2_HEADER_METHOD]: 'GET',
+          [constants.HTTP2_HEADER_PATH]:   '/api2/json/nonexistent',
+        })
+        req.on('response', (h) => resolve(Number(h[constants.HTTP2_HEADER_STATUS])))
+        req.on('error', reject)
+        req.end()
+      })
+
+      expect(status).toBe(404)
+    } finally {
+      session.close()
+    }
+  })
+
+  it('returns 501 for not-yet-implemented protocol upgrade endpoints', async () => {
+    const url = `https://127.0.0.1:${handle.address.port}`
+    const session = h2connect(url, { rejectUnauthorized: false })
+    try {
+      const status = await new Promise<number>((resolve, reject) => {
+        const req = session.request({
+          [constants.HTTP2_HEADER_METHOD]: 'GET',
+          [constants.HTTP2_HEADER_PATH]:   '/api2/json/backup',
+        })
+        req.on('response', (h) => resolve(Number(h[constants.HTTP2_HEADER_STATUS])))
+        req.on('error', reject)
+        req.end()
+      })
+
+      expect(status).toBe(501)
+    } finally {
+      session.close()
+    }
+  })
+
+  it('exposes the cert fingerprint', () => {
+    expect(handle.certFingerprint).toMatch(/^[0-9A-F]{2}(:[0-9A-F]{2}){31}$/)
+  })
+})

--- a/packages/pbs-server/src/server.ts
+++ b/packages/pbs-server/src/server.ts
@@ -1,0 +1,115 @@
+// PBS protocol HTTP/2 listener.
+//
+// Source: port (8007), endpoint shape, and HTTP/2 upgrade discipline are
+// from PBS public docs (https://pbs.proxmox.com/docs/backup-protocol.html
+// and https://pbs.proxmox.com/docs/sysadmin.html). Clean-room.
+
+import { createSecureServer, type Http2SecureServer, type ServerHttp2Session } from 'http2'
+import type { AddressInfo } from 'net'
+import { ensureSelfSignedCert, type CertPaths } from './cert'
+import { handleVersion } from './handlers/version'
+
+export interface StartPbsServerOptions {
+  /** TCP port for the listener. Defaults to 8007 (PBS default). */
+  port?: number
+  /** Bind address. Defaults to 0.0.0.0 (all interfaces). */
+  host?: string
+  /** Where the cert and key live on disk. */
+  certPaths: CertPaths
+  /** Reported version string. Defaults to "4.0.0". */
+  reportedVersion?: string
+  /** Reported release string. Defaults to "1". */
+  reportedRelease?: string
+  /** Optional log function for boot messages. Defaults to console.log. */
+  log?: (msg: string) => void
+}
+
+export interface PbsServerHandle {
+  /** Stop accepting new connections and close the listener. */
+  stop(): Promise<void>
+  /** The advertised cert fingerprint — surface this in the UI. */
+  certFingerprint: string
+  /** Resolved bind address. */
+  address: { host: string; port: number }
+}
+
+export function startPbsServer(opts: StartPbsServerOptions): Promise<PbsServerHandle> {
+  const port = opts.port ?? 8007
+  const host = opts.host ?? '0.0.0.0'
+  const log  = opts.log ?? ((m: string) => console.log(`[pbs-server] ${m}`))
+
+  const cert = ensureSelfSignedCert(opts.certPaths)
+
+  const server = createSecureServer({
+    cert: cert.cert,
+    key:  cert.key,
+    // HTTP/2 will negotiate via ALPN. Allow HTTP/1.1 fallback so the
+    // version endpoint is reachable from curl/HTTP-1.1 clients too.
+    allowHTTP1: true,
+  })
+
+  // Track open sessions so stop() can destroy them immediately rather than
+  // waiting for clients to close — server.close() alone hangs until all
+  // sessions drain naturally.
+  const sessions = new Set<ServerHttp2Session>()
+  server.on('session', (session: ServerHttp2Session) => {
+    sessions.add(session)
+    session.once('close', () => sessions.delete(session))
+  })
+
+  // The 'request' event fires for both HTTP/2 and HTTP/1.1 on Http2SecureServer
+  // with allowHTTP1: true. Using 'stream' in addition would double-handle H2
+  // requests and cause ERR_HTTP2_HEADERS_SENT.
+  server.on('request', (req, res) => {
+    const path = req.url ?? '/'
+    if (req.method === 'GET' && path.startsWith('/api2/json/version')) {
+      const body = JSON.stringify(handleVersion({
+        version: opts.reportedVersion ?? '4.0.0',
+        release: opts.reportedRelease ?? '1',
+      }))
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(body)
+      return
+    }
+    if (req.method === 'GET' && (path.startsWith('/api2/json/backup') || path.startsWith('/api2/json/reader'))) {
+      res.writeHead(501, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ error: 'protocol upgrade endpoints are not yet implemented (M4/M5)' }))
+      return
+    }
+    res.writeHead(404, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ error: 'not found' }))
+  })
+
+  server.on('error', (err) => log(`server error: ${err.message}`))
+
+  return new Promise<PbsServerHandle>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(port, host, () => {
+      server.off('error', reject)
+      const addr = server.address() as AddressInfo | null
+      const boundPort = addr?.port ?? port
+      log(`listening on ${host}:${boundPort}`)
+      log(`cert fingerprint: ${cert.fingerprint}`)
+      resolve({
+        certFingerprint: cert.fingerprint,
+        address: { host, port: boundPort },
+        stop: () => stopServer(server, sessions),
+      })
+    })
+  })
+}
+
+export function stopPbsServer(handle: PbsServerHandle): Promise<void> {
+  return handle.stop()
+}
+
+function stopServer(server: Http2SecureServer, sessions: Set<ServerHttp2Session>): Promise<void> {
+  // Destroy all open sessions first so server.close() callback fires immediately
+  // rather than waiting for clients to send GOAWAY.
+  for (const session of sessions) {
+    session.destroy()
+  }
+  return new Promise<void>((resolve, reject) => {
+    server.close((err) => err ? reject(err) : resolve())
+  })
+}

--- a/packages/pbs-server/vitest.config.ts
+++ b/packages/pbs-server/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

- Boots an HTTPS/HTTP-2 listener on `:8007` alongside Next.js (wired inside `server.listen` callback so it starts after Next.js is bound)
- Self-signed RSA-4096 cert auto-generated on first boot at `/etc/backupos/pbs-cert.pem` (key mode 0600)
- `GET /api2/json/version` returns PBS-compatible `{ data: { version, release, repoid: "backupos" } }` over both HTTP/2 and HTTP/1.1
- 501 stubs for `/api2/json/backup` and `/api2/json/reader` (M4/M5)
- Listener failure logs but does not crash the main app

## After deploy

- `curl -k https://localhost:8007/api2/json/version` returns the version JSON
- Cert fingerprint logged at boot — used by PVE via `pvesm add pbs --fingerprint <hex>`
- **Port 8007 must be opened in firewall:** `sudo ufw allow 8007/tcp`
- Auth deferred to M3b (next PR)

## Test plan

- [x] `pnpm typecheck` — 0 errors (pbs-server + web)
- [x] `pnpm build` — all packages clean
- [x] `pnpm test` — 11/11 passing in 5.3s

## Notes

`apps/web/server.ts` already had a custom boot file (`tsx server.ts`). The PBS listener is added as a `void (async () => { ... })()` block inside the existing `server.listen` callback — no new files created, no start script changed.

Refs M3a of #237. Clean-room implementation; source attribution in code comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)