### PR TITLE
feat(pbs): POST /blob handler — M4c-go-blob (#237)

### DIFF
--- a/services/backupos-pbs/README.md
+++ b/services/backupos-pbs/README.md
@@ -45,18 +45,27 @@ go run ./cmd/backupos-pbs \
 go test ./...
 ```
 
-## Endpoints (M4b-go-session)
+## Endpoints (M4c-go-blob)
+
+### HTTP/1.1 surface (upgrade handshake)
 
 | Method | Path | Auth | Upgrade | Result |
 |--------|------|------|---------|--------|
 | GET | /api2/json/version | No | n/a | 200 JSON |
 | any | /api2/json/backup | No | n/a | 401 |
 | any | /api2/json/backup | Yes | No | 501 stub |
-| GET | /api2/json/backup | Yes | Yes (valid params) | 101 → HTTP/2 → all streams 501 |
+| GET | /api2/json/backup | Yes | Yes (valid params) | 101 → HTTP/2 |
 | GET | /api2/json/backup | Yes | Yes (invalid params) | 400 |
 | GET | /api2/json/backup | Yes | Yes (datastore not found) | 404 |
 | same shape | /api2/json/reader | | | same as backup |
 | any | (other) | | | 404 |
+
+### HTTP/2 stream handlers (after upgrade)
+
+| Method | Path | Query params | Result |
+|--------|------|-------------|--------|
+| POST | /blob | `file-name=X.blob&encoded-size=N` | 200, blob written atomically to snapshot dir |
+| any other | (any) | | 501 stub (M4c-go-finish, M4c-go-fixed-index, etc. follow) |
 
 Authentication uses PBS token format:
 `Authorization: PBSAPIToken=user@realm!tokenname:secret`
@@ -71,6 +80,18 @@ When an upgrade is accepted, a row is inserted into `pbs_active_sessions`
 with `state='backup'` or `state='reader'` BEFORE the 101 response is written.
 When the HTTP/2 connection closes, the row's state is updated to `'aborted'`
 unless M4c-go-finish has already set `state='finished'`.
+
+### Snapshot directory layout
+
+Blobs are written atomically to:
+
+```
+<datastore-root>/<backup-type>/<backup-id>/<RFC3339-Z>/
+  <file>.blob    ← this PR
+  <file>.fidx    ← M4c-go-fixed-index
+  <file>.didx    ← M4c-go-dynamic-index
+  index.json     ← M4c-go-finish
+```
 
 ## Roadmap
 

--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -6,14 +6,14 @@
 //   - Reads/writes the same SQLite database as the Node service
 //   - Runs alongside backupos.service as a separate systemd unit
 //
-// In M4b-go-session (this PR), endpoints are:
+// In M4c-go-blob (this PR), endpoints are:
 //   - GET  /api2/json/version    unauthenticated, 200 JSON
-//   - any  /api2/json/backup     401 without valid auth; with auth: upgrade handshake → H2 streams (501 stubs)
-//   - any  /api2/json/reader     401 without valid auth; with auth: upgrade handshake → H2 streams (501 stubs)
+//   - any  /api2/json/backup     401 without valid auth; with auth: upgrade handshake → H2 streams
+//   - any  /api2/json/reader     401 without valid auth; with auth: upgrade handshake → H2 streams
 //
-// On upgrade accept: INSERT pbs_active_sessions (state='backup'/'reader').
-// On connection close: UPDATE state='aborted' unless already 'finished'.
-// Real backup endpoint handlers land in M4c-go-*.
+// Over the H2 connection:
+//   - POST /blob    write opaque blob atomically to snapshot directory (200)
+//   - any other     501 stub (M4c-go-finish, M4c-go-fixed-index, etc. follow)
 package main
 
 import (
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/blob"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/db"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/handlers"
@@ -79,7 +80,12 @@ func main() {
 	validator := auth.NewValidator(database)
 	datastoreLookup := datastore.NewLookup(database)
 	sessionStore := session.NewStore(database)
-	upgradeHandler := upgrade.NewHandler(datastoreLookup, sessionStore, upgrade.StubStreamHandler())
+	upgradeHandler := upgrade.NewHandler(
+		datastoreLookup,
+		sessionStore,
+		blob.NewHandler(),
+		upgrade.StubStreamHandler(),
+	)
 
 	cert, err := tls.LoadX509KeyPair(*certPath, *keyPath)
 	if err != nil {

--- a/services/backupos-pbs/internal/blob/blob.go
+++ b/services/backupos-pbs/internal/blob/blob.go
@@ -1,0 +1,248 @@
+// Package blob implements the POST /blob endpoint of the PBS backup protocol.
+//
+// Wire format:
+//
+//	POST /blob?file-name=<name>.blob&encoded-size=<N> HTTP/2
+//	<body: N bytes of opaque blob data>
+//
+// The server treats the body as opaque — PBS uses a 12-byte magic header +
+// zstd payload, but we don't parse it. We just write the bytes atomically
+// into the snapshot directory at <snapshot-dir>/<file-name>.
+package blob
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snapshot"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+// maxBlobSize is a generous safety bound to avoid unbounded reads on a
+// misbehaving client. Realistic PBS blobs are <1 MiB.
+const maxBlobSize int64 = 256 * 1024 * 1024 // 256 MiB
+
+// fileNameRegex matches valid blob file names. Must end in .blob.
+var fileNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_.-]+\.blob$`)
+
+type errBadRequest struct{ msg string }
+
+func (e *errBadRequest) Error() string { return e.msg }
+
+// Handler implements POST /blob.
+type Handler struct{}
+
+// NewHandler constructs a blob handler.
+func NewHandler() *Handler {
+	return &Handler{}
+}
+
+// ServeHTTP routes POST /blob → upload; any other method → 405.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil {
+		slog.Error("blob handler invoked without streamctx")
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	fileName, encodedSize, err := parseQuery(r.URL.Query())
+	if err != nil {
+		var bad *errBadRequest
+		if errors.As(err, &bad) {
+			slog.Info("blob rejected: bad request",
+				"reason", bad.msg,
+				"session_id", sc.SessionID,
+				"remote", r.RemoteAddr,
+			)
+			writeError(w, http.StatusBadRequest, bad.msg)
+			return
+		}
+		slog.Error("blob query parse failed", "error", err, "session_id", sc.SessionID)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	snapDir, err := snapshot.EnsureDir(sc.DatastoreRoot, sc.BackupType, sc.BackupID, sc.BackupTime)
+	if err != nil {
+		slog.Error("snapshot dir ensure failed",
+			"error", err,
+			"session_id", sc.SessionID,
+			"datastore_root", sc.DatastoreRoot,
+		)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	// +1 to detect over-cap without reading the full excess into memory
+	body := io.LimitReader(r.Body, maxBlobSize+1)
+	tmpPath, written, err := writeTempFile(snapDir, fileName, body)
+	if err != nil {
+		slog.Error("blob write failed",
+			"error", err,
+			"session_id", sc.SessionID,
+			"file_name", fileName,
+		)
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+		writeError(w, http.StatusInternalServerError, "write failed")
+		return
+	}
+
+	if written > maxBlobSize {
+		_ = os.Remove(tmpPath)
+		slog.Info("blob rejected: size exceeds cap",
+			"session_id", sc.SessionID,
+			"file_name", fileName,
+			"max", maxBlobSize,
+			"written", written,
+		)
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("blob exceeds maximum size of %d bytes", maxBlobSize))
+		return
+	}
+
+	if written != encodedSize {
+		_ = os.Remove(tmpPath)
+		slog.Info("blob rejected: size mismatch",
+			"session_id", sc.SessionID,
+			"file_name", fileName,
+			"expected", encodedSize,
+			"actual", written,
+		)
+		writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("body size %d does not match encoded-size %d", written, encodedSize))
+		return
+	}
+
+	finalPath := filepath.Join(snapDir, fileName)
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		_ = os.Remove(tmpPath)
+		slog.Error("blob rename failed",
+			"error", err,
+			"session_id", sc.SessionID,
+			"file_name", fileName,
+		)
+		writeError(w, http.StatusInternalServerError, "rename failed")
+		return
+	}
+
+	// fsync parent dir so the rename is durable on power loss.
+	if err := fsyncDir(snapDir); err != nil {
+		slog.Warn("blob parent fsync failed (file kept)",
+			"error", err,
+			"session_id", sc.SessionID,
+			"snapshot_dir", snapDir,
+		)
+	}
+
+	slog.Info("blob written",
+		"session_id", sc.SessionID,
+		"file_name", fileName,
+		"size", written,
+		"path", finalPath,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"data":null}`))
+}
+
+// parseQuery extracts and validates ?file-name and ?encoded-size.
+func parseQuery(q map[string][]string) (fileName string, encodedSize int64, err error) {
+	getOne := func(k string) string {
+		v := q[k]
+		if len(v) == 0 {
+			return ""
+		}
+		return v[0]
+	}
+
+	fileName = getOne("file-name")
+	if fileName == "" {
+		return "", 0, &errBadRequest{`missing required parameter "file-name"`}
+	}
+	if !fileNameRegex.MatchString(fileName) {
+		return "", 0, &errBadRequest{`invalid "file-name" — must match [A-Za-z0-9_.-]+\.blob`}
+	}
+	if len(fileName) > 128 {
+		return "", 0, &errBadRequest{`"file-name" too long (max 128 chars)`}
+	}
+
+	encodedSizeRaw := getOne("encoded-size")
+	if encodedSizeRaw == "" {
+		return "", 0, &errBadRequest{`missing required parameter "encoded-size"`}
+	}
+	encodedSize, err = strconv.ParseInt(encodedSizeRaw, 10, 64)
+	if err != nil || encodedSize < 0 {
+		return "", 0, &errBadRequest{`invalid "encoded-size" — must be a non-negative integer`}
+	}
+	if encodedSize > maxBlobSize {
+		return "", 0, &errBadRequest{fmt.Sprintf(`"encoded-size" exceeds maximum of %d`, maxBlobSize)}
+	}
+
+	return fileName, encodedSize, nil
+}
+
+// writeTempFile streams body into a temp file inside dir. Returns the temp
+// path and bytes written. Caller removes the temp file on any failure path.
+func writeTempFile(dir, baseName string, body io.Reader) (path string, written int64, err error) {
+	suffix := make([]byte, 8)
+	if _, err := rand.Read(suffix); err != nil {
+		return "", 0, fmt.Errorf("random suffix: %w", err)
+	}
+	tmpName := fmt.Sprintf(".%s.tmp.%s", baseName, hex.EncodeToString(suffix))
+	tmpPath := filepath.Join(dir, tmpName)
+
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return "", 0, fmt.Errorf("open temp: %w", err)
+	}
+
+	written, err = io.Copy(f, body)
+	if err != nil {
+		_ = f.Close()
+		return tmpPath, written, fmt.Errorf("copy body: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return tmpPath, written, fmt.Errorf("fsync: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return tmpPath, written, fmt.Errorf("close: %w", err)
+	}
+	return tmpPath, written, nil
+}
+
+// fsyncDir fsyncs a directory inode for durability of recent renames.
+func fsyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}
+
+// writeError emits a standard JSON error response.
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/blob/blob_test.go
+++ b/services/backupos-pbs/internal/blob/blob_test.go
@@ -1,0 +1,201 @@
+package blob
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+func makeReq(t *testing.T, dataRoot string, query, body string) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/blob?"+query, strings.NewReader(body))
+	r = r.WithContext(streamctx.WithSession(r.Context(), &streamctx.SessionContext{
+		SessionID:     "sess-test",
+		DatastoreID:   "ds-test",
+		DatastoreRoot: dataRoot,
+		BackupType:    "vm",
+		BackupID:      "100",
+		BackupTime:    time.Unix(1735000000, 0),
+	}))
+	return r
+}
+
+func TestHandler_HappyPath(t *testing.T) {
+	tmp := t.TempDir()
+	h := NewHandler()
+	body := "the body bytes"
+	r := makeReq(t, tmp, "file-name=test.blob&encoded-size=14", body)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	wrote, err := os.ReadFile(filepath.Join(tmp, "vm", "100", "2024-12-24T00:26:40Z", "test.blob"))
+	if err != nil {
+		t.Fatalf("blob not written: %v", err)
+	}
+	if string(wrote) != body {
+		t.Errorf("body mismatch: got %q, want %q", string(wrote), body)
+	}
+}
+
+func TestHandler_ResponseShape(t *testing.T) {
+	tmp := t.TempDir()
+	h := NewHandler()
+	r := makeReq(t, tmp, "file-name=test.blob&encoded-size=4", "abcd")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v body=%q", err, w.Body.String())
+	}
+	if v, ok := resp["data"]; !ok || v != nil {
+		t.Errorf(`expected {"data":null}, got %v`, resp)
+	}
+}
+
+func TestHandler_GETReturns405(t *testing.T) {
+	h := NewHandler()
+	r := httptest.NewRequest(http.MethodGet, "/blob", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_MissingStreamCtx(t *testing.T) {
+	h := NewHandler()
+	r := httptest.NewRequest(http.MethodPost, "/blob?file-name=t.blob&encoded-size=0", strings.NewReader(""))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 without streamctx, got %d", w.Code)
+	}
+}
+
+func TestHandler_ParamValidation(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		body  string
+	}{
+		{"missing file-name", "encoded-size=4", "abcd"},
+		{"missing encoded-size", "file-name=t.blob", "abcd"},
+		{"file-name without .blob", "file-name=t.txt&encoded-size=4", "abcd"},
+		{"file-name with traversal", "file-name=../escape.blob&encoded-size=4", "abcd"},
+		{"file-name with slash", "file-name=sub%2Fx.blob&encoded-size=4", "abcd"},
+		{"encoded-size negative", "file-name=t.blob&encoded-size=-1", ""},
+		{"encoded-size not integer", "file-name=t.blob&encoded-size=abc", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			h := NewHandler()
+			r := makeReq(t, tmp, tc.query, tc.body)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d. Body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandler_SizeMismatch(t *testing.T) {
+	tmp := t.TempDir()
+	h := NewHandler()
+	// Body is 4 bytes but encoded-size says 10
+	r := makeReq(t, tmp, "file-name=t.blob&encoded-size=10", "abcd")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	// Verify no partial blob or temp file was left behind
+	snapDir := filepath.Join(tmp, "vm", "100", "2024-12-24T00:26:40Z")
+	entries, _ := os.ReadDir(snapDir)
+	for _, e := range entries {
+		if e.Name() == "t.blob" {
+			t.Errorf("blob was kept despite size mismatch")
+		}
+		if strings.Contains(e.Name(), ".tmp.") {
+			t.Errorf("temp file leaked: %s", e.Name())
+		}
+	}
+}
+
+func TestHandler_AtomicWrite(t *testing.T) {
+	// After a successful POST, exactly one file (the blob) with no .tmp.* leftover.
+	tmp := t.TempDir()
+	h := NewHandler()
+	r := makeReq(t, tmp, "file-name=qemu-server.conf.blob&encoded-size=14", "the body bytes")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	snapDir := filepath.Join(tmp, "vm", "100", "2024-12-24T00:26:40Z")
+	entries, err := os.ReadDir(snapDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected 1 file in snapshot dir, got %d: %v", len(entries), names)
+	}
+	if entries[0].Name() != "qemu-server.conf.blob" {
+		t.Errorf("expected qemu-server.conf.blob, got %s", entries[0].Name())
+	}
+}
+
+func TestHandler_LargeBlob(t *testing.T) {
+	// Stream a multi-MB body to ensure we don't buffer in memory.
+	tmp := t.TempDir()
+	h := NewHandler()
+	const size = 5 * 1024 * 1024 // 5 MiB
+	body := bytes.Repeat([]byte{0xAB}, size)
+	r := httptest.NewRequest(http.MethodPost,
+		"/blob?file-name=big.blob&encoded-size="+strconv.Itoa(size),
+		bytes.NewReader(body))
+	r = r.WithContext(streamctx.WithSession(r.Context(), &streamctx.SessionContext{
+		SessionID:     "sess-big",
+		DatastoreRoot: tmp,
+		BackupType:    "vm",
+		BackupID:      "100",
+		BackupTime:    time.Unix(1735000000, 0),
+	}))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	written, err := os.ReadFile(filepath.Join(tmp, "vm", "100", "2024-12-24T00:26:40Z", "big.blob"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(written) != size {
+		t.Errorf("size: got %d, want %d", len(written), size)
+	}
+	if !bytes.Equal(written[:1024], body[:1024]) || !bytes.Equal(written[size-1024:], body[size-1024:]) {
+		t.Error("content corrupted in transit")
+	}
+}

--- a/services/backupos-pbs/internal/snapshot/snapshot.go
+++ b/services/backupos-pbs/internal/snapshot/snapshot.go
@@ -1,0 +1,64 @@
+// Package snapshot implements snapshot directory layout helpers for the
+// PBS protocol. Per the PBS spec, snapshots live at:
+//
+//	<datastore-root>/<backup-type>/<backup-id>/<backup-time-ISO>/
+//
+// The Go service creates the snapshot directory lazily on first write
+// (blob, index, etc.) so aborted sessions leave no filesystem footprint.
+package snapshot
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+)
+
+// backupIDRegex matches the same constraints upgrade.ParseParams enforces.
+// Defensive: reject path traversal even if the upgrade handler somehow missed it.
+var backupIDRegex = regexp.MustCompile(`^[a-zA-Z0-9_.-]{1,64}$`)
+
+// validBackupTypes is the set of allowed backup-type values per PBS spec.
+var validBackupTypes = map[string]bool{
+	"vm":   true,
+	"ct":   true,
+	"host": true,
+}
+
+// ErrInvalidBackupParams indicates one of the snapshot path components failed validation.
+type ErrInvalidBackupParams struct{ Reason string }
+
+func (e *ErrInvalidBackupParams) Error() string { return e.Reason }
+
+// Path returns the canonical filesystem path for the snapshot identified by
+// the given parameters. Validates inputs and returns ErrInvalidBackupParams
+// on any failure.
+//
+// The PBS time format is RFC3339 with second precision and no fractional
+// seconds, suffixed with Z (e.g. "2024-12-24T00:26:40Z"). The timestamp is
+// always normalized to UTC.
+func Path(datastoreRoot, backupType, backupID string, backupTime time.Time) (string, error) {
+	if !validBackupTypes[backupType] {
+		return "", &ErrInvalidBackupParams{Reason: fmt.Sprintf("invalid backup-type %q", backupType)}
+	}
+	if !backupIDRegex.MatchString(backupID) {
+		return "", &ErrInvalidBackupParams{Reason: fmt.Sprintf("invalid backup-id %q", backupID)}
+	}
+	timeStr := backupTime.UTC().Format("2006-01-02T15:04:05Z")
+	return filepath.Join(datastoreRoot, backupType, backupID, timeStr), nil
+}
+
+// EnsureDir returns the canonical snapshot path AND ensures it exists on
+// disk (creating parent directories as needed). Idempotent — safe to call
+// multiple times for the same snapshot.
+func EnsureDir(datastoreRoot, backupType, backupID string, backupTime time.Time) (string, error) {
+	p, err := Path(datastoreRoot, backupType, backupID, backupTime)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir snapshot dir: %w", err)
+	}
+	return p, nil
+}

--- a/services/backupos-pbs/internal/snapshot/snapshot_test.go
+++ b/services/backupos-pbs/internal/snapshot/snapshot_test.go
@@ -1,0 +1,88 @@
+package snapshot
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPath_Valid(t *testing.T) {
+	p, err := Path("/data", "vm", "100", time.Unix(1735000000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "/data/vm/100/2024-12-24T00:26:40Z"
+	if p != want {
+		t.Errorf("Path: got %q, want %q", p, want)
+	}
+}
+
+func TestPath_NormalizesToUTC(t *testing.T) {
+	loc, _ := time.LoadLocation("America/New_York")
+	t1 := time.Unix(1735000000, 0).In(loc)
+	p, err := Path("/data", "vm", "100", t1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "/data/vm/100/2024-12-24T00:26:40Z"
+	if p != want {
+		t.Errorf("Path: got %q, want %q", p, want)
+	}
+}
+
+func TestPath_RejectsInvalidBackupType(t *testing.T) {
+	_, err := Path("/data", "tape", "100", time.Unix(1735000000, 0))
+	var e *ErrInvalidBackupParams
+	if !errors.As(err, &e) {
+		t.Errorf("expected ErrInvalidBackupParams, got %v", err)
+	}
+}
+
+func TestPath_RejectsTraversal(t *testing.T) {
+	cases := []string{"../escape", "../../root", "with/slash", "with space", ""}
+	for _, bid := range cases {
+		t.Run(bid, func(t *testing.T) {
+			_, err := Path("/data", "vm", bid, time.Unix(1735000000, 0))
+			var e *ErrInvalidBackupParams
+			if !errors.As(err, &e) {
+				t.Errorf("expected ErrInvalidBackupParams, got %v", err)
+			}
+		})
+	}
+}
+
+func TestEnsureDir_CreatesDirs(t *testing.T) {
+	tmp := t.TempDir()
+	p, err := EnsureDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := filepath.Join(tmp, "vm", "100", "2024-12-24T00:26:40Z")
+	if p != expected {
+		t.Errorf("path: got %q, want %q", p, expected)
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("dir not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("expected directory")
+	}
+}
+
+func TestEnsureDir_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	p1, err := EnsureDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2, err := EnsureDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1 != p2 {
+		t.Errorf("paths differ across calls: %q vs %q", p1, p2)
+	}
+}

--- a/services/backupos-pbs/internal/streamctx/streamctx.go
+++ b/services/backupos-pbs/internal/streamctx/streamctx.go
@@ -1,0 +1,47 @@
+// Package streamctx carries per-session context to H2 stream handlers.
+//
+// After the upgrade handshake completes, every H2 stream on that connection
+// shares the same session: same datastore, same backup type/id/time. Stream
+// handlers (POST /blob, POST /fixed_index, etc.) need this context to know
+// where on the filesystem to write data.
+//
+// The upgrade handler attaches a SessionContext to each stream's request via
+// a wrapper http.Handler; stream handlers retrieve it via FromRequest.
+package streamctx
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// SessionContext holds everything a per-stream handler needs to know about
+// the session it's serving. Once the upgrade handshake completes, this is
+// constant for the lifetime of the H2 connection.
+type SessionContext struct {
+	SessionID     string    // pbs_active_sessions.id (UUID)
+	DatastoreID   string    // pbs_datastores.id
+	DatastoreRoot string    // absolute filesystem path of the datastore
+	BackupType    string    // "vm" | "ct" | "host"
+	BackupID      string    // e.g. "100"
+	BackupTime    time.Time // backup-time
+	Namespace     string    // optional, "" if none
+}
+
+type ctxKey struct{}
+
+// WithSession returns a child context carrying the given SessionContext.
+func WithSession(ctx context.Context, sc *SessionContext) context.Context {
+	return context.WithValue(ctx, ctxKey{}, sc)
+}
+
+// FromContext returns the SessionContext attached to ctx, or nil if none.
+func FromContext(ctx context.Context) *SessionContext {
+	sc, _ := ctx.Value(ctxKey{}).(*SessionContext)
+	return sc
+}
+
+// FromRequest is sugar for FromContext(r.Context()).
+func FromRequest(r *http.Request) *SessionContext {
+	return FromContext(r.Context())
+}

--- a/services/backupos-pbs/internal/streamctx/streamctx_test.go
+++ b/services/backupos-pbs/internal/streamctx/streamctx_test.go
@@ -1,0 +1,40 @@
+package streamctx
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestWithSession_RoundTrip(t *testing.T) {
+	want := &SessionContext{
+		SessionID:     "sess-1",
+		DatastoreID:   "ds-1",
+		DatastoreRoot: "/var/lib/backupos/pbs/default",
+		BackupType:    "vm",
+		BackupID:      "100",
+		BackupTime:    time.Unix(1735000000, 0),
+		Namespace:     "",
+	}
+	ctx := WithSession(context.Background(), want)
+	got := FromContext(ctx)
+	if got != want {
+		t.Errorf("FromContext returned different pointer: got %p, want %p", got, want)
+	}
+}
+
+func TestFromContext_Empty(t *testing.T) {
+	if got := FromContext(context.Background()); got != nil {
+		t.Errorf("expected nil for unset context, got %v", got)
+	}
+}
+
+func TestFromRequest(t *testing.T) {
+	want := &SessionContext{SessionID: "sess-1"}
+	r := httptest.NewRequest("GET", "/", nil)
+	r = r.WithContext(WithSession(r.Context(), want))
+	if got := FromRequest(r); got != want {
+		t.Errorf("FromRequest returned different pointer")
+	}
+}

--- a/services/backupos-pbs/internal/upgrade/handler.go
+++ b/services/backupos-pbs/internal/upgrade/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
 )
 
 // UpgradeToken is the custom Upgrade header value PVE sends for backup
@@ -28,7 +29,7 @@ const UpgradeToken = "proxmox-backup-protocol-v1"
 //  4. Insert a pbs_active_sessions row (state='backup' or 'reader')
 //  5. Hijack the underlying TCP connection
 //  6. Write 101 Switching Protocols
-//  7. Hand the connection to http2.Server.ServeConn
+//  7. Hand the connection to http2.Server.ServeConn with a per-session router
 //  8. Finalize the session row (state='aborted') when the connection closes
 //
 // Auth must already have passed before this handler is called — the caller
@@ -37,18 +38,25 @@ const UpgradeToken = "proxmox-backup-protocol-v1"
 type Handler struct {
 	datastores    *datastore.Lookup
 	sessions      *session.Store
-	streamHandler http.Handler
+	blobHandler   http.Handler
+	streamHandler http.Handler // fallback 501-stub for unimplemented H2 paths
 }
 
 // NewHandler constructs a new upgrade Handler.
 //
-// streamHandler is the http.Handler invoked for each HTTP/2 stream after the
-// upgrade succeeds. In M4b-go-session this is a 501-stub; M4c-go-* PRs replace
-// it with real backup endpoint handlers.
-func NewHandler(datastores *datastore.Lookup, sessions *session.Store, streamHandler http.Handler) *Handler {
+// blobHandler handles POST /blob on the H2 connection.
+// streamHandler is the fallback invoked for all other H2 paths (501 stub until
+// M4c-go-finish, M4c-go-fixed-index, etc. land).
+func NewHandler(
+	datastores *datastore.Lookup,
+	sessions *session.Store,
+	blobHandler http.Handler,
+	streamHandler http.Handler,
+) *Handler {
 	return &Handler{
 		datastores:    datastores,
 		sessions:      sessions,
+		blobHandler:   blobHandler,
 		streamHandler: streamHandler,
 	}
 }
@@ -163,15 +171,28 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Step 7: Hand off to http2.Server.
+	// Step 7: Hand off to http2.Server with a per-session router.
 	//
-	// We construct a per-connection http2.Server. This matches the
-	// pmoxs3backuproxy reference architecture and gives us a clean place
-	// to attach per-session state in subsequent PRs.
-	h2srv := &http2.Server{}
+	// Every H2 stream on this connection shares the same session context
+	// (datastore, backup-type/id/time). We build a per-session router that
+	// attaches that context to each stream's request before dispatching.
+	sessionCtx := &streamctx.SessionContext{
+		SessionID:     sessionID,
+		DatastoreID:   ds.ID,
+		DatastoreRoot: ds.Path,
+		BackupType:    string(params.BackupType),
+		BackupID:      params.BackupID,
+		BackupTime:    params.BackupTime,
+		Namespace:     params.Namespace,
+	}
+	sessionRouter := buildSessionRouter(h.blobHandler, h.streamHandler)
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sessionRouter.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sessionCtx)))
+	})
 
+	h2srv := &http2.Server{}
 	h2srv.ServeConn(conn, &http2.ServeConnOpts{
-		Handler: h.streamHandler,
+		Handler: wrapped,
 		// We intentionally do NOT set UpgradeRequest — that's specifically
 		// for h2c upgrades where the original HTTP/1.1 request becomes the
 		// first H2 stream. PBS doesn't work that way; the upgrade response
@@ -243,6 +264,18 @@ func identifyKind(path string) string {
 		return "reader"
 	}
 	return "backup"
+}
+
+// buildSessionRouter routes H2 streams: POST /blob goes to blobHandler;
+// everything else falls through to the fallback (501-stub until M4c-go-finish etc.).
+func buildSessionRouter(blobHandler http.Handler, fallback http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/blob" {
+			blobHandler.ServeHTTP(w, r)
+			return
+		}
+		fallback.ServeHTTP(w, r)
+	})
 }
 
 // writeStub501 mirrors the existing main.go stub501 for the no-upgrade-headers fallback.

--- a/services/backupos-pbs/internal/upgrade/handler_test.go
+++ b/services/backupos-pbs/internal/upgrade/handler_test.go
@@ -15,6 +15,7 @@ import (
 	_ "modernc.org/sqlite"
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/blob"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 )
@@ -75,7 +76,7 @@ func wrapWithTestIdentity(h http.Handler) http.Handler {
 
 func TestHandler_NoUpgradeHeaders_Returns501(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), StubStreamHandler())
+	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), StubStreamHandler())
 
 	srv := httptest.NewServer(wrapWithTestIdentity(h))
 	defer srv.Close()
@@ -93,7 +94,7 @@ func TestHandler_NoUpgradeHeaders_Returns501(t *testing.T) {
 
 func TestHandler_InvalidParams_Returns400(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), StubStreamHandler())
+	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), StubStreamHandler())
 
 	srv := httptest.NewServer(wrapWithTestIdentity(h))
 	defer srv.Close()
@@ -114,7 +115,7 @@ func TestHandler_InvalidParams_Returns400(t *testing.T) {
 
 func TestHandler_DatastoreNotFound_Returns404(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), StubStreamHandler())
+	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), StubStreamHandler())
 
 	srv := httptest.NewServer(wrapWithTestIdentity(h))
 	defer srv.Close()
@@ -145,7 +146,7 @@ func TestHandler_DatastoreNotFound_Returns404(t *testing.T) {
 // crashed Node in PR #244.
 func TestHandler_FullUpgradeDance(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), StubStreamHandler())
+	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), StubStreamHandler())
 
 	// Use a TLS test server. EnableHTTP2=false so the test server doesn't
 	// negotiate H2 via ALPN — we want to drive the upgrade manually.


### PR DESCRIPTION
## Summary

- First real H2 stream handler — PBS clients can now upload blobs (manifest, qemu-server.conf, client.log) over the upgraded connection
- New internal/streamctx: carries per-session context to every H2 stream handler via request context
- New internal/snapshot: snapshot path construction + lazy EnsureDir (<datastore-root>/<backup-type>/<backup-id>/<RFC3339-Z>/)
- New internal/blob: POST /blob?file-name=X.blob&encoded-size=N — streams body to temp file, fsyncs, verifies size, renames atomically, fsyncs parent dir
- internal/upgrade/handler.go: adds blobHandler field; per-session SessionContext attached to every H2 request; buildSessionRouter routes /blob → blob handler, other paths → 501 stub
- Max blob size: 256 MiB cap; body treated as opaque

## Atomic write pattern

1. Write body to .<file-name>.tmp.<random8hex> (O_CREATE|O_EXCL)
2. fsync temp file
3. Verify written == encoded-size (400 + remove tmp on mismatch)
4. Rename to <file-name>
5. fsync parent directory

No partial blobs survive a size mismatch.

## Test plan

- [ ] go mod tidy + go build ./cmd/backupos-pbs on Linux
- [ ] go test ./internal/streamctx/... — 3 tests
- [ ] go test ./internal/snapshot/... — 6 tests
- [ ] go test ./internal/blob/... — happy path, 405, missing streamctx, param validation, size mismatch (no leak), atomic write, large blob (5 MiB)
- [ ] go test ./... — all packages ~55+ tests total

NOTE: Go not on dev Mac — run on Linux before merging.

Generated with Claude Code