### PR TITLE
feat(pbs): POST /finish handler — M4c-go-finish (#237)

### DIFF
--- a/services/backupos-pbs/README.md
+++ b/services/backupos-pbs/README.md
@@ -45,7 +45,7 @@ go run ./cmd/backupos-pbs \
 go test ./...
 ```
 
-## Endpoints (M4c-go-blob)
+## Endpoints (M4c-go-finish)
 
 ### HTTP/1.1 surface (upgrade handshake)
 
@@ -65,7 +65,13 @@ go test ./...
 | Method | Path | Query params | Result |
 |--------|------|-------------|--------|
 | POST | /blob | `file-name=X.blob&encoded-size=N` | 200, blob written atomically to snapshot dir |
-| any other | (any) | | 501 stub (M4c-go-finish, M4c-go-fixed-index, etc. follow) |
+| POST | /finish | (none) | 200, session state→finished, snapshot dir fsynced |
+| any other | (any) | | 501 stub (M4c-go-fixed-index, dynamic-index, chunk-upload follow) |
+
+Session lifecycle: a clean session ends with `POST /finish`, which transitions
+state from `backup`/`reader` to `finished`. If the connection closes without
+`/finish`, the post-`ServeConn` finalize sets state to `aborted`. If `/finish`
+ran first, that finalize is a no-op (state remains `finished`).
 
 Authentication uses PBS token format:
 `Authorization: PBSAPIToken=user@realm!tokenname:secret`

--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -6,14 +6,15 @@
 //   - Reads/writes the same SQLite database as the Node service
 //   - Runs alongside backupos.service as a separate systemd unit
 //
-// In M4c-go-blob (this PR), endpoints are:
+// In M4c-go-finish (this PR), endpoints are:
 //   - GET  /api2/json/version    unauthenticated, 200 JSON
 //   - any  /api2/json/backup     401 without valid auth; with auth: upgrade handshake → H2 streams
 //   - any  /api2/json/reader     401 without valid auth; with auth: upgrade handshake → H2 streams
 //
 // Over the H2 connection:
 //   - POST /blob    write opaque blob atomically to snapshot directory (200)
-//   - any other     501 stub (M4c-go-finish, M4c-go-fixed-index, etc. follow)
+//   - POST /finish  mark session finished + fsync snapshot dir (200)
+//   - any other     501 stub (M4c-go-fixed-index, dynamic-index, chunk-upload follow)
 package main
 
 import (
@@ -33,6 +34,7 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/blob"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/db"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/finish"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/handlers"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/upgrade"
@@ -84,6 +86,7 @@ func main() {
 		datastoreLookup,
 		sessionStore,
 		blob.NewHandler(),
+		finish.NewHandler(sessionStore),
 		upgrade.StubStreamHandler(),
 	)
 

--- a/services/backupos-pbs/internal/finish/finish.go
+++ b/services/backupos-pbs/internal/finish/finish.go
@@ -1,0 +1,119 @@
+// Package finish implements the POST /finish endpoint.
+//
+// PBS clients call POST /finish after uploading all blobs, indexes, and
+// chunks. The server marks the session as 'finished' (vs 'aborted' which
+// is what happens if the connection closes without /finish) and fsyncs
+// the snapshot directory for durability.
+//
+// The client uploads index.json.blob via POST /blob immediately before
+// /finish. The server does NOT generate index.json — that's the client's
+// responsibility per the PBS protocol.
+package finish
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snapshot"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+// Handler implements POST /finish.
+type Handler struct {
+	sessions *session.Store
+}
+
+// NewHandler constructs a finish handler.
+func NewHandler(sessions *session.Store) *Handler {
+	return &Handler{sessions: sessions}
+}
+
+// ServeHTTP routes POST /finish → mark session finished, fsync snapshot dir, 200.
+// Any other method → 405.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil {
+		slog.Error("finish handler invoked without streamctx")
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	// Transition state: 'backup'/'reader' → 'finished'
+	updated, err := h.sessions.Finish(sc.SessionID)
+	if err != nil {
+		slog.Error("session finish DB update failed",
+			"error", err,
+			"session_id", sc.SessionID,
+		)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	if !updated {
+		// Session already finished or already aborted.
+		slog.Info("finish rejected: session not in active state",
+			"session_id", sc.SessionID,
+		)
+		writeError(w, http.StatusBadRequest, "session not active")
+		return
+	}
+
+	// Best-effort durability: fsync the snapshot directory.
+	snapDir, pathErr := snapshot.Path(sc.DatastoreRoot, sc.BackupType, sc.BackupID, sc.BackupTime)
+	if pathErr != nil {
+		// Path validation failure here is unexpected — upgrade.ParseParams
+		// already validated the same fields. Log and continue.
+		slog.Warn("finish: snapshot path computation failed",
+			"error", pathErr,
+			"session_id", sc.SessionID,
+		)
+	} else if err := fsyncDir(snapDir); err != nil {
+		// Best-effort. Blob handler also fsyncs after each write so
+		// per-blob durability is already in place.
+		slog.Warn("finish: snapshot dir fsync failed (state still transitioned)",
+			"error", err,
+			"session_id", sc.SessionID,
+			"snapshot_dir", snapDir,
+		)
+	}
+
+	slog.Info("session finished",
+		"session_id", sc.SessionID,
+		"datastore_id", sc.DatastoreID,
+		"backup_type", sc.BackupType,
+		"backup_id", sc.BackupID,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"data":null}`))
+}
+
+// fsyncDir fsyncs a directory inode for durability of recent renames.
+// If the directory doesn't exist (degenerate session with no uploads), it's a no-op.
+func fsyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/finish/finish_test.go
+++ b/services/backupos-pbs/internal/finish/finish_test.go
@@ -1,0 +1,193 @@
+package finish
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+func setupTestStore(t *testing.T) (*sql.DB, *session.Store) {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE pbs_active_sessions (
+			id            TEXT PRIMARY KEY,
+			token_id      TEXT,
+			datastore_id  TEXT,
+			backup_type   TEXT NOT NULL,
+			backup_id     TEXT NOT NULL,
+			backup_time   INTEGER NOT NULL,
+			started_at    INTEGER NOT NULL,
+			state         TEXT NOT NULL,
+			scratch_path  TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db, session.NewStore(db)
+}
+
+func makeReq(t *testing.T, sc *streamctx.SessionContext) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/finish", nil)
+	if sc != nil {
+		r = r.WithContext(streamctx.WithSession(context.Background(), sc))
+	}
+	return r
+}
+
+func TestHandler_HappyPath(t *testing.T) {
+	tmp := t.TempDir()
+	db, store := setupTestStore(t)
+	h := NewHandler(store)
+
+	id, err := store.Begin(session.BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: time.Unix(1735000000, 0), Kind: session.KindBackup,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sc := &streamctx.SessionContext{
+		SessionID: id, DatastoreID: "ds-1", DatastoreRoot: tmp,
+		BackupType: "vm", BackupID: "100", BackupTime: time.Unix(1735000000, 0),
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeReq(t, sc))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if v, ok := resp["data"]; !ok || v != nil {
+		t.Errorf(`expected {"data":null}, got %v`, resp)
+	}
+
+	var gotState string
+	_ = db.QueryRow(`SELECT state FROM pbs_active_sessions WHERE id = ?`, id).Scan(&gotState)
+	if gotState != "finished" {
+		t.Errorf("state: got %q, want finished", gotState)
+	}
+}
+
+func TestHandler_GETReturns405(t *testing.T) {
+	_, store := setupTestStore(t)
+	h := NewHandler(store)
+	r := httptest.NewRequest(http.MethodGet, "/finish", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_MissingStreamCtx(t *testing.T) {
+	_, store := setupTestStore(t)
+	h := NewHandler(store)
+	r := httptest.NewRequest(http.MethodPost, "/finish", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 without streamctx, got %d", w.Code)
+	}
+}
+
+func TestHandler_DoubleFinishRejected(t *testing.T) {
+	tmp := t.TempDir()
+	_, store := setupTestStore(t)
+	h := NewHandler(store)
+
+	id, _ := store.Begin(session.BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: time.Unix(1735000000, 0), Kind: session.KindBackup,
+	})
+	sc := &streamctx.SessionContext{
+		SessionID: id, DatastoreRoot: tmp,
+		BackupType: "vm", BackupID: "100", BackupTime: time.Unix(1735000000, 0),
+	}
+
+	w1 := httptest.NewRecorder()
+	h.ServeHTTP(w1, makeReq(t, sc))
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first finish: expected 200, got %d", w1.Code)
+	}
+
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, makeReq(t, sc))
+	if w2.Code != http.StatusBadRequest {
+		t.Errorf("second finish: expected 400, got %d. Body: %s", w2.Code, w2.Body.String())
+	}
+	if !strings.Contains(w2.Body.String(), "not active") {
+		t.Errorf("expected 'not active' in response, got %s", w2.Body.String())
+	}
+}
+
+func TestHandler_FinishOnAbortedSessionRejected(t *testing.T) {
+	tmp := t.TempDir()
+	_, store := setupTestStore(t)
+	h := NewHandler(store)
+
+	id, _ := store.Begin(session.BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: time.Unix(1735000000, 0), Kind: session.KindBackup,
+	})
+	if _, err := store.Finalize(id); err != nil {
+		t.Fatal(err)
+	}
+
+	sc := &streamctx.SessionContext{
+		SessionID: id, DatastoreRoot: tmp,
+		BackupType: "vm", BackupID: "100", BackupTime: time.Unix(1735000000, 0),
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeReq(t, sc))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_NoSnapshotDirIsOK(t *testing.T) {
+	tmp := t.TempDir()
+	_, store := setupTestStore(t)
+	h := NewHandler(store)
+
+	id, _ := store.Begin(session.BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: time.Unix(1735000000, 0), Kind: session.KindBackup,
+	})
+	sc := &streamctx.SessionContext{
+		SessionID: id, DatastoreRoot: tmp,
+		BackupType: "vm", BackupID: "100", BackupTime: time.Unix(1735000000, 0),
+	}
+	// Do NOT create the snapshot dir — finish should still return 200
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeReq(t, sc))
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 even without snapshot dir, got %d. Body: %s", w.Code, w.Body.String())
+	}
+}

--- a/services/backupos-pbs/internal/session/session.go
+++ b/services/backupos-pbs/internal/session/session.go
@@ -105,6 +105,30 @@ func (s *Store) Finalize(sessionID string) (bool, error) {
 	return rows > 0, nil
 }
 
+// Finish updates the session state to 'finished' if it's still in the
+// initial 'backup' or 'reader' state. Mirrors the idempotency guard of
+// Finalize: only transitions from active states, so calling Finish twice
+// returns updated=false on the second call.
+//
+// The post-ServeConn Finalize is idempotent against a finished state —
+// see Finalize doc.
+func (s *Store) Finish(sessionID string) (bool, error) {
+	const query = `
+		UPDATE pbs_active_sessions
+		SET state = 'finished'
+		WHERE id = ? AND state IN ('backup', 'reader')
+	`
+	res, err := s.db.Exec(query, sessionID)
+	if err != nil {
+		return false, fmt.Errorf("finish session: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("rows affected: %w", err)
+	}
+	return rows > 0, nil
+}
+
 // ErrNotFound is returned when no session matches the id.
 // Exposed for future M4c handlers that look up sessions by id during chunk uploads.
 var ErrNotFound = errors.New("session not found")

--- a/services/backupos-pbs/internal/session/session_test.go
+++ b/services/backupos-pbs/internal/session/session_test.go
@@ -197,3 +197,108 @@ func TestFinalize_NonexistentIDIsNoop(t *testing.T) {
 		t.Errorf("expected no-op for nonexistent ID")
 	}
 }
+
+func TestFinish_FromBackupToFinished(t *testing.T) {
+	db := setupTestDB(t)
+	s := NewStore(db)
+
+	id, _ := s.Begin(BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: time.Unix(1735000000, 0), Kind: KindBackup,
+	})
+
+	updated, err := s.Finish(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Errorf("expected row updated, got false")
+	}
+
+	var gotState string
+	_ = db.QueryRow(`SELECT state FROM pbs_active_sessions WHERE id = ?`, id).Scan(&gotState)
+	if gotState != "finished" {
+		t.Errorf("state: got %q, want finished", gotState)
+	}
+}
+
+func TestFinish_AlreadyFinishedIsNoop(t *testing.T) {
+	db := setupTestDB(t)
+	s := NewStore(db)
+
+	id, _ := s.Begin(BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: time.Unix(1735000000, 0), Kind: KindBackup,
+	})
+
+	if _, err := s.Finish(id); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := s.Finish(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Errorf("second Finish: expected no-op, but row was updated")
+	}
+}
+
+func TestFinish_AfterAbortedIsNoop(t *testing.T) {
+	db := setupTestDB(t)
+	s := NewStore(db)
+
+	id, _ := s.Begin(BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: time.Unix(1735000000, 0), Kind: KindBackup,
+	})
+
+	if _, err := s.Finalize(id); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := s.Finish(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Errorf("Finish after Finalize: expected no-op, row was updated")
+	}
+
+	var gotState string
+	_ = db.QueryRow(`SELECT state FROM pbs_active_sessions WHERE id = ?`, id).Scan(&gotState)
+	if gotState != "aborted" {
+		t.Errorf("state should remain aborted, got %q", gotState)
+	}
+}
+
+// TestFinishThenFinalize_StaysFinished verifies the connection-close Finalize
+// is a no-op when /finish already set state='finished'.
+func TestFinishThenFinalize_StaysFinished(t *testing.T) {
+	db := setupTestDB(t)
+	s := NewStore(db)
+
+	id, _ := s.Begin(BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: time.Unix(1735000000, 0), Kind: KindBackup,
+	})
+
+	if _, err := s.Finish(id); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := s.Finalize(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Errorf("Finalize after Finish: expected no-op, row was updated")
+	}
+
+	var gotState string
+	_ = db.QueryRow(`SELECT state FROM pbs_active_sessions WHERE id = ?`, id).Scan(&gotState)
+	if gotState != "finished" {
+		t.Errorf("state should remain finished, got %q", gotState)
+	}
+}

--- a/services/backupos-pbs/internal/upgrade/handler.go
+++ b/services/backupos-pbs/internal/upgrade/handler.go
@@ -39,24 +39,27 @@ type Handler struct {
 	datastores    *datastore.Lookup
 	sessions      *session.Store
 	blobHandler   http.Handler
+	finishHandler http.Handler
 	streamHandler http.Handler // fallback 501-stub for unimplemented H2 paths
 }
 
 // NewHandler constructs a new upgrade Handler.
 //
-// blobHandler handles POST /blob on the H2 connection.
+// blobHandler handles POST /blob; finishHandler handles POST /finish.
 // streamHandler is the fallback invoked for all other H2 paths (501 stub until
-// M4c-go-finish, M4c-go-fixed-index, etc. land).
+// M4c-go-fixed-index, etc. land).
 func NewHandler(
 	datastores *datastore.Lookup,
 	sessions *session.Store,
 	blobHandler http.Handler,
+	finishHandler http.Handler,
 	streamHandler http.Handler,
 ) *Handler {
 	return &Handler{
 		datastores:    datastores,
 		sessions:      sessions,
 		blobHandler:   blobHandler,
+		finishHandler: finishHandler,
 		streamHandler: streamHandler,
 	}
 }
@@ -185,7 +188,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		BackupTime:    params.BackupTime,
 		Namespace:     params.Namespace,
 	}
-	sessionRouter := buildSessionRouter(h.blobHandler, h.streamHandler)
+	sessionRouter := buildSessionRouter(h.blobHandler, h.finishHandler, h.streamHandler)
 	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sessionRouter.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sessionCtx)))
 	})
@@ -266,15 +269,17 @@ func identifyKind(path string) string {
 	return "backup"
 }
 
-// buildSessionRouter routes H2 streams: POST /blob goes to blobHandler;
-// everything else falls through to the fallback (501-stub until M4c-go-finish etc.).
-func buildSessionRouter(blobHandler http.Handler, fallback http.Handler) http.Handler {
+// buildSessionRouter routes H2 streams to the appropriate handler.
+func buildSessionRouter(blobHandler, finishHandler, fallback http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/blob" {
+		switch r.URL.Path {
+		case "/blob":
 			blobHandler.ServeHTTP(w, r)
-			return
+		case "/finish":
+			finishHandler.ServeHTTP(w, r)
+		default:
+			fallback.ServeHTTP(w, r)
 		}
-		fallback.ServeHTTP(w, r)
 	})
 }
 

--- a/services/backupos-pbs/internal/upgrade/handler_test.go
+++ b/services/backupos-pbs/internal/upgrade/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/blob"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/finish"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 )
 
@@ -76,7 +77,7 @@ func wrapWithTestIdentity(h http.Handler) http.Handler {
 
 func TestHandler_NoUpgradeHeaders_Returns501(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), StubStreamHandler())
+	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), finish.NewHandler(session.NewStore(db)), StubStreamHandler())
 
 	srv := httptest.NewServer(wrapWithTestIdentity(h))
 	defer srv.Close()
@@ -94,7 +95,7 @@ func TestHandler_NoUpgradeHeaders_Returns501(t *testing.T) {
 
 func TestHandler_InvalidParams_Returns400(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), StubStreamHandler())
+	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), finish.NewHandler(session.NewStore(db)), StubStreamHandler())
 
 	srv := httptest.NewServer(wrapWithTestIdentity(h))
 	defer srv.Close()
@@ -115,7 +116,7 @@ func TestHandler_InvalidParams_Returns400(t *testing.T) {
 
 func TestHandler_DatastoreNotFound_Returns404(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), StubStreamHandler())
+	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), finish.NewHandler(session.NewStore(db)), StubStreamHandler())
 
 	srv := httptest.NewServer(wrapWithTestIdentity(h))
 	defer srv.Close()
@@ -146,7 +147,7 @@ func TestHandler_DatastoreNotFound_Returns404(t *testing.T) {
 // crashed Node in PR #244.
 func TestHandler_FullUpgradeDance(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), StubStreamHandler())
+	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), finish.NewHandler(session.NewStore(db)), StubStreamHandler())
 
 	// Use a TLS test server. EnableHTTP2=false so the test server doesn't
 	// negotiate H2 via ALPN — we want to drive the upgrade manually.


### PR DESCRIPTION
## Summary

- Adds `internal/finish` package with `POST /finish` H2 stream handler
- Adds `session.Finish()` — transitions state from `backup`/`reader` to `finished` (idempotent, no-op if already finished/aborted)
- Wires finish handler into upgrade router alongside blob handler
- Post-`ServeConn` `Finalize` remains a no-op when `/finish` already ran (`WHERE state IN ('backup','reader')` guard)

## Session lifecycle (complete after this PR)

```
upgrade accepted  → state='backup'|'reader'
POST /finish      → state='finished'  (success path)
connection close  → Finalize no-op    (state stays 'finished')

upgrade accepted  → state='backup'|'reader'
connection close  → state='aborted'   (abort path, no /finish)
```

## Test plan

- [ ] `go test ./internal/finish/...` — 6 tests (POST /finish 200, non-POST 405, missing ctx 500, session not active 400, fsync best-effort on missing dir, 200 with no snapshot dir)
- [ ] `go test ./internal/session/...` — 4 new Finish tests (FromBackup→Finished, AlreadyFinished noop, AfterAborted noop, FinishThenFinalize stays finished)
- [ ] `go test ./internal/upgrade/...` — existing upgrade dance test still passes with 5-arg NewHandler
- [ ] `go build ./cmd/backupos-pbs` — clean build
- [ ] Run on Linux server: `go mod tidy && go test ./... && go build -o ../../bin/backupos-pbs ./cmd/backupos-pbs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)