### PR TITLE
feat(pbs): token auth + management UI (M3b)

### DIFF
--- a/apps/web/app/(dashboard)/pbs/tokens/client.tsx
+++ b/apps/web/app/(dashboard)/pbs/tokens/client.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { createPbsToken, revokePbsToken } from '@/app/actions/pbs-tokens'
+
+interface Token {
+  id:          string
+  user:        string
+  realm:       string
+  tokenName:   string
+  permissions: string
+  expiresAt:   Date | null
+  lastUsedAt:  Date | null
+  createdAt:   Date
+}
+
+export function PbsTokensClient({ initial }: { initial: Token[] }) {
+  const [tokens, setTokens]     = useState(initial)
+  const [newToken, setNewToken] = useState<string | null>(null)
+  const [error, setError]       = useState('')
+  const [pending, startTransition] = useTransition()
+
+  async function handleCreate(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError('')
+    setNewToken(null)
+    const fd = new FormData(e.currentTarget)
+    const result = await createPbsToken(fd)
+    if (result.error) { setError(result.error); return }
+    if (result.token && result.id) {
+      setNewToken(result.token)
+      setTokens(prev => [...prev, {
+        id:          result.id!,
+        user:        String(fd.get('user') ?? ''),
+        realm:       String(fd.get('realm') ?? 'pbs'),
+        tokenName:   String(fd.get('tokenName') ?? ''),
+        permissions: String(fd.get('permissions') ?? 'read'),
+        expiresAt:   fd.get('expires') ? new Date(String(fd.get('expires'))) : null,
+        lastUsedAt:  null,
+        createdAt:   new Date(),
+      }])
+    }
+    ;(e.target as HTMLFormElement).reset()
+  }
+
+  function handleRevoke(id: string) {
+    startTransition(async () => {
+      await revokePbsToken(id)
+      setTokens(t => t.filter(tk => tk.id !== id))
+    })
+  }
+
+  const inputStyle: React.CSSProperties = {
+    padding: '8px 12px', fontSize: 13,
+    backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none',
+    width: '100%',
+  }
+
+  return (
+    <div style={{ maxWidth: 640 }}>
+      <a href="/pbs" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--fg-dim)', textDecoration: 'none', marginBottom: 24 }}>← PBS</a>
+      <h1 style={{ fontSize: 20, fontWeight: 700, color: 'var(--fg)', marginBottom: 4 }}>PBS API tokens</h1>
+      <p style={{ fontSize: 13, color: 'var(--fg-dim)', marginBottom: 28 }}>
+        Tokens authenticate PVE hosts connecting to the PBS-compatible endpoint. Format: <code>user@realm!tokenname:secret</code>
+      </p>
+
+      {newToken && (
+        <div style={{ marginBottom: 20, padding: '12px 16px', backgroundColor: 'var(--surf2)', border: '1px solid var(--success,#22c55e)', borderRadius: 'var(--radius-sm)' }}>
+          <p style={{ fontSize: 13, color: 'var(--fg)', marginBottom: 6, fontWeight: 600 }}>Token created — copy it now, it won&apos;t be shown again:</p>
+          <code style={{ fontSize: 12, wordBreak: 'break-all', color: 'var(--fg)' }}>{newToken}</code>
+        </div>
+      )}
+
+      <form onSubmit={handleCreate} style={{ display: 'grid', gap: 12, marginBottom: 32, padding: '16px', backgroundColor: 'var(--surf2)', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)' }}>
+        <h2 style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', margin: 0 }}>New token</h2>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <div>
+            <label htmlFor="pbs-user" style={{ display: 'block', fontSize: 12, color: 'var(--fg-dim)', marginBottom: 4 }}>User</label>
+            <input id="pbs-user" name="user" required placeholder="root" style={inputStyle} />
+          </div>
+          <div>
+            <label htmlFor="pbs-realm" style={{ display: 'block', fontSize: 12, color: 'var(--fg-dim)', marginBottom: 4 }}>Realm</label>
+            <input id="pbs-realm" name="realm" defaultValue="pbs" required style={inputStyle} />
+          </div>
+          <div>
+            <label htmlFor="pbs-tokenName" style={{ display: 'block', fontSize: 12, color: 'var(--fg-dim)', marginBottom: 4 }}>Token name</label>
+            <input id="pbs-tokenName" name="tokenName" required placeholder="pve-host-1" style={inputStyle} />
+          </div>
+          <div>
+            <label htmlFor="pbs-permissions" style={{ display: 'block', fontSize: 12, color: 'var(--fg-dim)', marginBottom: 4 }}>Permissions</label>
+            <input id="pbs-permissions" name="permissions" defaultValue="read" style={inputStyle} />
+          </div>
+          <div style={{ gridColumn: '1 / -1' }}>
+            <label htmlFor="pbs-expires" style={{ display: 'block', fontSize: 12, color: 'var(--fg-dim)', marginBottom: 4 }}>Expires (optional)</label>
+            <input id="pbs-expires" name="expires" type="datetime-local" style={inputStyle} />
+          </div>
+        </div>
+        {error && <p style={{ fontSize: 12, color: 'var(--error,#ef4444)', margin: 0 }}>{error}</p>}
+        <button type="submit" disabled={pending} style={{ justifySelf: 'start', padding: '8px 16px', fontSize: 13, fontWeight: 500, backgroundColor: 'var(--accent)', color: '#fff', border: 'none', borderRadius: 'var(--radius-sm)', cursor: 'pointer' }}>
+          Create token
+        </button>
+      </form>
+
+      {tokens.length === 0 ? (
+        <p style={{ fontSize: 13, color: 'var(--fg-dim)' }}>No tokens yet.</p>
+      ) : (
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+          <thead>
+            <tr style={{ borderBottom: '1px solid var(--border)' }}>
+              {(['Identity', 'Permissions', 'Expires', 'Last used', ''] as const).map(h => (
+                <th key={h} style={{ textAlign: 'left', padding: '6px 8px', fontSize: 12, color: 'var(--fg-dim)', fontWeight: 500 }}>{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {tokens.map(tk => (
+              <tr key={tk.id} style={{ borderBottom: '1px solid var(--border)' }}>
+                <td style={{ padding: '8px', color: 'var(--fg)' }}>
+                  <code style={{ fontSize: 12 }}>{tk.user}@{tk.realm}!{tk.tokenName}</code>
+                </td>
+                <td style={{ padding: '8px', color: 'var(--fg-dim)' }}>{tk.permissions}</td>
+                <td style={{ padding: '8px', color: 'var(--fg-dim)' }}>{tk.expiresAt ? new Date(tk.expiresAt).toLocaleDateString() : '—'}</td>
+                <td style={{ padding: '8px', color: 'var(--fg-dim)' }}>{tk.lastUsedAt ? new Date(tk.lastUsedAt).toLocaleDateString() : '—'}</td>
+                <td style={{ padding: '8px' }}>
+                  <button
+                    onClick={() => handleRevoke(tk.id)}
+                    disabled={pending}
+                    style={{ padding: '4px 10px', fontSize: 12, backgroundColor: 'transparent', color: 'var(--error,#ef4444)', border: '1px solid var(--error,#ef4444)', borderRadius: 'var(--radius-sm)', cursor: 'pointer' }}
+                  >
+                    Revoke
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/pbs/tokens/page.tsx
+++ b/apps/web/app/(dashboard)/pbs/tokens/page.tsx
@@ -1,0 +1,24 @@
+import { getDb, pbsTokens } from '@backupos/db'
+import { requireAdmin }     from '@/lib/user'
+import { PbsTokensClient }  from './client'
+
+export const dynamic = 'force-dynamic'
+
+export default async function PbsTokensPage() {
+  await requireAdmin()
+  const db   = getDb()
+  const rows = await db.select().from(pbsTokens).orderBy(pbsTokens.createdAt)
+
+  const tokens = rows.map((r) => ({
+    id:          r.id,
+    user:        r.user,
+    realm:       r.realm,
+    tokenName:   r.tokenName,
+    permissions: r.permissions,
+    expiresAt:   r.expiresAt ?? null,
+    lastUsedAt:  r.lastUsedAt ?? null,
+    createdAt:   r.createdAt,
+  }))
+
+  return <PbsTokensClient initial={tokens} />
+}

--- a/apps/web/app/actions/pbs-tokens.ts
+++ b/apps/web/app/actions/pbs-tokens.ts
@@ -1,0 +1,70 @@
+'use server'
+
+import { revalidatePath }                          from 'next/cache'
+import { randomBytes }                             from 'crypto'
+import { getDb, pbsTokens, eq }                    from '@backupos/db'
+import { requireAdmin }                            from '@/lib/user'
+import { generatePbsSecret, hashPbsSecret, formatPbsToken } from '@/lib/pbs-tokens'
+import { appendAuditEntry }                        from '@/lib/audit'
+import { headers }                                 from 'next/headers'
+import { auth }                                    from '@/lib/auth'
+
+export async function createPbsToken(formData: FormData): Promise<{
+  token?: string
+  id?: string
+  error?: string
+}> {
+  await requireAdmin()
+  const { api } = auth
+  const session = await api.getSession({ headers: await headers() })
+  if (!session) return { error: 'Not authenticated' }
+
+  const user      = String(formData.get('user')      ?? '').trim()
+  const realm     = String(formData.get('realm')     ?? 'pbs').trim()
+  const tokenName = String(formData.get('tokenName') ?? '').trim()
+  const perms     = String(formData.get('permissions') ?? 'read').trim()
+  const expiresStr = formData.get('expires') as string | null
+
+  if (!user)      return { error: 'User is required' }
+  if (!realm)     return { error: 'Realm is required' }
+  if (!tokenName) return { error: 'Token name is required' }
+
+  const secret = generatePbsSecret()
+  const hash   = hashPbsSecret(secret)
+  const id     = randomBytes(8).toString('hex')
+
+  const db = getDb()
+  await db.insert(pbsTokens).values({
+    id,
+    user,
+    realm,
+    tokenName,
+    secretHash:  hash,
+    permissions: perms,
+    expiresAt:   expiresStr ? new Date(expiresStr) : undefined,
+    createdAt:   new Date(),
+  })
+
+  await appendAuditEntry({
+    action:       'pbs_token.created',
+    resourceType: 'pbs_token',
+    resourceId:   id,
+    resourceName: `${user}@${realm}!${tokenName}`,
+    actor:        session.user.id,
+  })
+
+  revalidatePath('/pbs/tokens')
+  return { token: formatPbsToken({ user, realm, tokenName, secret }), id }
+}
+
+export async function revokePbsToken(id: string): Promise<void> {
+  await requireAdmin()
+  const db = getDb()
+  await db.delete(pbsTokens).where(eq(pbsTokens.id, id))
+  await appendAuditEntry({
+    action:       'pbs_token.revoked',
+    resourceType: 'pbs_token',
+    resourceId:   id,
+  })
+  revalidatePath('/pbs/tokens')
+}

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -17,6 +17,7 @@ export type AuditAction =
   | 'settings.updated'
   | 'user.created'
   | 'user.role_changed'
+  | 'pbs_token.created' | 'pbs_token.revoked'
 
 function canonical(fields: {
   action: string; resourceType: string; resourceId?: string | null;

--- a/apps/web/lib/pbs-tokens.test.ts
+++ b/apps/web/lib/pbs-tokens.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parsePbsToken,
+  formatPbsToken,
+  generatePbsSecret,
+  hashPbsSecret,
+  verifyPbsSecret,
+  extractPbsAuthHeader,
+} from './pbs-tokens'
+
+describe('parsePbsToken', () => {
+  it('parses a valid token string', () => {
+    const result = parsePbsToken('alice@pbs!backup-agent:supersecret')
+    expect(result).toEqual({
+      user:      'alice',
+      realm:     'pbs',
+      tokenName: 'backup-agent',
+      secret:    'supersecret',
+    })
+  })
+
+  it('returns null when colon is missing', () => {
+    expect(parsePbsToken('alice@pbs!backup-agent')).toBeNull()
+  })
+
+  it('returns null when bang is missing', () => {
+    expect(parsePbsToken('alice@pbs:secret')).toBeNull()
+  })
+
+  it('returns null when @ is missing', () => {
+    expect(parsePbsToken('alicepbs!token:secret')).toBeNull()
+  })
+
+  it('returns null when user is empty', () => {
+    expect(parsePbsToken('@pbs!token:secret')).toBeNull()
+  })
+
+  it('returns null when realm is empty', () => {
+    expect(parsePbsToken('alice@!token:secret')).toBeNull()
+  })
+
+  it('returns null when tokenName is empty', () => {
+    expect(parsePbsToken('alice@pbs!:secret')).toBeNull()
+  })
+
+  it('returns null when secret is empty', () => {
+    expect(parsePbsToken('alice@pbs!token:')).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(parsePbsToken('')).toBeNull()
+  })
+
+  it('uses the first colon as the secret delimiter', () => {
+    const result = parsePbsToken('alice@pbs!token:sec:ret')
+    expect(result?.secret).toBe('sec:ret')
+  })
+})
+
+describe('formatPbsToken', () => {
+  it('formats parts into the canonical token string', () => {
+    expect(formatPbsToken({ user: 'alice', realm: 'pbs', tokenName: 'agent', secret: 'abc' }))
+      .toBe('alice@pbs!agent:abc')
+  })
+
+  it('round-trips through parse', () => {
+    const parts = { user: 'bob', realm: 'realm1', tokenName: 'mytoken', secret: 'xyz' }
+    expect(parsePbsToken(formatPbsToken(parts))).toEqual(parts)
+  })
+})
+
+describe('generatePbsSecret', () => {
+  it('returns a 64-char hex string', () => {
+    expect(generatePbsSecret()).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('returns a different value each call', () => {
+    expect(generatePbsSecret()).not.toBe(generatePbsSecret())
+  })
+})
+
+describe('hashPbsSecret / verifyPbsSecret', () => {
+  it('returns a 64-char hex hash', () => {
+    expect(hashPbsSecret('mysecret')).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('is deterministic', () => {
+    expect(hashPbsSecret('same')).toBe(hashPbsSecret('same'))
+  })
+
+  it('verifies correct secret against stored hash', () => {
+    const hash = hashPbsSecret('correct-horse')
+    expect(verifyPbsSecret('correct-horse', hash)).toBe(true)
+  })
+
+  it('rejects wrong secret', () => {
+    const hash = hashPbsSecret('correct-horse')
+    expect(verifyPbsSecret('wrong-horse', hash)).toBe(false)
+  })
+})
+
+describe('extractPbsAuthHeader', () => {
+  it('extracts the token from a well-formed header', () => {
+    expect(extractPbsAuthHeader('PBSAPIToken=alice@pbs!token:secret'))
+      .toBe('alice@pbs!token:secret')
+  })
+
+  it('returns null for a Bearer header', () => {
+    expect(extractPbsAuthHeader('Bearer sometoken')).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(extractPbsAuthHeader('')).toBeNull()
+  })
+})

--- a/apps/web/lib/pbs-tokens.ts
+++ b/apps/web/lib/pbs-tokens.ts
@@ -1,0 +1,81 @@
+// PBS token utilities — parse, format, generate, hash, and verify.
+//
+// PBS token format (from PBS user-management docs):
+//   <user>@<realm>!<tokenname>:<secret>
+//
+// Authorization header (from PBS forum / pve-storage source):
+//   Authorization: PBSAPIToken=<full-token>
+//
+// Clean-room.
+
+import { createHash, randomBytes, timingSafeEqual } from 'crypto'
+
+export interface PbsTokenParts {
+  user:      string
+  realm:     string
+  tokenName: string
+  secret:    string
+}
+
+/**
+ * Parse `user@realm!tokenname:secret` → parts, or null if malformed.
+ * Validates that all four segments are non-empty.
+ */
+export function parsePbsToken(raw: string): PbsTokenParts | null {
+  const colonIdx = raw.indexOf(':')
+  if (colonIdx === -1) return null
+  const secret    = raw.slice(colonIdx + 1)
+  const identPart = raw.slice(0, colonIdx)
+  if (!secret) return null
+
+  const bangIdx = identPart.indexOf('!')
+  if (bangIdx === -1) return null
+  const tokenName = identPart.slice(bangIdx + 1)
+  const userRealm = identPart.slice(0, bangIdx)
+  if (!tokenName) return null
+
+  const atIdx = userRealm.indexOf('@')
+  if (atIdx === -1) return null
+  const user  = userRealm.slice(0, atIdx)
+  const realm = userRealm.slice(atIdx + 1)
+  if (!user || !realm) return null
+
+  return { user, realm, tokenName, secret }
+}
+
+/** Format `{ user, realm, tokenName, secret }` → `user@realm!tokenname:secret`. */
+export function formatPbsToken(parts: PbsTokenParts): string {
+  return `${parts.user}@${parts.realm}!${parts.tokenName}:${parts.secret}`
+}
+
+/** Generate a cryptographically random 32-byte hex secret. */
+export function generatePbsSecret(): string {
+  return randomBytes(32).toString('hex')
+}
+
+/** Hash a plaintext secret with SHA-256 for storage. */
+export function hashPbsSecret(secret: string): string {
+  return createHash('sha256').update(secret).digest('hex')
+}
+
+/**
+ * Constant-time comparison of a plaintext candidate against a stored SHA-256 hash.
+ * Always hashes the candidate first so both buffers are the same length.
+ */
+export function verifyPbsSecret(candidate: string, storedHash: string): boolean {
+  const candidateHash = hashPbsSecret(candidate)
+  const a = Buffer.from(candidateHash, 'utf8')
+  const b = Buffer.from(storedHash, 'utf8')
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+/**
+ * Extract the raw PBS token from an `Authorization: PBSAPIToken=<token>` header value.
+ * Returns null if the prefix is absent.
+ */
+export function extractPbsAuthHeader(authHeader: string): string | null {
+  const prefix = 'PBSAPIToken='
+  if (!authHeader.startsWith(prefix)) return null
+  return authHeader.slice(prefix.length)
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "tsx server.ts",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@backupos/agent-protocol": "workspace:*",
@@ -47,6 +48,7 @@
     "@types/react-dom": "^19.0.0",
     "@types/ws": "^8.5.0",
     "tailwindcss": "^4.0.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -8,7 +8,7 @@ import type { IncomingMessage } from 'http'
 import next from 'next'
 import { WebSocketServer } from 'ws'
 import type { WebSocket } from 'ws'
-import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, verificationRuns, verificationTests, snapshots, eq, and, desc } from '@backupos/db'
+import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, verificationRuns, verificationTests, snapshots, pbsTokens, eq, and, desc } from '@backupos/db'
 import { ResticEngine } from '@backupos/engine'
 import { parseExpression } from 'cron-parser'
 import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository, resolveFilesystemRestoreStarted, resolveDatabaseRestoreStarted, resolveDatabaseRestoreComplete } from './lib/ws-state'
@@ -862,7 +862,6 @@ void app.prepare().then(() => {
 
     // PBS-compatible protocol listener (port 8007).
     // Boots after Next.js. Cert lives in /var/lib/backupos/pbs/ (writable by service user).
-    // Version endpoint only in M3a; auth and protocol endpoints land in M3b/M4/M5.
     void (async () => {
       try {
         const pbsHandle = await startPbsServer({
@@ -873,6 +872,31 @@ void app.prepare().then(() => {
             keyPath:  process.env['PBS_TLS_KEY']  ?? '/var/lib/backupos/pbs/key.pem',
           },
           log: (msg) => console.log(`[pbs] ${msg}`),
+          authLookup: async (user, realm, tokenName) => {
+            const db = getDb()
+            const rows = await db
+              .select()
+              .from(pbsTokens)
+              .where(
+                and(
+                  eq(pbsTokens.user,      user),
+                  eq(pbsTokens.realm,     realm),
+                  eq(pbsTokens.tokenName, tokenName),
+                )
+              )
+              .limit(1)
+            const row = rows[0]
+            if (!row) return null
+            return {
+              tokenId:     row.id,
+              secretHash:  row.secretHash,
+              user:        row.user,
+              realm:       row.realm,
+              tokenName:   row.tokenName,
+              permissions: row.permissions,
+              expiresAt:   row.expiresAt ?? null,
+            }
+          },
         })
         console.log(`[pbs] cert fingerprint: ${pbsHandle.certFingerprint}`)
       } catch (err) {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -35,6 +35,8 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx"
   ]
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['lib/**/*.test.ts'],
+  },
+})

--- a/packages/pbs-server/src/auth.test.ts
+++ b/packages/pbs-server/src/auth.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { createHash }         from 'crypto'
+import type { IncomingMessage } from 'http'
+import { validatePbsAuth, type AuthLookup, type AuthLookupResult } from './auth'
+
+function makeReq(authHeader?: string): IncomingMessage {
+  return {
+    headers: authHeader ? { authorization: authHeader } : {},
+  } as unknown as IncomingMessage
+}
+
+function hashSecret(s: string): string {
+  return createHash('sha256').update(s).digest('hex')
+}
+
+const SECRET = 'correctsecret123'
+const HASH   = hashSecret(SECRET)
+
+const goodRecord: AuthLookupResult = {
+  tokenId:     'tok-1',
+  secretHash:  HASH,
+  user:        'alice',
+  realm:       'pbs',
+  tokenName:   'ci-agent',
+  permissions: 'read',
+}
+
+const alwaysFound: AuthLookup = async () => goodRecord
+const neverFound:  AuthLookup = async () => null
+
+describe('validatePbsAuth', () => {
+  it('accepts a valid token', async () => {
+    const req = makeReq(`PBSAPIToken=alice@pbs!ci-agent:${SECRET}`)
+    const result = await validatePbsAuth(req, alwaysFound)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.identity.user).toBe('alice')
+      expect(result.identity.tokenId).toBe('tok-1')
+    }
+  })
+
+  it('rejects when Authorization header is absent', async () => {
+    const req = makeReq()
+    const result = await validatePbsAuth(req, alwaysFound)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/missing/)
+  })
+
+  it('rejects a Bearer header (wrong scheme)', async () => {
+    const req = makeReq('Bearer sometoken')
+    const result = await validatePbsAuth(req, alwaysFound)
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects when token is not found', async () => {
+    const req = makeReq(`PBSAPIToken=alice@pbs!ci-agent:${SECRET}`)
+    const result = await validatePbsAuth(req, neverFound)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/not found/)
+  })
+
+  it('rejects an incorrect secret', async () => {
+    const req = makeReq('PBSAPIToken=alice@pbs!ci-agent:wrongsecret')
+    const result = await validatePbsAuth(req, alwaysFound)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/invalid/)
+  })
+
+  it('rejects an expired token', async () => {
+    const expired: AuthLookup = async () => ({
+      ...goodRecord,
+      expiresAt: new Date(Date.now() - 1000),
+    })
+    const req = makeReq(`PBSAPIToken=alice@pbs!ci-agent:${SECRET}`)
+    const result = await validatePbsAuth(req, expired)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/expired/)
+  })
+
+  it('accepts a token whose expiresAt is in the future', async () => {
+    const notYetExpired: AuthLookup = async () => ({
+      ...goodRecord,
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+    const req = makeReq(`PBSAPIToken=alice@pbs!ci-agent:${SECRET}`)
+    const result = await validatePbsAuth(req, notYetExpired)
+    expect(result.ok).toBe(true)
+  })
+
+  it('accepts a token with no expiresAt', async () => {
+    const noExpiry: AuthLookup = async () => ({
+      ...goodRecord,
+      expiresAt: null,
+    })
+    const req = makeReq(`PBSAPIToken=alice@pbs!ci-agent:${SECRET}`)
+    const result = await validatePbsAuth(req, noExpiry)
+    expect(result.ok).toBe(true)
+  })
+})

--- a/packages/pbs-server/src/auth.ts
+++ b/packages/pbs-server/src/auth.ts
@@ -1,0 +1,115 @@
+// PBS token authentication middleware.
+//
+// PBS uses `Authorization: PBSAPIToken=user@realm!tokenname:secret`.
+// This module parses that header, looks up the token via the caller-supplied
+// AuthLookup callback, and performs a constant-time secret comparison.
+//
+// The version endpoint does not require auth (liveness probe); all other
+// endpoints 401 if authLookup is provided and auth fails.
+//
+// Clean-room.
+
+import { createHash, timingSafeEqual } from 'crypto'
+
+export interface AuthLookupResult {
+  tokenId:     string
+  secretHash:  string
+  user:        string
+  realm:       string
+  tokenName:   string
+  permissions: string
+  expiresAt?:  Date | null
+}
+
+/**
+ * Called by the server for every authenticated request.
+ * Look up a token row by (user, realm, tokenName).
+ * Return null if no matching token exists.
+ */
+export type AuthLookup = (
+  user:      string,
+  realm:     string,
+  tokenName: string,
+) => Promise<AuthLookupResult | null>
+
+export interface PbsTokenIdentity {
+  tokenId:     string
+  user:        string
+  realm:       string
+  tokenName:   string
+  permissions: string
+}
+
+export type ValidateResult =
+  | { ok: true;  identity: PbsTokenIdentity }
+  | { ok: false; reason: string }
+
+function parseAuthHeader(
+  authHeader: string,
+): { user: string; realm: string; tokenName: string; secret: string } | null {
+  const prefix = 'PBSAPIToken='
+  if (!authHeader.startsWith(prefix)) return null
+  const raw = authHeader.slice(prefix.length)
+
+  const colonIdx = raw.indexOf(':')
+  if (colonIdx === -1) return null
+  const secret    = raw.slice(colonIdx + 1)
+  const identPart = raw.slice(0, colonIdx)
+  if (!secret) return null
+
+  const bangIdx = identPart.indexOf('!')
+  if (bangIdx === -1) return null
+  const tokenName = identPart.slice(bangIdx + 1)
+  const userRealm = identPart.slice(0, bangIdx)
+  if (!tokenName) return null
+
+  const atIdx = userRealm.indexOf('@')
+  if (atIdx === -1) return null
+  const user  = userRealm.slice(0, atIdx)
+  const realm = userRealm.slice(atIdx + 1)
+  if (!user || !realm) return null
+
+  return { user, realm, tokenName, secret }
+}
+
+function hashSecret(secret: string): string {
+  return createHash('sha256').update(secret).digest('hex')
+}
+
+interface RequestLike {
+  headers: Record<string, string | string[] | undefined>
+}
+
+export async function validatePbsAuth(
+  req:    RequestLike,
+  lookup: AuthLookup,
+): Promise<ValidateResult> {
+  const authHeader = (req.headers['authorization'] as string | undefined) ?? ''
+  const parsed = parseAuthHeader(authHeader)
+  if (!parsed) return { ok: false, reason: 'missing or malformed Authorization header' }
+
+  const record = await lookup(parsed.user, parsed.realm, parsed.tokenName)
+  if (!record) return { ok: false, reason: 'token not found' }
+
+  if (record.expiresAt && record.expiresAt < new Date()) {
+    return { ok: false, reason: 'token expired' }
+  }
+
+  const candidateHash = hashSecret(parsed.secret)
+  const a = Buffer.from(candidateHash, 'utf8')
+  const b = Buffer.from(record.secretHash, 'utf8')
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    return { ok: false, reason: 'invalid secret' }
+  }
+
+  return {
+    ok: true,
+    identity: {
+      tokenId:     record.tokenId,
+      user:        record.user,
+      realm:       record.realm,
+      tokenName:   record.tokenName,
+      permissions: record.permissions,
+    },
+  }
+}

--- a/packages/pbs-server/src/index.ts
+++ b/packages/pbs-server/src/index.ts
@@ -15,3 +15,6 @@ export {
   computeCertFingerprint,
 } from './cert'
 export type { CertPaths, CertMaterial } from './cert'
+
+export { validatePbsAuth } from './auth'
+export type { AuthLookup, AuthLookupResult, PbsTokenIdentity, ValidateResult } from './auth'

--- a/packages/pbs-server/src/server.ts
+++ b/packages/pbs-server/src/server.ts
@@ -8,6 +8,7 @@ import { createSecureServer, type Http2SecureServer, type ServerHttp2Session } f
 import type { AddressInfo } from 'net'
 import { ensureSelfSignedCert, type CertPaths } from './cert'
 import { handleVersion } from './handlers/version'
+import { validatePbsAuth, type AuthLookup } from './auth'
 
 export interface StartPbsServerOptions {
   /** TCP port for the listener. Defaults to 8007 (PBS default). */
@@ -22,6 +23,12 @@ export interface StartPbsServerOptions {
   reportedRelease?: string
   /** Optional log function for boot messages. Defaults to console.log. */
   log?: (msg: string) => void
+  /**
+   * Token lookup callback. When provided, every request is authenticated via
+   * `Authorization: PBSAPIToken=…`; unauthenticated requests receive 401.
+   * When omitted, auth is skipped (useful for integration tests and local dev).
+   */
+  authLookup?: AuthLookup
 }
 
 export interface PbsServerHandle {
@@ -60,7 +67,16 @@ export function startPbsServer(opts: StartPbsServerOptions): Promise<PbsServerHa
   // The 'request' event fires for both HTTP/2 and HTTP/1.1 on Http2SecureServer
   // with allowHTTP1: true. Using 'stream' in addition would double-handle H2
   // requests and cause ERR_HTTP2_HEADERS_SENT.
-  server.on('request', (req, res) => {
+  server.on('request', async (req, res) => {
+    if (opts.authLookup) {
+      const authResult = await validatePbsAuth(req, opts.authLookup)
+      if (!authResult.ok) {
+        res.writeHead(401, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ error: authResult.reason }))
+        return
+      }
+    }
+
     const path = req.url ?? '/'
     if (req.method === 'GET' && path.startsWith('/api2/json/version')) {
       const body = JSON.stringify(handleVersion({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@backupos/monitors':
         specifier: workspace:*
         version: link:../../packages/monitors
+      '@backupos/pbs-server':
+        specifier: workspace:*
+        version: link:../../packages/pbs-server
       '@backupos/restore':
         specifier: workspace:*
         version: link:../../packages/restore
@@ -176,6 +179,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/web-site:
     dependencies:
@@ -355,6 +361,47 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+
+  packages/pbs-protocol:
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/pbs-server:
+    dependencies:
+      '@backupos/pbs-protocol':
+        specifier: workspace:*
+        version: link:../pbs-protocol
+      '@backupos/pbs-storage':
+        specifier: workspace:*
+        version: link:../pbs-storage
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/pbs-storage:
+    dependencies:
+      '@backupos/pbs-protocol':
+        specifier: workspace:*
+        version: link:../pbs-protocol
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/restore:
     dependencies:


### PR DESCRIPTION
## Summary
- **`packages/pbs-server`**: `auth.ts` — `validatePbsAuth` middleware parses `Authorization: PBSAPIToken=user@realm!tokenname:secret`, looks up the token via caller-supplied `AuthLookup` callback, constant-time secret comparison with `timingSafeEqual`
- **`packages/pbs-server`**: `server.ts` — `authLookup?: AuthLookup` option added; all requests get a 401 when auth fails (skipped when option omitted, so existing tests pass unchanged)
- **`apps/web`**: `lib/pbs-tokens.ts` — parse / format / generate / hash / verify helpers for the PBS token format
- **`apps/web`**: `app/actions/pbs-tokens.ts` — `createPbsToken` / `revokePbsToken` server actions, writes audit log entries
- **`apps/web`**: `app/(dashboard)/pbs/tokens` — server + client components for token CRUD UI
- **`apps/web`**: `server.ts` — `authLookup` callback queries the `pbsTokens` table and passes results to the PBS listener
- **`apps/web`**: vitest wired up for `lib/**/*.test.ts`; `*.test.ts` excluded from Next.js tsconfig

## Test plan
- [ ] `pnpm --filter @backupos/pbs-server test` — 19 tests pass (8 new auth tests)
- [ ] `pnpm --filter @backupos/web test` — 21 pbs-tokens tests pass
- [ ] `pnpm --filter @backupos/web exec tsc --noEmit` — no type errors
- [ ] Navigate to `/pbs/tokens`, create a token, verify the one-time secret string is shown
- [ ] Revoke the token, verify it disappears from the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)