### PR TITLE
feat(pbs): session lifecycle — M4b-go-session (#237)

### DIFF
--- a/services/backupos-pbs/README.md
+++ b/services/backupos-pbs/README.md
@@ -45,15 +45,18 @@ go run ./cmd/backupos-pbs \
 go test ./...
 ```
 
-## Endpoints (M4b-go-upgrade)
+## Endpoints (M4b-go-session)
 
-| Method | Path | Behavior |
-|--------|------|----------|
-| GET | /api2/json/version | 200 JSON, unauthenticated (PVE liveness probe) |
-| GET | /api2/json/backup | 401 without auth; with `Upgrade: proxmox-backup-protocol-v1` → 101, H2 streams (501 stubs) |
-| GET | /api2/json/reader | 401 without auth; with `Upgrade: proxmox-backup-protocol-v1` → 101, H2 streams (501 stubs) |
-| GET | /api2/json/backup (no upgrade headers) | 501 — caller missing Upgrade headers |
-| any | (other) | 404 |
+| Method | Path | Auth | Upgrade | Result |
+|--------|------|------|---------|--------|
+| GET | /api2/json/version | No | n/a | 200 JSON |
+| any | /api2/json/backup | No | n/a | 401 |
+| any | /api2/json/backup | Yes | No | 501 stub |
+| GET | /api2/json/backup | Yes | Yes (valid params) | 101 → HTTP/2 → all streams 501 |
+| GET | /api2/json/backup | Yes | Yes (invalid params) | 400 |
+| GET | /api2/json/backup | Yes | Yes (datastore not found) | 404 |
+| same shape | /api2/json/reader | | | same as backup |
+| any | (other) | | | 404 |
 
 Authentication uses PBS token format:
 `Authorization: PBSAPIToken=user@realm!tokenname:secret`
@@ -61,6 +64,13 @@ Authentication uses PBS token format:
 The secret is hashed with SHA-256 (no salt) and compared against the
 `secret_hash` column in `pbs_tokens`. This matches the M3b Node
 implementation, so existing tokens validate.
+
+### Session lifecycle
+
+When an upgrade is accepted, a row is inserted into `pbs_active_sessions`
+with `state='backup'` or `state='reader'` BEFORE the 101 response is written.
+When the HTTP/2 connection closes, the row's state is updated to `'aborted'`
+unless M4c-go-finish has already set `state='finished'`.
 
 ## Roadmap
 

--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -6,11 +6,13 @@
 //   - Reads/writes the same SQLite database as the Node service
 //   - Runs alongside backupos.service as a separate systemd unit
 //
-// In M4b-go-upgrade (this PR), endpoints are:
+// In M4b-go-session (this PR), endpoints are:
 //   - GET  /api2/json/version    unauthenticated, 200 JSON
 //   - any  /api2/json/backup     401 without valid auth; with auth: upgrade handshake → H2 streams (501 stubs)
 //   - any  /api2/json/reader     401 without valid auth; with auth: upgrade handshake → H2 streams (501 stubs)
 //
+// On upgrade accept: INSERT pbs_active_sessions (state='backup'/'reader').
+// On connection close: UPDATE state='aborted' unless already 'finished'.
 // Real backup endpoint handlers land in M4c-go-*.
 package main
 
@@ -31,6 +33,7 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/db"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/handlers"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/upgrade"
 )
 
@@ -75,7 +78,8 @@ func main() {
 
 	validator := auth.NewValidator(database)
 	datastoreLookup := datastore.NewLookup(database)
-	upgradeHandler := upgrade.NewHandler(datastoreLookup, upgrade.StubStreamHandler())
+	sessionStore := session.NewStore(database)
+	upgradeHandler := upgrade.NewHandler(datastoreLookup, sessionStore, upgrade.StubStreamHandler())
 
 	cert, err := tls.LoadX509KeyPair(*certPath, *keyPath)
 	if err != nil {
@@ -133,11 +137,8 @@ func main() {
 // requireAuth wraps a handler with PBS token authentication.
 //
 // If the Authorization header is missing or invalid, returns 401.
-// If the token is valid, calls the wrapped handler.
-//
-// On success, the identity is logged but not currently passed to the
-// handler — that becomes important when the upgrade handshake needs
-// the token_id for session creation (M4b-go-session).
+// If the token is valid, attaches the Identity to the request context
+// (via auth.WithIdentity) and calls the wrapped handler.
 func requireAuth(v *auth.Validator, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		authHeader := r.Header.Get("Authorization")
@@ -177,7 +178,8 @@ func requireAuth(v *auth.Validator, next http.HandlerFunc) http.HandlerFunc {
 			"method", r.Method,
 		)
 
-		next(w, r)
+		ctx := auth.WithIdentity(r.Context(), identity)
+		next(w, r.WithContext(ctx))
 	}
 }
 

--- a/services/backupos-pbs/go.mod
+++ b/services/backupos-pbs/go.mod
@@ -3,13 +3,13 @@ module github.com/dariusvorster/backupos/services/backupos-pbs
 go 1.26
 
 require (
+	github.com/google/uuid v1.6.0
 	golang.org/x/net v0.27.0
 	modernc.org/sqlite v1.34.1
 )
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect

--- a/services/backupos-pbs/internal/auth/auth.go
+++ b/services/backupos-pbs/internal/auth/auth.go
@@ -7,6 +7,7 @@
 package auth
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/subtle"
 	"database/sql"
@@ -165,4 +166,21 @@ func (v *Validator) Validate(parsed *ParsedHeader) (*Identity, error) {
 		TokenName:   parsed.TokenName,
 		Permissions: permissions,
 	}, nil
+}
+
+// identityCtxKey is the context key type for stashing an Identity. Unexported
+// so external packages can only access it via WithIdentity / FromContext.
+type identityCtxKey struct{}
+
+// WithIdentity returns a child context that carries the given Identity.
+// The upgrade handler reads this via FromContext to record the token_id
+// on session rows.
+func WithIdentity(ctx context.Context, id *Identity) context.Context {
+	return context.WithValue(ctx, identityCtxKey{}, id)
+}
+
+// FromContext returns the Identity attached by WithIdentity, or nil if none.
+func FromContext(ctx context.Context) *Identity {
+	id, _ := ctx.Value(identityCtxKey{}).(*Identity)
+	return id
 }

--- a/services/backupos-pbs/internal/session/session.go
+++ b/services/backupos-pbs/internal/session/session.go
@@ -1,0 +1,110 @@
+// Package session manages pbs_active_sessions row lifecycle.
+//
+// Sessions are created on upgrade-accepted and finalized when the connection
+// closes. The state column transitions:
+//
+//	'backup' or 'reader'  (initial, set by Begin)
+//	     ↓
+//	'finished' (set by M4c-go-finish when client cleanly closes)
+//	OR
+//	'aborted' (set by Finalize when connection closes without finish)
+//
+// Finalize is idempotent: it only updates if state is still 'backup' or
+// 'reader'. This means a session that's already 'finished' won't be
+// downgraded to 'aborted' by the post-ServeConn cleanup path.
+package session
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Kind identifies whether the session is for backup writes or reader reads.
+// The initial state column value matches Kind (string-equal).
+type Kind string
+
+const (
+	KindBackup Kind = "backup"
+	KindReader Kind = "reader"
+)
+
+// BeginParams carries the data needed to insert a new session row.
+//
+// All foreign keys (TokenID, DatastoreID) must reference existing rows;
+// the caller is expected to have already validated those.
+type BeginParams struct {
+	TokenID     string
+	DatastoreID string
+	BackupType  string // "vm" | "ct" | "host"
+	BackupID    string
+	BackupTime  time.Time
+	Kind        Kind
+}
+
+// Store provides session lifecycle operations against pbs_active_sessions.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore constructs a session Store using the given DB connection.
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// Begin inserts a new session row with state=Kind. Returns the new session id.
+func (s *Store) Begin(p BeginParams) (string, error) {
+	id := uuid.NewString()
+	now := time.Now().UnixMilli()
+
+	const query = `
+		INSERT INTO pbs_active_sessions (
+			id, token_id, datastore_id, backup_type, backup_id, backup_time,
+			started_at, state, scratch_path
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+	`
+	_, err := s.db.Exec(query,
+		id,
+		p.TokenID,
+		p.DatastoreID,
+		p.BackupType,
+		p.BackupID,
+		p.BackupTime.UnixMilli(),
+		now,
+		string(p.Kind),
+	)
+	if err != nil {
+		return "", fmt.Errorf("insert session: %w", err)
+	}
+	return id, nil
+}
+
+// Finalize updates the session's state to 'aborted' IF it's still in the
+// initial 'backup' or 'reader' state. If state is already 'finished'
+// (M4c-go-finish path) or already 'aborted', this is a no-op.
+//
+// Returns nil on success (including no-op). The boolean indicates whether
+// the row was actually updated.
+func (s *Store) Finalize(sessionID string) (bool, error) {
+	const query = `
+		UPDATE pbs_active_sessions
+		SET state = 'aborted'
+		WHERE id = ? AND state IN ('backup', 'reader')
+	`
+	res, err := s.db.Exec(query, sessionID)
+	if err != nil {
+		return false, fmt.Errorf("finalize session: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("rows affected: %w", err)
+	}
+	return rows > 0, nil
+}
+
+// ErrNotFound is returned when no session matches the id.
+// Exposed for future M4c handlers that look up sessions by id during chunk uploads.
+var ErrNotFound = errors.New("session not found")

--- a/services/backupos-pbs/internal/session/session_test.go
+++ b/services/backupos-pbs/internal/session/session_test.go
@@ -1,0 +1,199 @@
+package session
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE pbs_active_sessions (
+			id            TEXT PRIMARY KEY,
+			token_id      TEXT,
+			datastore_id  TEXT,
+			backup_type   TEXT NOT NULL,
+			backup_id     TEXT NOT NULL,
+			backup_time   INTEGER NOT NULL,
+			started_at    INTEGER NOT NULL,
+			state         TEXT NOT NULL,
+			scratch_path  TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestBegin_InsertsRow(t *testing.T) {
+	db := setupTestDB(t)
+	s := NewStore(db)
+
+	id, err := s.Begin(BeginParams{
+		TokenID:     "tok-1",
+		DatastoreID: "ds-1",
+		BackupType:  "vm",
+		BackupID:    "100",
+		BackupTime:  time.Unix(1735000000, 0),
+		Kind:        KindBackup,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id == "" {
+		t.Errorf("expected non-empty id, got empty")
+	}
+
+	var (
+		gotState     string
+		gotTokenID   sql.NullString
+		gotBackupID  string
+		gotBackupTm  int64
+		gotStartedAt int64
+	)
+	err = db.QueryRow(`SELECT state, token_id, backup_id, backup_time, started_at FROM pbs_active_sessions WHERE id = ?`, id).
+		Scan(&gotState, &gotTokenID, &gotBackupID, &gotBackupTm, &gotStartedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotState != "backup" {
+		t.Errorf("state: got %q, want backup", gotState)
+	}
+	if !gotTokenID.Valid || gotTokenID.String != "tok-1" {
+		t.Errorf("token_id: got %v", gotTokenID)
+	}
+	if gotBackupID != "100" {
+		t.Errorf("backup_id: got %q", gotBackupID)
+	}
+	if gotBackupTm != 1735000000000 {
+		t.Errorf("backup_time: got %d", gotBackupTm)
+	}
+	now := time.Now().UnixMilli()
+	if gotStartedAt < now-5000 || gotStartedAt > now+5000 {
+		t.Errorf("started_at: got %d, expected ~%d", gotStartedAt, now)
+	}
+}
+
+func TestBegin_KindReader(t *testing.T) {
+	db := setupTestDB(t)
+	s := NewStore(db)
+
+	id, err := s.Begin(BeginParams{
+		TokenID:     "tok-1",
+		DatastoreID: "ds-1",
+		BackupType:  "vm",
+		BackupID:    "100",
+		BackupTime:  time.Unix(1735000000, 0),
+		Kind:        KindReader,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotState string
+	_ = db.QueryRow(`SELECT state FROM pbs_active_sessions WHERE id = ?`, id).Scan(&gotState)
+	if gotState != "reader" {
+		t.Errorf("state: got %q, want reader", gotState)
+	}
+}
+
+func TestFinalize_FromBackupToAborted(t *testing.T) {
+	db := setupTestDB(t)
+	s := NewStore(db)
+
+	id, _ := s.Begin(BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: time.Unix(1735000000, 0), Kind: KindBackup,
+	})
+
+	updated, err := s.Finalize(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Errorf("expected row updated, got false")
+	}
+
+	var gotState string
+	_ = db.QueryRow(`SELECT state FROM pbs_active_sessions WHERE id = ?`, id).Scan(&gotState)
+	if gotState != "aborted" {
+		t.Errorf("state: got %q, want aborted", gotState)
+	}
+}
+
+func TestFinalize_AlreadyFinishedIsNoop(t *testing.T) {
+	db := setupTestDB(t)
+	s := NewStore(db)
+
+	id, _ := s.Begin(BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: time.Unix(1735000000, 0), Kind: KindBackup,
+	})
+
+	// Simulate M4c-go-finish having set state='finished'
+	_, err := db.Exec(`UPDATE pbs_active_sessions SET state = 'finished' WHERE id = ?`, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := s.Finalize(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Errorf("expected no-op, but row was updated")
+	}
+
+	var gotState string
+	_ = db.QueryRow(`SELECT state FROM pbs_active_sessions WHERE id = ?`, id).Scan(&gotState)
+	if gotState != "finished" {
+		t.Errorf("state should remain finished, got %q", gotState)
+	}
+}
+
+func TestFinalize_AlreadyAbortedIsNoop(t *testing.T) {
+	db := setupTestDB(t)
+	s := NewStore(db)
+
+	id, _ := s.Begin(BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: time.Unix(1735000000, 0), Kind: KindBackup,
+	})
+
+	if _, err := s.Finalize(id); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := s.Finalize(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Errorf("second Finalize: expected no-op, but row was updated")
+	}
+}
+
+func TestFinalize_NonexistentIDIsNoop(t *testing.T) {
+	db := setupTestDB(t)
+	s := NewStore(db)
+
+	updated, err := s.Finalize("does-not-exist")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Errorf("expected no-op for nonexistent ID")
+	}
+}

--- a/services/backupos-pbs/internal/upgrade/handler.go
+++ b/services/backupos-pbs/internal/upgrade/handler.go
@@ -11,7 +11,9 @@ import (
 
 	"golang.org/x/net/http2"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 )
 
 // UpgradeToken is the custom Upgrade header value PVE sends for backup
@@ -23,37 +25,40 @@ const UpgradeToken = "proxmox-backup-protocol-v1"
 //  1. Validate the Upgrade headers (Connection: Upgrade, Upgrade: proxmox-backup-protocol-v1)
 //  2. Parse and validate the query parameters
 //  3. Look up the datastore by name
-//  4. Hijack the underlying TCP connection
-//  5. Write 101 Switching Protocols
-//  6. Hand the connection to http2.Server.ServeConn
-//  7. The H2 server dispatches streams to streamHandler (501 stubs in this PR)
+//  4. Insert a pbs_active_sessions row (state='backup' or 'reader')
+//  5. Hijack the underlying TCP connection
+//  6. Write 101 Switching Protocols
+//  7. Hand the connection to http2.Server.ServeConn
+//  8. Finalize the session row (state='aborted') when the connection closes
 //
 // Auth must already have passed before this handler is called — the caller
-// is expected to wrap this with the requireAuth middleware.
+// is expected to wrap this with the requireAuth middleware, which also
+// attaches the Identity to the request context via auth.WithIdentity.
 type Handler struct {
 	datastores    *datastore.Lookup
+	sessions      *session.Store
 	streamHandler http.Handler
 }
 
 // NewHandler constructs a new upgrade Handler.
 //
 // streamHandler is the http.Handler invoked for each HTTP/2 stream after the
-// upgrade succeeds. In M4b-go-upgrade this is a 501-stub; M4c-go-* PRs replace
+// upgrade succeeds. In M4b-go-session this is a 501-stub; M4c-go-* PRs replace
 // it with real backup endpoint handlers.
-func NewHandler(datastores *datastore.Lookup, streamHandler http.Handler) *Handler {
+func NewHandler(datastores *datastore.Lookup, sessions *session.Store, streamHandler http.Handler) *Handler {
 	return &Handler{
 		datastores:    datastores,
+		sessions:      sessions,
 		streamHandler: streamHandler,
 	}
 }
 
 // ServeHTTP implements http.Handler. The auth middleware is expected to
-// have already gated this; we don't re-check Authorization here.
+// have already gated this and attached the Identity to the context.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Step 1: Validate Upgrade headers.
 	if !hasUpgradeHeaders(r) {
 		// Fallback to 501 — caller used /backup or /reader without upgrade.
-		// This matches the existing M4b-go-auth stub behavior.
 		writeStub501(w, identifyKind(r.URL.Path))
 		return
 	}
@@ -91,18 +96,48 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Step 4: Hijack the connection.
+	// Step 4: Begin session row (token from context, set by requireAuth).
+	identity := auth.FromContext(r.Context())
+	if identity == nil {
+		// Should be impossible — requireAuth always attaches identity.
+		// Defensive: refuse the upgrade rather than insert a row with NULL token_id.
+		slog.Error("upgrade reached without auth identity in context")
+		writeUpgradeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	kind := session.KindBackup
+	if identifyKind(r.URL.Path) == "reader" {
+		kind = session.KindReader
+	}
+
+	sessionID, err := h.sessions.Begin(session.BeginParams{
+		TokenID:     identity.TokenID,
+		DatastoreID: ds.ID,
+		BackupType:  string(params.BackupType),
+		BackupID:    params.BackupID,
+		BackupTime:  params.BackupTime,
+		Kind:        kind,
+	})
+	if err != nil {
+		slog.Error("session begin failed", "error", err, "datastore_id", ds.ID)
+		writeUpgradeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	// Step 5: Hijack the connection.
 	hj, ok := w.(http.Hijacker)
 	if !ok {
-		// Should never happen with the standard http.Server, but the
-		// type system requires us to check.
+		// Should never happen with the standard http.Server.
 		slog.Error("ResponseWriter does not support hijacking")
 		writeUpgradeError(w, http.StatusInternalServerError, "hijack not supported")
+		_, _ = h.sessions.Finalize(sessionID)
 		return
 	}
 	conn, brw, err := hj.Hijack()
 	if err != nil {
 		slog.Error("hijack failed", "error", err)
+		_, _ = h.sessions.Finalize(sessionID)
 		return
 	}
 	// After Hijack, we own conn. ServeConn (below) blocks until the connection
@@ -112,6 +147,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"path", r.URL.Path,
 		"store", params.Store,
 		"datastore_id", ds.ID,
+		"session_id", sessionID,
 		"backup_type", params.BackupType,
 		"backup_id", params.BackupID,
 		"backup_time", params.BackupTime,
@@ -119,14 +155,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"remote", r.RemoteAddr,
 	)
 
-	// Step 5: Write the 101 response.
+	// Step 6: Write the 101 response.
 	if err := writeSwitchingProtocols(brw); err != nil {
-		slog.Error("failed to write 101", "error", err)
+		slog.Error("failed to write 101", "error", err, "session_id", sessionID)
 		_ = conn.Close()
+		_, _ = h.sessions.Finalize(sessionID)
 		return
 	}
 
-	// Step 6: Hand off to http2.Server.
+	// Step 7: Hand off to http2.Server.
 	//
 	// We construct a per-connection http2.Server. This matches the
 	// pmoxs3backuproxy reference architecture and gives us a clean place
@@ -144,9 +181,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// expects as its default state.
 	})
 
+	// Step 8: Finalize on connection close.
+	updated, finErr := h.sessions.Finalize(sessionID)
+	if finErr != nil {
+		slog.Error("session finalize failed", "error", finErr, "session_id", sessionID)
+	}
 	slog.Info("upgrade connection closed",
 		"path", r.URL.Path,
 		"datastore_id", ds.ID,
+		"session_id", sessionID,
+		"finalized_to_aborted", updated,
 	)
 }
 

--- a/services/backupos-pbs/internal/upgrade/handler_test.go
+++ b/services/backupos-pbs/internal/upgrade/handler_test.go
@@ -14,7 +14,9 @@ import (
 
 	_ "modernc.org/sqlite"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 )
 
 func setupTestDB(t *testing.T) *sql.DB {
@@ -36,6 +38,18 @@ func setupTestDB(t *testing.T) *sql.DB {
 		);
 		INSERT INTO pbs_datastores (id, name, path, created_at)
 		VALUES ('test-ds-1', 'default', '/tmp/test-ds', 1735000000000);
+
+		CREATE TABLE pbs_active_sessions (
+			id            TEXT PRIMARY KEY,
+			token_id      TEXT,
+			datastore_id  TEXT,
+			backup_type   TEXT NOT NULL,
+			backup_id     TEXT NOT NULL,
+			backup_time   INTEGER NOT NULL,
+			started_at    INTEGER NOT NULL,
+			state         TEXT NOT NULL,
+			scratch_path  TEXT
+		);
 	`)
 	if err != nil {
 		t.Fatal(err)
@@ -43,11 +57,27 @@ func setupTestDB(t *testing.T) *sql.DB {
 	return db
 }
 
+// wrapWithTestIdentity injects a synthetic auth.Identity into the request
+// context, simulating what requireAuth does in production. Tests that bypass
+// the auth middleware need this wrapper so the upgrade handler can read the
+// identity for session row creation.
+func wrapWithTestIdentity(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.WithIdentity(r.Context(), &auth.Identity{
+			TokenID:   "test-token-id",
+			User:      "root",
+			Realm:     "pbs",
+			TokenName: "test1",
+		})
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 func TestHandler_NoUpgradeHeaders_Returns501(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), StubStreamHandler())
+	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), StubStreamHandler())
 
-	srv := httptest.NewServer(h)
+	srv := httptest.NewServer(wrapWithTestIdentity(h))
 	defer srv.Close()
 
 	resp, err := http.Get(srv.URL + "/api2/json/backup?store=default&backup-type=vm&backup-id=1&backup-time=1735000000")
@@ -63,9 +93,9 @@ func TestHandler_NoUpgradeHeaders_Returns501(t *testing.T) {
 
 func TestHandler_InvalidParams_Returns400(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), StubStreamHandler())
+	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), StubStreamHandler())
 
-	srv := httptest.NewServer(h)
+	srv := httptest.NewServer(wrapWithTestIdentity(h))
 	defer srv.Close()
 
 	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/backup?store=default", nil)
@@ -84,9 +114,9 @@ func TestHandler_InvalidParams_Returns400(t *testing.T) {
 
 func TestHandler_DatastoreNotFound_Returns404(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), StubStreamHandler())
+	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), StubStreamHandler())
 
-	srv := httptest.NewServer(h)
+	srv := httptest.NewServer(wrapWithTestIdentity(h))
 	defer srv.Close()
 
 	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/backup?store=nonexistent&backup-type=vm&backup-id=1&backup-time=1735000000", nil)
@@ -109,16 +139,17 @@ func TestHandler_DatastoreNotFound_Returns404(t *testing.T) {
 //  3. Drive HTTP/2 over the same connection
 //  4. Issue an H2 GET request
 //  5. Receive 501 from the stub stream handler
+//  6. Verify session row was created and finalized to 'aborted'
 //
 // This is the moment-of-truth integration test — the same dance that
 // crashed Node in PR #244.
 func TestHandler_FullUpgradeDance(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), StubStreamHandler())
+	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), StubStreamHandler())
 
 	// Use a TLS test server. EnableHTTP2=false so the test server doesn't
 	// negotiate H2 via ALPN — we want to drive the upgrade manually.
-	srv := httptest.NewUnstartedServer(h)
+	srv := httptest.NewUnstartedServer(wrapWithTestIdentity(h))
 	srv.EnableHTTP2 = false
 	srv.StartTLS()
 	defer srv.Close()
@@ -193,5 +224,22 @@ func TestHandler_FullUpgradeDance(t *testing.T) {
 	// Step 5: expect 501 from StubStreamHandler.
 	if resp.StatusCode != http.StatusNotImplemented {
 		t.Errorf("expected 501 from stub stream handler, got %d", resp.StatusCode)
+	}
+
+	// Close the connection so ServeConn returns and the finalize runs.
+	tlsConn.Close()
+	// Give the server goroutine a moment to finalize the session row.
+	time.Sleep(100 * time.Millisecond)
+
+	// Step 6: verify session row was created and finalized to 'aborted'.
+	var rowCount int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM pbs_active_sessions`).Scan(&rowCount)
+	if rowCount != 1 {
+		t.Errorf("expected 1 session row, got %d", rowCount)
+	}
+	var state string
+	_ = db.QueryRow(`SELECT state FROM pbs_active_sessions LIMIT 1`).Scan(&state)
+	if state != "aborted" {
+		t.Errorf("expected state='aborted' after connection close, got %q", state)
 	}
 }


### PR DESCRIPTION
## Summary

- First DB write path from Go — `pbs_active_sessions` row inserted on upgrade accept, finalized on connection close
- `internal/session/session.go`: `Store` with `Begin` (INSERT) and `Finalize` (idempotent UPDATE → `'aborted'`)
- `internal/auth/auth.go`: adds `WithIdentity` / `FromContext` context helpers so the upgrade handler can read `token_id` without changing the middleware signature
- `cmd/backupos-pbs/main.go`: `requireAuth` now attaches identity to context; `session.NewStore` wired into `upgrade.NewHandler`
- `internal/upgrade/handler.go`: `Begin` before writing 101; `Finalize` after `ServeConn` returns; defensive `Finalize` on all early-return error paths after session creation; `session_id` added to all upgrade log events
- `internal/upgrade/handler_test.go`: all `NewHandler` calls updated for new signature; `wrapWithTestIdentity` injects auth context; `TestHandler_FullUpgradeDance` now verifies session row is created and finalized to `'aborted'`

## State machine

| State | Set by |
|-------|--------|
| `'backup'` | `Begin` (this PR) |
| `'reader'` | `Begin` (this PR) |
| `'finished'` | M4c-go-finish (future) |
| `'aborted'` | `Finalize` (this PR) |

`Finalize` only transitions `backup`/`reader` → `aborted`. Already-`finished` or already-`aborted` rows are no-ops, so M4c-go-finish can safely set `'finished'` before the connection closes.

## Test plan

- [ ] `go mod tidy` on Linux server (promotes `github.com/google/uuid` to direct in go.sum)
- [ ] `go build ./cmd/backupos-pbs` — clean build
- [ ] `go test ./internal/session/...` — 6 lifecycle tests pass (Begin, KindReader, Finalize transitions, idempotency, nonexistent ID)
- [ ] `go test ./internal/upgrade/...` — all 4 handler tests pass; `TestHandler_FullUpgradeDance` now also asserts `state='aborted'` after connection close
- [ ] `go test ./...` — all packages pass (~40+ tests total)
- [ ] Clean up stale session rows on deploy: `sqlite3 /var/lib/backupos/backupos.db "UPDATE pbs_active_sessions SET state='aborted' WHERE state IN ('backup','reader');"`

> **NOTE:** Go not on dev Mac — run `go mod tidy && go test ./...` on Linux before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)