### PR TITLE
fix(pbs): unauthenticated /api2/json/version for PVE liveness probes

### DIFF
--- a/packages/pbs-server/src/server.test.ts
+++ b/packages/pbs-server/src/server.test.ts
@@ -99,3 +99,74 @@ describe('PBS HTTP/2 server', () => {
     expect(handle.certFingerprint).toMatch(/^[0-9A-F]{2}(:[0-9A-F]{2}){31}$/)
   })
 })
+
+describe('PBS HTTP/2 server — auth enforcement', () => {
+  let dir: string
+  let handle: PbsServerHandle
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'pbs-server-auth-test-'))
+    handle = await startPbsServer({
+      port: 0,
+      host: '127.0.0.1',
+      certPaths: {
+        certPath: join(dir, 'cert.pem'),
+        keyPath:  join(dir, 'key.pem'),
+      },
+      log: () => { /* silence */ },
+      authLookup: async () => null,
+    })
+  }, 30_000)
+
+  afterEach(async () => {
+    await handle.stop()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('serves /api2/json/version without an Authorization header', async () => {
+    const url = `https://127.0.0.1:${handle.address.port}`
+    const session = h2connect(url, { rejectUnauthorized: false })
+    try {
+      const res = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+        const req = session.request({
+          [constants.HTTP2_HEADER_METHOD]: 'GET',
+          [constants.HTTP2_HEADER_PATH]:   '/api2/json/version',
+        })
+        let body = ''
+        let status = 0
+        req.on('response', (h) => { status = Number(h[constants.HTTP2_HEADER_STATUS]) })
+        req.setEncoding('utf8')
+        req.on('data', (chunk: string) => { body += chunk })
+        req.on('end', () => resolve({ status, body }))
+        req.on('error', reject)
+        req.end()
+      })
+
+      expect(res.status).toBe(200)
+      const parsed = JSON.parse(res.body) as { data: { version: string } }
+      expect(parsed.data.version).toBeDefined()
+    } finally {
+      session.close()
+    }
+  })
+
+  it('requires auth for /api2/json/backup', async () => {
+    const url = `https://127.0.0.1:${handle.address.port}`
+    const session = h2connect(url, { rejectUnauthorized: false })
+    try {
+      const status = await new Promise<number>((resolve, reject) => {
+        const req = session.request({
+          [constants.HTTP2_HEADER_METHOD]: 'GET',
+          [constants.HTTP2_HEADER_PATH]:   '/api2/json/backup',
+        })
+        req.on('response', (h) => resolve(Number(h[constants.HTTP2_HEADER_STATUS])))
+        req.on('error', reject)
+        req.end()
+      })
+
+      expect(status).toBe(401)
+    } finally {
+      session.close()
+    }
+  })
+})

--- a/packages/pbs-server/src/server.ts
+++ b/packages/pbs-server/src/server.ts
@@ -68,16 +68,10 @@ export function startPbsServer(opts: StartPbsServerOptions): Promise<PbsServerHa
   // with allowHTTP1: true. Using 'stream' in addition would double-handle H2
   // requests and cause ERR_HTTP2_HEADERS_SENT.
   server.on('request', async (req, res) => {
-    if (opts.authLookup) {
-      const authResult = await validatePbsAuth(req, opts.authLookup)
-      if (!authResult.ok) {
-        res.writeHead(401, { 'content-type': 'application/json' })
-        res.end(JSON.stringify({ error: authResult.reason }))
-        return
-      }
-    }
-
     const path = req.url ?? '/'
+
+    // /api2/json/version is unauthenticated. PVE uses this as a liveness
+    // probe before any authentication is configured — same as real PBS behaviour.
     if (req.method === 'GET' && path.startsWith('/api2/json/version')) {
       const body = JSON.stringify(handleVersion({
         version: opts.reportedVersion ?? '4.0.0',
@@ -87,6 +81,16 @@ export function startPbsServer(opts: StartPbsServerOptions): Promise<PbsServerHa
       res.end(body)
       return
     }
+
+    if (opts.authLookup) {
+      const authResult = await validatePbsAuth(req, opts.authLookup)
+      if (!authResult.ok) {
+        res.writeHead(401, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ error: authResult.reason }))
+        return
+      }
+    }
+
     if (req.method === 'GET' && (path.startsWith('/api2/json/backup') || path.startsWith('/api2/json/reader'))) {
       res.writeHead(501, { 'content-type': 'application/json' })
       res.end(JSON.stringify({ error: 'PBS protocol upgrade endpoints are pending — Go service in progress' }))


### PR DESCRIPTION
## Summary

- Move `/api2/json/version` handler **before** the auth gate so PVE can reach it as a liveness probe without a token
- Auth (401) still applies to `/backup`, `/reader`, and all other endpoints
- Matches real PBS behaviour: `/version` is publicly accessible per PBS public docs

## Tests added

- `serves /api2/json/version without an Authorization header` — 200 with `authLookup` configured
- `requires auth for /api2/json/backup` — 401 without a token header

## Test plan

- [ ] `pnpm --filter @backupos/pbs-server test` — all 21 tests pass
- [ ] `pnpm --filter @backupos/pbs-server typecheck` — 0 errors
- [ ] Manual: PVE can reach `/api2/json/version` before configuring a token

🤖 Generated with [Claude Code](https://claude.com/claude-code)