### PR TITLE
feat(pbs): datastore creation + UI — milestone 4a (#237)

### DIFF
--- a/apps/web/app/(dashboard)/pbs/client.tsx
+++ b/apps/web/app/(dashboard)/pbs/client.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { deletePbsDatastore }       from '@/app/actions/pbs-datastores'
+import { Button }                   from '@/components/ui/button'
+
+export interface DatastoreRow {
+  id:        string
+  name:      string
+  path:      string
+  createdAt: string
+}
+
+export function DatastoreList({ initialDatastores }: { initialDatastores: DatastoreRow[] }) {
+  const [datastores, setDatastores]  = useState(initialDatastores)
+  const [error, setError]            = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function handleDelete(id: string, name: string) {
+    if (!confirm(
+      `Delete datastore "${name}"?\n\n` +
+      `This permanently removes all chunks and snapshots stored here. ` +
+      `PVE clusters configured to back up to this datastore will fail their next backup.\n\n` +
+      `This cannot be undone.`,
+    )) return
+    setError(null)
+    startTransition(async () => {
+      const result = await deletePbsDatastore(id)
+      if (result.error) { setError(result.error); return }
+      setDatastores(ds => ds.filter(d => d.id !== id))
+    })
+  }
+
+  const th: React.CSSProperties = {
+    textAlign: 'left', padding: '8px 10px', fontSize: 12,
+    color: 'var(--fg-dim)', fontWeight: 500, borderBottom: '1px solid var(--border)',
+  }
+  const td: React.CSSProperties = {
+    padding: '10px', color: 'var(--fg)', borderBottom: '1px solid var(--border)',
+  }
+
+  return (
+    <div>
+      {error && (
+        <div style={{ marginBottom: 12, padding: '10px 14px', fontSize: 13, color: 'var(--err,#ef4444)', border: '1px solid var(--err,#ef4444)', borderRadius: 'var(--radius-sm)' }}>
+          {error}
+        </div>
+      )}
+      <div style={{ border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', overflow: 'hidden' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+          <thead>
+            <tr>
+              <th style={th}>Name</th>
+              <th style={th}>Path</th>
+              <th style={th}>Created</th>
+              <th style={{ ...th, width: 80 }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {datastores.length === 0 ? (
+              <tr>
+                <td colSpan={4} style={{ ...td, textAlign: 'center', color: 'var(--fg-dim)', padding: 32 }}>
+                  No datastores yet
+                </td>
+              </tr>
+            ) : (
+              datastores.map(d => (
+                <tr key={d.id}>
+                  <td style={td}><code style={{ fontSize: 12 }}>{d.name}</code></td>
+                  <td style={{ ...td, color: 'var(--fg-dim)', fontSize: 12 }}><code>{d.path}</code></td>
+                  <td style={{ ...td, color: 'var(--fg-dim)' }}>{new Date(d.createdAt).toLocaleString()}</td>
+                  <td style={{ ...td, textAlign: 'right' }}>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDelete(d.id, d.name)}
+                      disabled={isPending}
+                    >
+                      Delete
+                    </Button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/pbs/datastores/new/client.tsx
+++ b/apps/web/app/(dashboard)/pbs/datastores/new/client.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { createPbsDatastore }       from '@/app/actions/pbs-datastores'
+import { Button }                   from '@/components/ui/button'
+
+export function CreateDatastoreForm() {
+  const [error, setError]            = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function handleSubmit(formData: FormData) {
+    setError(null)
+    startTransition(async () => {
+      const result = await createPbsDatastore(formData)
+      if (result?.error) setError(result.error)
+      // On success the server action calls redirect('/pbs') — we never reach here.
+    })
+  }
+
+  const inputStyle: React.CSSProperties = {
+    display: 'block', width: '100%', padding: '8px 12px', fontSize: 13,
+    backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none',
+    boxSizing: 'border-box',
+  }
+  const labelStyle: React.CSSProperties = {
+    display: 'block', fontSize: 12, color: 'var(--fg-dim)', marginBottom: 4,
+  }
+
+  return (
+    <form action={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div>
+        <label htmlFor="ds-name" style={labelStyle}>Name</label>
+        <input
+          id="ds-name"
+          name="name"
+          required
+          autoFocus
+          placeholder="default"
+          pattern="[a-zA-Z0-9_-]{1,64}"
+          disabled={isPending}
+          style={inputStyle}
+        />
+        <p style={{ fontSize: 12, color: 'var(--fg-dim)', marginTop: 4 }}>
+          Letters, digits, dash, underscore. 1-64 chars. This is the name PVE uses in its
+          datastore configuration. Cannot be changed later.
+        </p>
+      </div>
+
+      {error && (
+        <div style={{ padding: '10px 14px', fontSize: 13, color: 'var(--err,#ef4444)', border: '1px solid var(--err,#ef4444)', borderRadius: 'var(--radius-sm)' }}>
+          {error}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 8 }}>
+        <Button type="submit" variant="primary" disabled={isPending}>
+          {isPending ? 'Creating…' : 'Create datastore'}
+        </Button>
+        <a href="/pbs" style={{ textDecoration: 'none' }}>
+          <Button type="button" variant="ghost" disabled={isPending}>Cancel</Button>
+        </a>
+      </div>
+    </form>
+  )
+}

--- a/apps/web/app/(dashboard)/pbs/datastores/new/page.tsx
+++ b/apps/web/app/(dashboard)/pbs/datastores/new/page.tsx
@@ -1,0 +1,22 @@
+import { redirect }           from 'next/navigation'
+import { getCurrentUser }     from '@/lib/user'
+import { CreateDatastoreForm } from './client'
+
+export default async function NewDatastorePage() {
+  const user = await getCurrentUser()
+  if (!user) redirect('/login')
+  if (user.role !== 'admin') redirect('/dashboard')
+
+  return (
+    <div style={{ maxWidth: 520, padding: '32px 0' }}>
+      <a href="/pbs" style={{ display: 'inline-block', fontSize: 13, color: 'var(--fg-dim)', textDecoration: 'none', marginBottom: 24 }}>← Back to datastores</a>
+      <h1 style={{ fontSize: 22, fontWeight: 700, color: 'var(--fg)', marginBottom: 8 }}>New PBS datastore</h1>
+      <p style={{ fontSize: 13, color: 'var(--fg-dim)', marginBottom: 28 }}>
+        Creates a directory under{' '}
+        <code style={{ fontSize: 12 }}>/var/lib/backupos/pbs/&lt;name&gt;/</code> and pre-allocates the
+        chunk-store layout (65,536 shard directories). This may take a few seconds on the first run.
+      </p>
+      <CreateDatastoreForm />
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/pbs/page.tsx
+++ b/apps/web/app/(dashboard)/pbs/page.tsx
@@ -1,0 +1,47 @@
+import { redirect }      from 'next/navigation'
+import { getDb, pbsDatastores, desc } from '@backupos/db'
+import { getCurrentUser } from '@/lib/user'
+import { Button }         from '@/components/ui/button'
+import { DatastoreList }  from './client'
+
+export const dynamic = 'force-dynamic'
+
+export default async function PbsIndexPage() {
+  const user = await getCurrentUser()
+  if (!user) redirect('/login')
+  if (user.role !== 'admin') redirect('/dashboard')
+
+  const db   = getDb()
+  const rows = await db
+    .select()
+    .from(pbsDatastores)
+    .orderBy(desc(pbsDatastores.createdAt))
+
+  const datastores = rows.map(r => ({
+    id:        r.id,
+    name:      r.name,
+    path:      r.path,
+    createdAt: r.createdAt.toISOString(),
+  }))
+
+  return (
+    <div style={{ maxWidth: 700, padding: '32px 0' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 24 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 700, color: 'var(--fg)', margin: 0 }}>PBS datastores</h1>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <a href="/pbs/tokens" style={{ textDecoration: 'none' }}>
+            <Button variant="ghost" size="sm">Tokens</Button>
+          </a>
+          <a href="/pbs/datastores/new" style={{ textDecoration: 'none' }}>
+            <Button variant="primary" size="sm">New datastore</Button>
+          </a>
+        </div>
+      </div>
+      <p style={{ fontSize: 13, color: 'var(--fg-dim)', marginBottom: 28 }}>
+        Datastores are storage locations for PBS-protocol backups. PVE clusters point at a specific
+        datastore by name when configuring this server as a backup target.
+      </p>
+      <DatastoreList initialDatastores={datastores} />
+    </div>
+  )
+}

--- a/apps/web/app/actions/pbs-datastores.ts
+++ b/apps/web/app/actions/pbs-datastores.ts
@@ -1,0 +1,127 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect }       from 'next/navigation'
+import { rm }             from 'node:fs/promises'
+import { join }           from 'node:path'
+import { randomBytes }    from 'node:crypto'
+import { getDb, pbsDatastores, eq } from '@backupos/db'
+import { FsChunkStore }   from '@backupos/pbs-storage'
+import { requireAdmin }   from '@/lib/user'
+import { appendAuditEntry } from '@/lib/audit'
+
+/**
+ * Root under which each datastore creates a named subdirectory.
+ * Layout: /var/lib/backupos/pbs/<name>/
+ *   ├── .chunks/0000..ffff/       (managed by FsChunkStore)
+ *   └── backups/<type>/<id>/<ts>/ (created on backup completion in M4c+)
+ *
+ * Cert + key from M3a live as siblings at /var/lib/backupos/pbs/cert.pem
+ * and key.pem; they are outside any datastore directory.
+ */
+const PBS_ROOT = '/var/lib/backupos/pbs'
+
+export interface CreatePbsDatastoreResult {
+  id?:    string
+  error?: string
+}
+
+/**
+ * Insert a pbs_datastores row then call FsChunkStore.initialize() to
+ * pre-create the 65536 shard directories. If filesystem init fails the DB
+ * row is rolled back. The reverse (orphaned directories) is left in place —
+ * empty shard dirs are harmless until M6 GC.
+ */
+export async function createPbsDatastore(
+  formData: FormData,
+): Promise<CreatePbsDatastoreResult> {
+  const adminUser = await requireAdmin()
+  const name = (formData.get('name') as string | null)?.trim()
+
+  if (!name) return { error: 'Datastore name is required' }
+  if (!/^[a-zA-Z0-9_-]{1,64}$/.test(name)) {
+    return { error: 'Datastore name must be 1-64 chars: letters, digits, dash, underscore' }
+  }
+
+  const db = getDb()
+
+  const existing = await db
+    .select()
+    .from(pbsDatastores)
+    .where(eq(pbsDatastores.name, name))
+    .limit(1)
+  if (existing.length > 0) {
+    return { error: `A datastore named "${name}" already exists` }
+  }
+
+  const id   = randomBytes(8).toString('hex')
+  const path = join(PBS_ROOT, name)
+
+  await db.insert(pbsDatastores).values({
+    id,
+    name,
+    path,
+    createdAt:       new Date(),
+    pruneSchedule:   null,
+    gcSchedule:      null,
+    lastGcAt:        null,
+    totalSizeBytes:  null,
+    uniqueSizeBytes: null,
+    chunkCount:      null,
+  })
+
+  try {
+    const store = new FsChunkStore({ root: path })
+    await store.initialize()
+  } catch (e) {
+    await db.delete(pbsDatastores).where(eq(pbsDatastores.id, id))
+    return { error: `Failed to initialize chunk store: ${(e as Error).message}` }
+  }
+
+  void appendAuditEntry({
+    action:       'pbs_datastore.created',
+    resourceType: 'pbs_datastore',
+    resourceId:   id,
+    resourceName: name,
+    actor:        adminUser.id,
+    detail:       { name, path },
+  })
+
+  revalidatePath('/pbs')
+  redirect('/pbs')
+}
+
+export async function deletePbsDatastore(id: string): Promise<{ error?: string }> {
+  const adminUser = await requireAdmin()
+  const db = getDb()
+
+  const rows = await db
+    .select()
+    .from(pbsDatastores)
+    .where(eq(pbsDatastores.id, id))
+    .limit(1)
+  if (rows.length === 0) return { error: 'Datastore not found' }
+  const ds = rows[0]!
+
+  // Delete row first. If rm fails, we have an orphan directory —
+  // documented and acceptable. Reverse order would leave the row pointing
+  // at a missing path, which is worse.
+  await db.delete(pbsDatastores).where(eq(pbsDatastores.id, id))
+
+  try {
+    await rm(ds.path, { recursive: true, force: true })
+  } catch (e) {
+    console.error(`[pbs-datastore] failed to remove ${ds.path}:`, e)
+  }
+
+  void appendAuditEntry({
+    action:       'pbs_datastore.deleted',
+    resourceType: 'pbs_datastore',
+    resourceId:   id,
+    actor:        adminUser.id,
+    detail:       { name: ds.name, path: ds.path },
+  })
+
+  revalidatePath('/pbs')
+  return {}
+}

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -18,6 +18,7 @@ export type AuditAction =
   | 'user.created'
   | 'user.role_changed'
   | 'pbs_token.created' | 'pbs_token.revoked'
+  | 'pbs_datastore.created' | 'pbs_datastore.deleted'
 
 function canonical(fields: {
   action: string; resourceType: string; resourceId?: string | null;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@backupos/agent-protocol": "workspace:*",
     "@backupos/pbs-server": "workspace:*",
+    "@backupos/pbs-storage": "workspace:*",
     "@backupos/api": "workspace:*",
     "@backupos/db": "workspace:*",
     "@backupos/docs-content": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@backupos/pbs-server':
         specifier: workspace:*
         version: link:../../packages/pbs-server
+      '@backupos/pbs-storage':
+        specifier: workspace:*
+        version: link:../../packages/pbs-storage
       '@backupos/restore':
         specifier: workspace:*
         version: link:../../packages/restore


### PR DESCRIPTION
## Summary
- **`apps/web/app/actions/pbs-datastores.ts`** — `createPbsDatastore` / `deletePbsDatastore` server actions. Insert row → `FsChunkStore.initialize()` (pre-creates 65,536 shard dirs). If filesystem init fails, the DB row is rolled back. Delete removes the row first, then `rm -rf` the directory.
- **`apps/web/app/(dashboard)/pbs/page.tsx` + `client.tsx`** — datastores list with delete confirmation prompt, links to `/pbs/tokens` and `/pbs/datastores/new`.
- **`apps/web/app/(dashboard)/pbs/datastores/new/`** — create form with name validation (1-64 chars, `[a-zA-Z0-9_-]`). Server-side regex is the source of truth.
- **`apps/web/lib/audit.ts`** — `pbs_datastore.created` / `pbs_datastore.deleted` audit actions added.
- **`apps/web/package.json`** — `@backupos/pbs-storage` workspace dependency added.

## After merge
- Admin can create a PBS datastore via `/pbs/datastores/new`
- Row lands in `pbs_datastores`; directory layout `/var/lib/backupos/pbs/<name>/.chunks/0000..ffff/` is pre-allocated
- Datastore appears in `/pbs` list and can be deleted

## Test plan
- [ ] `pnpm --filter @backupos/web exec tsc --noEmit` — 0 errors
- [ ] Navigate to `/pbs`, verify datastores list renders (empty state)
- [ ] Navigate to `/pbs/datastores/new`, create a datastore named `test-ds`, verify redirect to `/pbs` and row appears
- [ ] Confirm `/var/lib/backupos/pbs/test-ds/.chunks/` exists with shard dirs
- [ ] Delete the datastore, verify row removed and directory deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)