### PR TITLE
fix(install): auto-detect Go installed at /usr/local/go/bin

### DIFF
--- a/scripts/server-install.sh
+++ b/scripts/server-install.sh
@@ -161,7 +161,21 @@ fi
 restic version &>/dev/null || die "restic installed but cannot execute — check architecture"
 ok "restic $(restic version | head -1 | awk '{print $2}')"
 
-# Go (1.22+) for backupos-pbs service
+# Go (1.22+) for backupos-pbs service.
+#
+# Users typically install Go from the official tarball at /usr/local/go/.
+# That puts go at /usr/local/go/bin/go but it's only on $PATH for shells
+# that source /etc/profile.d/go.sh (login shells). sudo non-login bash
+# (which is what runs this script) doesn't get that. Augment PATH here
+# and create symlinks in /usr/local/bin/ so subsequent sudo invocations
+# find go automatically.
+if [[ -x /usr/local/go/bin/go ]] && ! command -v go &>/dev/null; then
+  log "Found Go at /usr/local/go/bin — adding to PATH and linking to /usr/local/bin"
+  export PATH="/usr/local/go/bin:$PATH"
+  ln -sf /usr/local/go/bin/go /usr/local/bin/go
+  ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+fi
+
 if ! command -v go &>/dev/null; then
   die "Go not installed — install Go 1.22+ from https://go.dev/dl/ and re-run"
 fi


### PR DESCRIPTION
## Summary

Install script runs as non-login `sudo bash` and misses Go installed via the official tarball at `/usr/local/go/`. Detect `/usr/local/go/bin/go` automatically, augment `PATH` for the current run, and create idempotent symlinks in `/usr/local/bin/`.

## Behavior

- **Go via tarball, not on PATH** → detects it, links it, continues ✓
- **Go via apt / already on PATH** → unchanged ✓
- **Go not installed at all** → same `die` message as before ✓

## Background

Hit during M4b-go scaffolding deploy (#249) — required a manual `ln -sf` workaround. This makes future installs self-healing.

## Test plan

- [ ] `bash -n scripts/server-install.sh` — syntax OK ✓ (verified locally)
- [ ] Fresh host with Go tarball at `/usr/local/go/` but no symlink: `sudo bash scripts/server-install.sh` finds Go automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)