### PR TITLE
feat(pbs): datastore lookup — M4b-go-datastore-lookup (#237)

### DIFF
--- a/services/backupos-pbs/internal/datastore/datastore.go
+++ b/services/backupos-pbs/internal/datastore/datastore.go
@@ -1,0 +1,95 @@
+// Package datastore provides lookups against the pbs_datastores table.
+//
+// The PBS protocol uses a `?store=<name>` query parameter on backup and
+// reader upgrade requests. This package validates that the name maps to
+// an existing datastore and returns the row's id + path for downstream use.
+//
+// Datastore creation is owned by the Node side (M4a UI). The Go service
+// is read-only for this table.
+package datastore
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+// Datastore is a row from pbs_datastores. We only expose the columns
+// the Go service needs.
+type Datastore struct {
+	ID        string
+	Name      string
+	Path      string
+	CreatedAt time.Time
+}
+
+// ErrNotFound indicates no row matched the requested name.
+var ErrNotFound = errors.New("datastore not found")
+
+// ErrInvalidName indicates the name failed format validation.
+var ErrInvalidName = errors.New("invalid datastore name")
+
+// Same regex as the M4a Node-side createPbsDatastore action:
+// 1-64 chars, letters/digits/dash/underscore.
+var nameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+
+// ValidateName returns ErrInvalidName if the name is not in the expected
+// format. It does NOT check existence; use Lookup for that.
+//
+// Validating shape before hitting the DB lets us reject obvious garbage
+// (e.g. ?store=../etc/passwd) without a query.
+func ValidateName(name string) error {
+	if !nameRegex.MatchString(name) {
+		return ErrInvalidName
+	}
+	return nil
+}
+
+// Lookup looks up a datastore by name.
+type Lookup struct {
+	db *sql.DB
+}
+
+// NewLookup constructs a Lookup using the given DB connection.
+func NewLookup(db *sql.DB) *Lookup {
+	return &Lookup{db: db}
+}
+
+// ByName returns the datastore matching the given name.
+//
+// Returns ErrInvalidName if the name doesn't match the expected format,
+// ErrNotFound if no row matches, or a wrapped error for DB failures.
+func (l *Lookup) ByName(name string) (*Datastore, error) {
+	if err := ValidateName(name); err != nil {
+		return nil, err
+	}
+
+	const query = `
+		SELECT id, name, path, created_at
+		FROM pbs_datastores
+		WHERE name = ?
+		LIMIT 1
+	`
+	var (
+		id           string
+		gotName      string
+		path         string
+		createdMilli int64
+	)
+	err := l.db.QueryRow(query, name).Scan(&id, &gotName, &path, &createdMilli)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("datastore lookup: %w", err)
+	}
+
+	return &Datastore{
+		ID:        id,
+		Name:      gotName,
+		Path:      path,
+		CreatedAt: time.UnixMilli(createdMilli),
+	}, nil
+}

--- a/services/backupos-pbs/internal/datastore/datastore_test.go
+++ b/services/backupos-pbs/internal/datastore/datastore_test.go
@@ -1,0 +1,131 @@
+package datastore
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// setupTestDB creates an in-memory SQLite DB with the pbs_datastores schema
+// and a seeded row for testing.
+//
+// We minimize the schema to only the columns Lookup reads. The full
+// Drizzle-generated schema is not needed for an isolated lookup test.
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE pbs_datastores (
+			id                  TEXT PRIMARY KEY,
+			name                TEXT NOT NULL UNIQUE,
+			path                TEXT NOT NULL,
+			created_at          INTEGER NOT NULL,
+			prune_schedule      TEXT,
+			gc_schedule         TEXT,
+			last_gc_at          INTEGER,
+			total_size_bytes    INTEGER,
+			unique_size_bytes   INTEGER,
+			chunk_count         INTEGER
+		);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.Exec(`
+		INSERT INTO pbs_datastores (id, name, path, created_at)
+		VALUES ('test-id-1', 'default', '/var/lib/backupos/pbs/default', 1735000000000)
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return db
+}
+
+func TestValidateName_Valid(t *testing.T) {
+	cases := []string{
+		"default",
+		"a",
+		"a-b_c",
+		"123",
+		"DataStore_v2",
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_", // 64 chars
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			if err := ValidateName(c); err != nil {
+				t.Errorf("expected valid, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateName_Invalid(t *testing.T) {
+	cases := []string{
+		"",
+		"with spaces",
+		"with/slash",
+		"with.dot",
+		"with:colon",
+		"../etc/passwd",
+		"../../escape",
+		"a" + string(make([]byte, 64)), // > 64 chars
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			if err := ValidateName(c); !errors.Is(err, ErrInvalidName) {
+				t.Errorf("expected ErrInvalidName, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLookup_Success(t *testing.T) {
+	db := setupTestDB(t)
+	l := NewLookup(db)
+
+	ds, err := l.ByName("default")
+	if err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+	if ds.ID != "test-id-1" {
+		t.Errorf("ID: got %q", ds.ID)
+	}
+	if ds.Name != "default" {
+		t.Errorf("Name: got %q", ds.Name)
+	}
+	if ds.Path != "/var/lib/backupos/pbs/default" {
+		t.Errorf("Path: got %q", ds.Path)
+	}
+	if ds.CreatedAt.UnixMilli() != 1735000000000 {
+		t.Errorf("CreatedAt: got %v", ds.CreatedAt)
+	}
+}
+
+func TestLookup_NotFound(t *testing.T) {
+	db := setupTestDB(t)
+	l := NewLookup(db)
+
+	_, err := l.ByName("nonexistent")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestLookup_InvalidNameRejectedWithoutDBQuery(t *testing.T) {
+	db := setupTestDB(t)
+	l := NewLookup(db)
+
+	_, err := l.ByName("../escape")
+	if !errors.Is(err, ErrInvalidName) {
+		t.Errorf("expected ErrInvalidName, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `datastore` package mirroring the `auth` package shape. Validates `?store=<name>` query params with regex (rejects path-traversal before any DB query) and looks up `id` + `path` from `pbs_datastores`.

Used in subsequent `M4b-go-upgrade` to validate the store param before accepting upgrade requests. This PR adds the package only — `main.go` is unchanged.

## New files

| File | Purpose |
|------|---------|
| `internal/datastore/datastore.go` | `ValidateName`, `Lookup`, typed errors |
| `internal/datastore/datastore_test.go` | 5 test cases (in-memory SQLite) |

## Test plan

- [ ] On Linux server: `cd services/backupos-pbs && go test ./...` — all tests pass (~22 total)
- [ ] `go build ./...` — BUILD OK

Closes M4b-go-datastore-lookup milestone of #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)