### PR TITLE
feat(pbs): fixed-index lifecycle — M4c-go-fixed-index (#237)

### DIFF
--- a/services/backupos-pbs/README.md
+++ b/services/backupos-pbs/README.md
@@ -45,7 +45,7 @@ go run ./cmd/backupos-pbs \
 go test ./...
 ```
 
-## Endpoints (M4c-go-finish)
+## Endpoints (M4c-go-fixed-index)
 
 ### HTTP/1.1 surface (upgrade handshake)
 
@@ -66,7 +66,11 @@ go test ./...
 |--------|------|-------------|--------|
 | POST | /blob | `file-name=X.blob&encoded-size=N` | 200, blob written atomically to snapshot dir |
 | POST | /finish | (none) | 200, session state→finished, snapshot dir fsynced |
-| any other | (any) | | 501 stub (M4c-go-fixed-index, dynamic-index, chunk-upload follow) |
+| POST | /fixed_index | `archive-name=X.fidx&size=N` | 200, creates .fidx writer, returns wid |
+| PUT | /fixed_index | JSON `{wid, digest-list, offset-list}` | 200, batch-associate digests with positions |
+| POST | /fixed_chunk | `wid=N&digest=H&size=N&encoded-size=N` body=DataBlob | 200, chunk stored, registered in known_chunks |
+| POST | /fixed_close | `wid=N&chunk-count=N&size=N&csum=H` | 200, validates and finalises .fidx file |
+| any other | (any) | | 501 stub (M4c-go-dynamic-index follows) |
 
 Session lifecycle: a clean session ends with `POST /finish`, which transitions
 state from `backup`/`reader` to `finished`. If the connection closes without

--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -35,6 +35,10 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/db"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/finish"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedappend"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedchunk"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedclose"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedindex"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/handlers"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/upgrade"
@@ -87,6 +91,10 @@ func main() {
 		sessionStore,
 		blob.NewHandler(),
 		finish.NewHandler(sessionStore),
+		fixedindex.NewHandler(),
+		fixedchunk.NewHandler(),
+		fixedappend.NewHandler(),
+		fixedclose.NewHandler(),
 		upgrade.StubStreamHandler(),
 	)
 

--- a/services/backupos-pbs/go.mod
+++ b/services/backupos-pbs/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/klauspost/compress v1.17.11
 	golang.org/x/net v0.27.0
 	modernc.org/sqlite v1.34.1
 )

--- a/services/backupos-pbs/internal/chunkstore/chunkstore.go
+++ b/services/backupos-pbs/internal/chunkstore/chunkstore.go
@@ -1,0 +1,138 @@
+// Package chunkstore implements content-addressed chunk storage for PBS.
+//
+// Chunks are stored at:
+//
+//	<datastore-root>/.chunks/<prefix4>/<full-64-hex-digest>
+//
+// where prefix4 is the first 4 hex characters of the digest (= first 2 bytes).
+// Production deployments pre-create all 65536 shard directories at setup time
+// (M4a). Tests must create the specific shard dirs they need.
+package chunkstore
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Store is a handle to a content-addressed chunk directory.
+// The mutex guards concurrent inserts to the same chunk path.
+type Store struct {
+	root string
+	mu   sync.Mutex
+}
+
+// New returns a Store rooted at datastoreRoot. Returns an error if
+// <root>/.chunks does not exist or is not a directory.
+func New(root string) (*Store, error) {
+	chunkDir := filepath.Join(root, ".chunks")
+	st, err := os.Stat(chunkDir)
+	if err != nil {
+		return nil, fmt.Errorf("chunk dir not accessible: %w", err)
+	}
+	if !st.IsDir() {
+		return nil, fmt.Errorf("chunk dir is not a directory: %s", chunkDir)
+	}
+	return &Store{root: root}, nil
+}
+
+// Path returns the filesystem path for the chunk identified by digest.
+func (s *Store) Path(digest [32]byte) string {
+	hexDigest := hex.EncodeToString(digest[:])
+	prefix := hexDigest[:4]
+	return filepath.Join(s.root, ".chunks", prefix, hexDigest)
+}
+
+// Insert writes raw (a full DataBlob) to the chunk store under digest.
+//
+// Returns (isDuplicate=true, existingSize, nil) if a file with the same size
+// already exists — the existing file is kept and its atime is touched.
+//
+// Returns (isDuplicate=true, existingSize, nil) if a file with a DIFFERENT size
+// exists — the existing file is kept with a warning logged (V1 simplification;
+// encrypted tie-breaking deferred to M9).
+//
+// Returns (isDuplicate=false, encodedSize, nil) on a fresh write.
+func (s *Store) Insert(digest [32]byte, raw []byte) (bool, uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := s.Path(digest)
+	dir := filepath.Dir(path)
+
+	if st, err := os.Stat(path); err == nil {
+		if !st.Mode().IsRegular() {
+			return false, 0, fmt.Errorf("chunk path %s is not a regular file", path)
+		}
+		existingSize := uint64(st.Size())
+		incomingSize := uint64(len(raw))
+		if existingSize == incomingSize {
+			if touchErr := touchAtime(path); touchErr != nil {
+				slog.Warn("chunk touch failed", "path", path, "error", touchErr)
+			}
+			return true, existingSize, nil
+		}
+		slog.Warn("chunk size mismatch on insert; keeping existing",
+			"digest", hex.EncodeToString(digest[:]),
+			"existing_size", existingSize,
+			"incoming_size", incomingSize,
+		)
+		return true, existingSize, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, 0, fmt.Errorf("stat chunk: %w", err)
+	}
+
+	tmpPath, err := writeTempInDir(dir, raw)
+	if err != nil {
+		return false, 0, fmt.Errorf("write temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return false, 0, fmt.Errorf("rename to final: %w", err)
+	}
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return false, uint64(len(raw)), nil
+}
+
+// writeTempInDir writes raw to a randomly-named temp file inside dir,
+// fsyncs it, and returns the path.
+func writeTempInDir(dir string, raw []byte) (string, error) {
+	suffix := make([]byte, 8)
+	if _, err := rand.Read(suffix); err != nil {
+		return "", err
+	}
+	tmpPath := filepath.Join(dir, ".chunk.tmp."+hex.EncodeToString(suffix))
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return "", err
+	}
+	if _, err := f.Write(raw); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	return tmpPath, nil
+}
+
+func touchAtime(path string) error {
+	now := time.Now()
+	return os.Chtimes(path, now, now)
+}

--- a/services/backupos-pbs/internal/chunkstore/chunkstore_test.go
+++ b/services/backupos-pbs/internal/chunkstore/chunkstore_test.go
@@ -1,0 +1,161 @@
+package chunkstore
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupStore creates a temp datastore root with a .chunks dir and a subset
+// of shard dirs needed for the digests used in each test.
+func setupStore(t *testing.T, digests ...[32]byte) (string, *Store) {
+	t.Helper()
+	root := t.TempDir()
+	chunkDir := filepath.Join(root, ".chunks")
+	if err := os.MkdirAll(chunkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range digests {
+		prefix := hex.EncodeToString(d[:])[:4]
+		if err := os.MkdirAll(filepath.Join(chunkDir, prefix), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s, err := New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root, s
+}
+
+func TestPath_Sharding(t *testing.T) {
+	root := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(root, ".chunks"), 0o755)
+	s, _ := New(root)
+
+	var digest [32]byte
+	digest[0] = 0x0a
+	digest[1] = 0x1b
+	digest[2] = 0x2c
+
+	got := s.Path(digest)
+	hexDigest := hex.EncodeToString(digest[:])
+	want := filepath.Join(root, ".chunks", "0a1b", hexDigest)
+	if got != want {
+		t.Errorf("Path: got %s, want %s", got, want)
+	}
+}
+
+func TestInsert_NewChunk_WritesFile(t *testing.T) {
+	var digest [32]byte
+	digest[0] = 0xde
+	digest[1] = 0xad
+	_, s := setupStore(t, digest)
+
+	raw := []byte("chunk data payload")
+	isDup, size, err := s.Insert(digest, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isDup {
+		t.Error("expected isDuplicate=false for new chunk")
+	}
+	if size != uint64(len(raw)) {
+		t.Errorf("size: got %d, want %d", size, len(raw))
+	}
+
+	// Verify file exists on disk with correct contents.
+	path := s.Path(digest)
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	if string(got) != string(raw) {
+		t.Error("chunk contents mismatch")
+	}
+}
+
+func TestInsert_DuplicateSameSize_ReturnsDuplicate(t *testing.T) {
+	var digest [32]byte
+	digest[0] = 0xca
+	digest[1] = 0xfe
+	_, s := setupStore(t, digest)
+
+	raw := []byte("same chunk")
+	_, _, _ = s.Insert(digest, raw)
+
+	isDup, size, err := s.Insert(digest, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isDup {
+		t.Error("expected isDuplicate=true for same-size re-insert")
+	}
+	if size != uint64(len(raw)) {
+		t.Errorf("size: got %d, want %d", size, len(raw))
+	}
+}
+
+func TestInsert_SizeMismatch_KeepsExisting(t *testing.T) {
+	var digest [32]byte
+	digest[0] = 0xba
+	digest[1] = 0xbe
+	_, s := setupStore(t, digest)
+
+	original := []byte("original chunk data")
+	larger := []byte("longer chunk data with more bytes here")
+	_, _, _ = s.Insert(digest, original)
+
+	// Inserting different-size data for same digest: existing kept, isDuplicate=true.
+	isDup, existingSize, err := s.Insert(digest, larger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isDup {
+		t.Error("expected isDuplicate=true on size mismatch (keep existing)")
+	}
+	if existingSize != uint64(len(original)) {
+		t.Errorf("returned existingSize: got %d, want %d", existingSize, len(original))
+	}
+
+	// File on disk should still have the original content.
+	path := s.Path(digest)
+	got, _ := os.ReadFile(path)
+	if string(got) != string(original) {
+		t.Error("existing chunk was overwritten on size mismatch (should keep existing)")
+	}
+}
+
+func TestInsert_AtomicWrite_NoTmpFilesRemain(t *testing.T) {
+	var digest [32]byte
+	digest[0] = 0xfe
+	digest[1] = 0xed
+	root, s := setupStore(t, digest)
+
+	raw := []byte("atomic test")
+	_, _, err := s.Insert(digest, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify no .tmp.* files remain in the shard dir.
+	prefix := hex.EncodeToString(digest[:])[:4]
+	shardDir := filepath.Join(root, ".chunks", prefix)
+	entries, _ := os.ReadDir(shardDir)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp.") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestNew_MissingChunksDir_ReturnsError(t *testing.T) {
+	root := t.TempDir()
+	// Do NOT create .chunks dir.
+	_, err := New(root)
+	if err == nil {
+		t.Error("expected error when .chunks dir missing, got nil")
+	}
+}

--- a/services/backupos-pbs/internal/datablob/datablob.go
+++ b/services/backupos-pbs/internal/datablob/datablob.go
@@ -1,0 +1,160 @@
+// Package datablob parses and verifies the PBS DataBlob wire format.
+//
+// Wire format:
+//
+//	offset 0:  magic [8]byte  — one of the four blob magic constants
+//	offset 8:  crc   [4]byte  — CRC32 of payload (server stores as-is; client verifies)
+//	offset 12: data           — raw / compressed / encrypted payload
+//
+// Encrypted variants have an extended header:
+//
+//	offset 12: iv  [16]byte
+//	offset 28: tag [16]byte
+//	offset 44: encrypted data
+package datablob
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// Magic constants from pbs-datastore/src/file_formats.rs — do not modify.
+var (
+	MagicUncompressed = [8]byte{66, 171, 56, 7, 190, 131, 112, 161}
+	MagicCompressed   = [8]byte{49, 185, 88, 66, 111, 182, 163, 127}
+	MagicEncrypted    = [8]byte{123, 103, 133, 190, 34, 45, 76, 240}
+	MagicEncrCompr    = [8]byte{230, 89, 27, 191, 11, 191, 216, 11}
+)
+
+const (
+	headerSizeUnencrypted = 12
+	headerSizeEncrypted   = 44
+	maxBlobPlaintext      = 16 * 1024 * 1024
+)
+
+// Kind identifies the encoding of a DataBlob.
+type Kind int
+
+const (
+	KindUnknown Kind = iota
+	KindUncompressed
+	KindCompressed
+	KindEncrypted
+	KindEncrCompr
+)
+
+// ErrDigestMismatch is returned when SHA256(plaintext) does not match the
+// expected digest supplied by the caller.
+var ErrDigestMismatch = errors.New("blob plaintext digest mismatch")
+
+// ErrSizeMismatch is returned when the decompressed plaintext length does not
+// match the expected size supplied by the caller.
+var ErrSizeMismatch = errors.New("blob plaintext size mismatch")
+
+// Blob is a parsed PBS DataBlob. It holds the raw wire bytes and the decoded
+// kind; the full payload is decoded on demand.
+type Blob struct {
+	raw  []byte
+	kind Kind
+}
+
+// Parse parses raw DataBlob bytes and validates the magic header.
+// It does NOT decompress or verify the payload — call VerifyUnencrypted for that.
+func Parse(raw []byte) (*Blob, error) {
+	if len(raw) < headerSizeUnencrypted {
+		return nil, fmt.Errorf("blob too short (%d bytes)", len(raw))
+	}
+	var magic [8]byte
+	copy(magic[:], raw[:8])
+
+	var kind Kind
+	var minHeader int
+	switch magic {
+	case MagicUncompressed:
+		kind, minHeader = KindUncompressed, headerSizeUnencrypted
+	case MagicCompressed:
+		kind, minHeader = KindCompressed, headerSizeUnencrypted
+	case MagicEncrypted:
+		kind, minHeader = KindEncrypted, headerSizeEncrypted
+	case MagicEncrCompr:
+		kind, minHeader = KindEncrCompr, headerSizeEncrypted
+	default:
+		return nil, fmt.Errorf("unknown blob magic %v", magic)
+	}
+
+	if len(raw) < minHeader {
+		return nil, fmt.Errorf("blob too short for kind %d (%d < %d)", kind, len(raw), minHeader)
+	}
+	return &Blob{raw: raw, kind: kind}, nil
+}
+
+// Kind returns the encoding kind of the blob.
+func (b *Blob) Kind() Kind { return b.kind }
+
+// Raw returns the full wire bytes of the blob.
+func (b *Blob) Raw() []byte { return b.raw }
+
+// IsEncrypted reports whether the blob uses encryption.
+func (b *Blob) IsEncrypted() bool {
+	return b.kind == KindEncrypted || b.kind == KindEncrCompr
+}
+
+// CRC returns the CRC32 stored in the blob header (client-computed; not
+// re-verified by the server on ingest).
+func (b *Blob) CRC() uint32 {
+	return binary.LittleEndian.Uint32(b.raw[8:12])
+}
+
+// VerifyUnencrypted decodes the plaintext, checks its length against
+// expectedSize, and verifies SHA256(plaintext) == expectedDigest.
+//
+// For encrypted blobs this is a no-op (returns nil) because the server cannot
+// decrypt them.
+func (b *Blob) VerifyUnencrypted(expectedSize uint32, expectedDigest [32]byte) error {
+	if b.IsEncrypted() {
+		return nil
+	}
+	plaintext, err := b.plaintext()
+	if err != nil {
+		return fmt.Errorf("decode plaintext: %w", err)
+	}
+	if uint32(len(plaintext)) != expectedSize {
+		return fmt.Errorf("%w: got %d, want %d", ErrSizeMismatch, len(plaintext), expectedSize)
+	}
+	gotDigest := sha256.Sum256(plaintext)
+	if gotDigest != expectedDigest {
+		return ErrDigestMismatch
+	}
+	return nil
+}
+
+// plaintext extracts and (if necessary) decompresses the data payload.
+// Only valid for unencrypted kinds.
+func (b *Blob) plaintext() ([]byte, error) {
+	switch b.kind {
+	case KindUncompressed:
+		return b.raw[headerSizeUnencrypted:], nil
+	case KindCompressed:
+		dec, err := zstd.NewReader(bytes.NewReader(b.raw[headerSizeUnencrypted:]))
+		if err != nil {
+			return nil, err
+		}
+		defer dec.Close()
+		buf, err := io.ReadAll(io.LimitReader(dec, maxBlobPlaintext+1))
+		if err != nil {
+			return nil, err
+		}
+		if len(buf) > maxBlobPlaintext {
+			return nil, fmt.Errorf("decompressed size exceeds %d byte cap", maxBlobPlaintext)
+		}
+		return buf, nil
+	default:
+		return nil, fmt.Errorf("plaintext not available for kind %d", b.kind)
+	}
+}

--- a/services/backupos-pbs/internal/datablob/datablob_test.go
+++ b/services/backupos-pbs/internal/datablob/datablob_test.go
@@ -1,0 +1,139 @@
+package datablob
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// makeUncompressedBlob builds a minimal uncompressed DataBlob from data.
+// CRC is left as zeros (server doesn't re-verify CRC on ingest).
+func makeUncompressedBlob(data []byte) []byte {
+	blob := make([]byte, headerSizeUnencrypted+len(data))
+	copy(blob[0:8], MagicUncompressed[:])
+	// blob[8:12] = CRC32 zeros — not verified by server
+	copy(blob[headerSizeUnencrypted:], data)
+	return blob
+}
+
+// makeCompressedBlob builds a zstd-compressed DataBlob from data.
+func makeCompressedBlob(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("zstd writer: %v", err)
+	}
+	if _, err := enc.Write(data); err != nil {
+		t.Fatalf("zstd write: %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatalf("zstd close: %v", err)
+	}
+	compressed := buf.Bytes()
+	blob := make([]byte, headerSizeUnencrypted+len(compressed))
+	copy(blob[0:8], MagicCompressed[:])
+	copy(blob[headerSizeUnencrypted:], compressed)
+	return blob
+}
+
+// makeEncryptedBlob builds a minimal encrypted DataBlob (payload is opaque zeros).
+func makeEncryptedBlob() []byte {
+	payload := make([]byte, 1)
+	blob := make([]byte, headerSizeEncrypted+len(payload))
+	copy(blob[0:8], MagicEncrypted[:])
+	copy(blob[headerSizeEncrypted:], payload)
+	return blob
+}
+
+func TestParse_Uncompressed(t *testing.T) {
+	raw := makeUncompressedBlob([]byte("hello"))
+	b, err := Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Kind() != KindUncompressed {
+		t.Errorf("kind: got %d, want KindUncompressed", b.Kind())
+	}
+	if b.IsEncrypted() {
+		t.Error("IsEncrypted should be false")
+	}
+}
+
+func TestParse_RejectsUnknownMagic(t *testing.T) {
+	raw := make([]byte, 20)
+	raw[0] = 0xFF // not a valid magic byte sequence
+	_, err := Parse(raw)
+	if err == nil {
+		t.Error("expected error for unknown magic, got nil")
+	}
+}
+
+func TestParse_RejectsTooShort(t *testing.T) {
+	_, err := Parse([]byte{1, 2, 3})
+	if err == nil {
+		t.Error("expected error for too-short blob, got nil")
+	}
+}
+
+func TestVerifyUnencrypted_Uncompressed_HappyPath(t *testing.T) {
+	data := []byte("test payload")
+	raw := makeUncompressedBlob(data)
+	b, _ := Parse(raw)
+	digest := sha256.Sum256(data)
+	if err := b.VerifyUnencrypted(uint32(len(data)), digest); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestVerifyUnencrypted_Compressed_HappyPath(t *testing.T) {
+	data := []byte("test payload for compression test — longer to make compression meaningful")
+	raw := makeCompressedBlob(t, data)
+	b, _ := Parse(raw)
+	digest := sha256.Sum256(data)
+	if err := b.VerifyUnencrypted(uint32(len(data)), digest); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestVerifyUnencrypted_DigestMismatch(t *testing.T) {
+	data := []byte("test")
+	raw := makeUncompressedBlob(data)
+	b, _ := Parse(raw)
+	var wrongDigest [32]byte
+	wrongDigest[0] = 0xFF
+	err := b.VerifyUnencrypted(uint32(len(data)), wrongDigest)
+	if !errors.Is(err, ErrDigestMismatch) {
+		t.Errorf("expected ErrDigestMismatch, got %v", err)
+	}
+}
+
+func TestVerifyUnencrypted_SizeMismatch(t *testing.T) {
+	data := []byte("test")
+	raw := makeUncompressedBlob(data)
+	b, _ := Parse(raw)
+	digest := sha256.Sum256(data)
+	err := b.VerifyUnencrypted(uint32(len(data))+1, digest) // wrong size
+	if !errors.Is(err, ErrSizeMismatch) {
+		t.Errorf("expected ErrSizeMismatch, got %v", err)
+	}
+}
+
+func TestVerifyUnencrypted_SkipsEncryptedBlobs(t *testing.T) {
+	raw := makeEncryptedBlob()
+	b, err := Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b.IsEncrypted() {
+		t.Error("expected IsEncrypted=true")
+	}
+	// VerifyUnencrypted must return nil for encrypted blobs regardless of inputs.
+	var anyDigest [32]byte
+	if err := b.VerifyUnencrypted(999, anyDigest); err != nil {
+		t.Errorf("expected nil for encrypted blob, got %v", err)
+	}
+}

--- a/services/backupos-pbs/internal/fidx/fidx.go
+++ b/services/backupos-pbs/internal/fidx/fidx.go
@@ -1,0 +1,263 @@
+// Package fidx implements writers for the PBS Fixed Index (.fidx) file format.
+//
+// Header layout (4096 bytes, all integers little-endian):
+//
+//	offset 0:    magic      [8]byte   = {47,127,65,237,145,253,15,205}
+//	offset 8:    uuid       [16]byte  = random per writer
+//	offset 24:   ctime      int64     = unix epoch seconds
+//	offset 32:   index_csum [32]byte  = SHA256(digest_0 || digest_1 || ...) — written at Close
+//	offset 64:   size       uint64    = total content size — written at Close
+//	offset 72:   chunk_size uint64    = power of 2, in bytes
+//	offset 80:   reserved   [4016]byte = zeros
+//
+// Body (immediately after header):
+//
+//	offset 4096 + i*32: digest_i [32]byte
+//
+// File size = 4096 + index_length * 32
+// where index_length = ceil(size / chunk_size).
+package fidx
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// Magic is the fixed-index file magic from file_formats.rs — do not modify.
+var Magic = [8]byte{47, 127, 65, 237, 145, 253, 15, 205}
+
+const (
+	headerSize = 4096
+	digestSize = 32
+)
+
+// Writer is a memory-mapped .fidx file writer. The file is written atomically
+// via a temp-file rename on Close.
+type Writer struct {
+	mu sync.Mutex
+
+	finalPath string
+	tmpPath   string
+	file      *os.File
+	mmap      []byte
+
+	chunkSize     uint64
+	size          uint64
+	indexLength   uint64
+
+	uuid  [16]byte
+	ctime int64
+
+	closed bool
+}
+
+// Create allocates a new .fidx writer. The file is written to a temp path
+// inside the same directory as finalPath and renamed on Close.
+//
+// knownSize must be > 0 (growable .fidx writers are deferred to a future PR).
+// chunkSize must be a power of two.
+func Create(finalPath string, knownSize uint64, chunkSize uint32) (*Writer, error) {
+	if chunkSize == 0 || chunkSize&(chunkSize-1) != 0 {
+		return nil, fmt.Errorf("chunk_size must be a power of two, got %d", chunkSize)
+	}
+	if knownSize == 0 {
+		return nil, fmt.Errorf("growable .fidx writers not supported in V1 (size must be > 0)")
+	}
+
+	tmpSuffix := make([]byte, 8)
+	if _, err := rand.Read(tmpSuffix); err != nil {
+		return nil, err
+	}
+	tmpPath := finalPath + ".tmp." + hex.EncodeToString(tmpSuffix)
+
+	f, err := os.OpenFile(tmpPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open temp fidx: %w", err)
+	}
+
+	indexLength := (knownSize + uint64(chunkSize) - 1) / uint64(chunkSize)
+	fileSize := int64(headerSize) + int64(indexLength)*int64(digestSize)
+	if err := f.Truncate(fileSize); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return nil, fmt.Errorf("truncate fidx: %w", err)
+	}
+
+	mm, err := syscall.Mmap(int(f.Fd()), 0, int(fileSize),
+		syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	if err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return nil, fmt.Errorf("mmap fidx: %w", err)
+	}
+
+	var uuid [16]byte
+	if _, err := rand.Read(uuid[:]); err != nil {
+		_ = syscall.Munmap(mm)
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return nil, err
+	}
+	ctime := time.Now().Unix()
+
+	w := &Writer{
+		finalPath:   finalPath,
+		tmpPath:     tmpPath,
+		file:        f,
+		mmap:        mm,
+		chunkSize:   uint64(chunkSize),
+		size:        knownSize,
+		indexLength: indexLength,
+		uuid:        uuid,
+		ctime:       ctime,
+	}
+	w.writeInitialHeader()
+	return w, nil
+}
+
+// writeInitialHeader populates the header fields that are known at create time.
+func (w *Writer) writeInitialHeader() {
+	copy(w.mmap[0:8], Magic[:])
+	copy(w.mmap[8:24], w.uuid[:])
+	binary.LittleEndian.PutUint64(w.mmap[24:32], uint64(w.ctime))
+	// index_csum (32:64) and size (64:72) are written at Close.
+	binary.LittleEndian.PutUint64(w.mmap[72:80], w.chunkSize)
+}
+
+// AddChunk writes digest into the index slot corresponding to the chunk ending
+// at offset. offset is the byte position AFTER this chunk (PBS convention).
+func (w *Writer) AddChunk(offset uint64, size uint32, digest [32]byte) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return errors.New("AddChunk called on closed writer")
+	}
+	if size == 0 {
+		return errors.New("zero-size chunk not allowed")
+	}
+	if offset > w.size {
+		return fmt.Errorf("chunk end %d exceeds total size %d", offset, w.size)
+	}
+	if uint64(size) > w.chunkSize {
+		return fmt.Errorf("chunk size %d > chunk_size %d", size, w.chunkSize)
+	}
+	// Non-last chunks must be full chunk_size.
+	if offset != w.size && uint64(size) != w.chunkSize {
+		return fmt.Errorf("non-last chunk has wrong size %d (expected %d)", size, w.chunkSize)
+	}
+	pos := offset - uint64(size)
+	if pos%w.chunkSize != 0 {
+		return fmt.Errorf("chunk start %d not aligned to chunk_size %d", pos, w.chunkSize)
+	}
+	idx := pos / w.chunkSize
+	if idx >= w.indexLength {
+		return fmt.Errorf("chunk index %d out of range (length %d)", idx, w.indexLength)
+	}
+	bodyOffset := uint64(headerSize) + idx*digestSize
+	copy(w.mmap[bodyOffset:bodyOffset+digestSize], digest[:])
+	return nil
+}
+
+// IndexLength returns the number of digest slots in this index.
+func (w *Writer) IndexLength() uint64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.indexLength
+}
+
+// UUID returns the per-writer random UUID embedded in the header.
+func (w *Writer) UUID() [16]byte { return w.uuid }
+
+// Close finalises the .fidx file: computes index_csum, writes size and csum
+// into the header, msyncs, fsyncs, and renames the temp file to finalPath.
+// Returns the computed index checksum.
+func (w *Writer) Close() ([32]byte, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return [32]byte{}, errors.New("already closed")
+	}
+
+	bodyStart := uint64(headerSize)
+	bodyEnd := bodyStart + w.indexLength*digestSize
+	digestArea := w.mmap[bodyStart:bodyEnd]
+	csum := sha256.Sum256(digestArea)
+
+	copy(w.mmap[32:64], csum[:])
+	binary.LittleEndian.PutUint64(w.mmap[64:72], w.size)
+
+	_ = msync(w.mmap)
+
+	if err := syscall.Munmap(w.mmap); err != nil {
+		return [32]byte{}, fmt.Errorf("munmap: %w", err)
+	}
+	w.mmap = nil
+
+	if err := w.file.Sync(); err != nil {
+		_ = w.file.Close()
+		_ = os.Remove(w.tmpPath)
+		return [32]byte{}, fmt.Errorf("fsync fidx: %w", err)
+	}
+	if err := w.file.Close(); err != nil {
+		_ = os.Remove(w.tmpPath)
+		return [32]byte{}, fmt.Errorf("close fidx: %w", err)
+	}
+	w.file = nil
+
+	if err := os.Rename(w.tmpPath, w.finalPath); err != nil {
+		_ = os.Remove(w.tmpPath)
+		return [32]byte{}, fmt.Errorf("rename fidx to final: %w", err)
+	}
+
+	if d, err := os.Open(filepath.Dir(w.finalPath)); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+
+	w.closed = true
+	return csum, nil
+}
+
+// Drop discards the writer, removing the temp file without promoting it.
+// Safe to call on an already-closed writer (no-op).
+func (w *Writer) Drop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return
+	}
+	if w.mmap != nil {
+		_ = syscall.Munmap(w.mmap)
+		w.mmap = nil
+	}
+	if w.file != nil {
+		_ = w.file.Close()
+		w.file = nil
+	}
+	_ = os.Remove(w.tmpPath)
+	w.closed = true
+}
+
+func msync(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+	_, _, errno := syscall.Syscall(syscall.SYS_MSYNC,
+		uintptr(unsafe.Pointer(&b[0])),
+		uintptr(len(b)),
+		uintptr(syscall.MS_SYNC))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/services/backupos-pbs/internal/fidx/fidx_test.go
+++ b/services/backupos-pbs/internal/fidx/fidx_test.go
@@ -1,0 +1,255 @@
+package fidx
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testChunkSize = 4 * 1024 * 1024 // 4 MiB
+
+func TestCreate_RejectsNonPowerOfTwo(t *testing.T) {
+	dir := t.TempDir()
+	_, err := Create(filepath.Join(dir, "test.fidx"), 4194304, 3)
+	if err == nil {
+		t.Error("expected error for non-power-of-two chunk_size")
+	}
+}
+
+func TestCreate_RejectsZeroChunkSize(t *testing.T) {
+	dir := t.TempDir()
+	_, err := Create(filepath.Join(dir, "test.fidx"), 4194304, 0)
+	if err == nil {
+		t.Error("expected error for zero chunk_size")
+	}
+}
+
+func TestCreate_RejectsZeroSize(t *testing.T) {
+	dir := t.TempDir()
+	_, err := Create(filepath.Join(dir, "test.fidx"), 0, testChunkSize)
+	if err == nil {
+		t.Error("expected error for zero content size (growable not supported)")
+	}
+}
+
+// TestAddChunk_AndClose_ByteExact verifies the complete .fidx file layout
+// against the spec. This is the moment-of-truth test — offsets, magic,
+// uuid, ctime, index_csum, size, chunk_size, and digest positions.
+func TestAddChunk_AndClose_ByteExact(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.fidx")
+
+	totalSize := uint64(2 * testChunkSize)
+	w, err := Create(path, totalSize, testChunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build two distinct digests.
+	var digest0, digest1 [32]byte
+	for i := range digest0 {
+		digest0[i] = byte(i)
+	}
+	for i := range digest1 {
+		digest1[i] = byte(i + 32)
+	}
+
+	// offset = end of chunk (PBS convention).
+	if err := w.AddChunk(uint64(testChunkSize), uint32(testChunkSize), digest0); err != nil {
+		t.Fatalf("AddChunk 0: %v", err)
+	}
+	if err := w.AddChunk(totalSize, uint32(testChunkSize), digest1); err != nil {
+		t.Fatalf("AddChunk 1: %v", err)
+	}
+
+	before := time.Now().Unix()
+	csum, err := w.Close()
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fidx: %v", err)
+	}
+
+	expectedFileSize := headerSize + 2*digestSize
+	if len(data) != expectedFileSize {
+		t.Errorf("file size: got %d, want %d", len(data), expectedFileSize)
+	}
+
+	// Magic at 0:8.
+	var gotMagic [8]byte
+	copy(gotMagic[:], data[0:8])
+	if gotMagic != Magic {
+		t.Errorf("magic mismatch: got %v, want %v", gotMagic, Magic)
+	}
+
+	// UUID at 8:24 must be non-zero.
+	var uuid [16]byte
+	copy(uuid[:], data[8:24])
+	if uuid == ([16]byte{}) {
+		t.Error("uuid is all-zeros; expected a random value")
+	}
+
+	// ctime at 24:32 (LE int64) must be near now.
+	ctime := int64(binary.LittleEndian.Uint64(data[24:32]))
+	after := time.Now().Unix()
+	if ctime < before-5 || ctime > after+5 {
+		t.Errorf("ctime %d not near test time [%d, %d]", ctime, before, after)
+	}
+
+	// index_csum at 32:64 = SHA256(digest_0 || digest_1).
+	expected := sha256.Sum256(append(digest0[:], digest1[:]...))
+	var gotCsum [32]byte
+	copy(gotCsum[:], data[32:64])
+	if gotCsum != expected {
+		t.Errorf("index_csum mismatch in file")
+	}
+	if csum != expected {
+		t.Errorf("Close() returned csum != written csum")
+	}
+
+	// size at 64:72 (LE uint64).
+	gotSize := binary.LittleEndian.Uint64(data[64:72])
+	if gotSize != totalSize {
+		t.Errorf("size: got %d, want %d", gotSize, totalSize)
+	}
+
+	// chunk_size at 72:80 (LE uint64).
+	gotChunkSize := binary.LittleEndian.Uint64(data[72:80])
+	if gotChunkSize != uint64(testChunkSize) {
+		t.Errorf("chunk_size: got %d, want %d", gotChunkSize, testChunkSize)
+	}
+
+	// reserved 80:4096 must be all zeros.
+	for i := 80; i < headerSize; i++ {
+		if data[i] != 0 {
+			t.Errorf("reserved byte at offset %d is non-zero (%d)", i, data[i])
+			break
+		}
+	}
+
+	// digest_0 at 4096:4128.
+	var gotDigest0 [32]byte
+	copy(gotDigest0[:], data[headerSize:headerSize+digestSize])
+	if gotDigest0 != digest0 {
+		t.Error("digest_0 mismatch")
+	}
+
+	// digest_1 at 4128:4160.
+	var gotDigest1 [32]byte
+	copy(gotDigest1[:], data[headerSize+digestSize:headerSize+2*digestSize])
+	if gotDigest1 != digest1 {
+		t.Error("digest_1 mismatch")
+	}
+}
+
+func TestAddChunk_LastChunkSmaller_OK(t *testing.T) {
+	dir := t.TempDir()
+	totalSize := uint64(5 * 1024 * 1024) // 5 MiB: 1 full + 1 partial chunk
+	w, err := Create(filepath.Join(dir, "test.fidx"), totalSize, testChunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var d0, d1 [32]byte
+	if err := w.AddChunk(uint64(testChunkSize), uint32(testChunkSize), d0); err != nil {
+		t.Fatalf("full chunk: %v", err)
+	}
+	if err := w.AddChunk(totalSize, uint32(1024*1024), d1); err != nil { // 1 MiB last chunk
+		t.Fatalf("small last chunk: %v", err)
+	}
+	if _, err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAddChunk_NonLastChunkWrongSize_Rejected(t *testing.T) {
+	dir := t.TempDir()
+	totalSize := uint64(8 * 1024 * 1024)
+	w, _ := Create(filepath.Join(dir, "test.fidx"), totalSize, testChunkSize)
+	defer w.Drop()
+
+	// Non-last chunk with size < chunk_size (misaligned pos → error).
+	var d [32]byte
+	err := w.AddChunk(uint64(3*1024*1024), uint32(3*1024*1024), d)
+	if err == nil {
+		t.Error("expected error for non-last chunk with wrong size")
+	}
+}
+
+func TestAddChunk_OversizedChunk_Rejected(t *testing.T) {
+	dir := t.TempDir()
+	w, _ := Create(filepath.Join(dir, "test.fidx"), uint64(8*testChunkSize), testChunkSize)
+	defer w.Drop()
+
+	var d [32]byte
+	err := w.AddChunk(uint64(testChunkSize)+1, uint32(testChunkSize)+1, d)
+	if err == nil {
+		t.Error("expected error for oversized chunk")
+	}
+}
+
+func TestClose_IsIdempotentError(t *testing.T) {
+	dir := t.TempDir()
+	w, _ := Create(filepath.Join(dir, "test.fidx"), uint64(testChunkSize), testChunkSize)
+	var d [32]byte
+	_ = w.AddChunk(uint64(testChunkSize), uint32(testChunkSize), d)
+	if _, err := w.Close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	if _, err := w.Close(); err == nil {
+		t.Error("expected error on second Close, got nil")
+	}
+}
+
+func TestDrop_RemovesTempFile(t *testing.T) {
+	dir := t.TempDir()
+	finalPath := filepath.Join(dir, "test.fidx")
+	w, err := Create(finalPath, uint64(testChunkSize), testChunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Drop()
+
+	// Final path must not exist.
+	if _, err := os.Stat(finalPath); err == nil {
+		t.Error("final .fidx exists after Drop (should not)")
+	}
+
+	// No .tmp.* files should remain in dir.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp.") {
+			t.Errorf("temp file left after Drop: %s", e.Name())
+		}
+	}
+}
+
+func TestClose_AtomicRename(t *testing.T) {
+	dir := t.TempDir()
+	finalPath := filepath.Join(dir, "atomic.fidx")
+	w, _ := Create(finalPath, uint64(testChunkSize), testChunkSize)
+	var d [32]byte
+	_ = w.AddChunk(uint64(testChunkSize), uint32(testChunkSize), d)
+	if _, err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Final file must exist.
+	if _, err := os.Stat(finalPath); err != nil {
+		t.Errorf("final .fidx not found after Close: %v", err)
+	}
+
+	// No temp files remain.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp.") {
+			t.Errorf("temp file left after Close: %s", e.Name())
+		}
+	}
+}

--- a/services/backupos-pbs/internal/fixedappend/fixedappend.go
+++ b/services/backupos-pbs/internal/fixedappend/fixedappend.go
@@ -1,0 +1,111 @@
+// Package fixedappend implements the PUT /fixed_index H2 endpoint.
+//
+// The client sends a batch of (digest, offset) pairs to associate with an open
+// .fidx writer. Each digest must already be in the session's known_chunks map
+// (populated by POST /fixed_chunk). This is the critical check that prevents
+// associating unuploaded chunks.
+package fixedappend
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+// appendRequest is the JSON body for PUT /fixed_index.
+type appendRequest struct {
+	Wid        int      `json:"wid"`
+	DigestList []string `json:"digest-list"`
+	OffsetList []uint64 `json:"offset-list"`
+}
+
+// Handler implements PUT /fixed_index.
+type Handler struct{}
+
+// NewHandler constructs a fixedappend handler.
+func NewHandler() *Handler { return &Handler{} }
+
+// ServeHTTP routes PUT /fixed_index → batch append; any other method → 405.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		w.Header().Set("Allow", http.MethodPut)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil {
+		slog.Error("fixedappend handler invoked without streamctx")
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	var req appendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON body: %s", err.Error()))
+		return
+	}
+
+	if req.Wid < 1 || req.Wid > 256 {
+		writeError(w, http.StatusBadRequest, "invalid \"wid\": must be 1..256")
+		return
+	}
+	if len(req.DigestList) != len(req.OffsetList) {
+		writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("digest-list length %d != offset-list length %d",
+				len(req.DigestList), len(req.OffsetList)))
+		return
+	}
+
+	for i, digestHex := range req.DigestList {
+		offset := req.OffsetList[i]
+
+		if len(digestHex) != 64 {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("digest-list[%d]: must be 64 hex chars", i))
+			return
+		}
+		digestBytes, err := hex.DecodeString(digestHex)
+		if err != nil {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("digest-list[%d]: invalid hex", i))
+			return
+		}
+		var digest [32]byte
+		copy(digest[:], digestBytes)
+
+		size, ok := sc.WriterState.LookupChunk(digest)
+		if !ok {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("digest-list[%d]: chunk %s not uploaded in this session", i, digestHex[:16]+"..."))
+			return
+		}
+
+		if err := sc.WriterState.FixedWriterAppendChunk(req.Wid, offset, size, digest); err != nil {
+			slog.Info("fixedappend chunk append failed",
+				"reason", err.Error(), "session_id", sc.SessionID, "index", i)
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
+	slog.Info("fixed_index appended",
+		"session_id", sc.SessionID,
+		"wid", req.Wid,
+		"count", len(req.DigestList),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"data":null}`))
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/fixedappend/fixedappend_test.go
+++ b/services/backupos-pbs/internal/fixedappend/fixedappend_test.go
@@ -1,0 +1,154 @@
+package fixedappend
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
+)
+
+func injectCtx(sc *streamctx.SessionContext, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sc)))
+	})
+}
+
+type testFidx struct{ chunks int }
+
+func (f *testFidx) AddChunk(_ uint64, _ uint32, _ [32]byte) error {
+	f.chunks++
+	return nil
+}
+func (f *testFidx) IndexLength() uint64       { return uint64(f.chunks) }
+func (f *testFidx) Close() ([32]byte, error)  { return [32]byte{}, nil }
+func (f *testFidx) UUID() [16]byte            { return [16]byte{} }
+func (f *testFidx) Drop()                     {}
+
+func setupSC(t *testing.T) (*streamctx.SessionContext, int, [32]byte) {
+	t.Helper()
+	ws := wstate.New()
+	fi := &testFidx{}
+	size := uint64(4 * 1024 * 1024)
+	wid, _ := ws.RegisterFixedWriter("drive-0.fidx", fi, &size, 4*1024*1024, false)
+
+	// Register a known chunk in the session.
+	var digest [32]byte
+	for i := range digest {
+		digest[i] = byte(i)
+	}
+	_ = ws.RegisterFixedChunk(wid, digest, 4*1024*1024, false)
+
+	sc := &streamctx.SessionContext{
+		SessionID:   "sess-test",
+		WriterState: ws,
+		BackupType:  "vm",
+		BackupID:    "100",
+		BackupTime:  time.Unix(1735000000, 0),
+	}
+	return sc, wid, digest
+}
+
+func bodyJSON(v interface{}) *bytes.Buffer {
+	b, _ := json.Marshal(v)
+	return bytes.NewBuffer(b)
+}
+
+func TestFixedAppend_WrongMethod_Returns405(t *testing.T) {
+	sc, _, _ := setupSC(t)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/fixed_index", "application/json", bytes.NewReader([]byte("{}")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedAppend_MissingStreamCtx_Returns500(t *testing.T) {
+	srv := httptest.NewServer(NewHandler())
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/fixed_index",
+		bodyJSON(map[string]interface{}{"wid": 1, "digest-list": []string{}, "offset-list": []int{}}))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedAppend_MismatchedLists_Returns400(t *testing.T) {
+	sc, wid, _ := setupSC(t)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	body := map[string]interface{}{
+		"wid":         wid,
+		"digest-list": []string{"aa"},
+		"offset-list": []int{},
+	}
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/fixed_index", bodyJSON(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for mismatched lists, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedAppend_DigestNotInKnownChunks_Returns400(t *testing.T) {
+	sc, wid, _ := setupSC(t)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	var unknownDigest [32]byte
+	unknownDigest[0] = 0xFF
+	body := map[string]interface{}{
+		"wid":         wid,
+		"digest-list": []string{hex.EncodeToString(unknownDigest[:])},
+		"offset-list": []uint64{4194304},
+	}
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/fixed_index", bodyJSON(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for unknown digest, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedAppend_HappyPath_Returns200(t *testing.T) {
+	sc, wid, digest := setupSC(t)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	body := map[string]interface{}{
+		"wid":         wid,
+		"digest-list": []string{hex.EncodeToString(digest[:])},
+		"offset-list": []uint64{4194304},
+	}
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/fixed_index", bodyJSON(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}

--- a/services/backupos-pbs/internal/fixedchunk/fixedchunk.go
+++ b/services/backupos-pbs/internal/fixedchunk/fixedchunk.go
@@ -1,0 +1,179 @@
+// Package fixedchunk implements the POST /fixed_chunk H2 endpoint.
+//
+// The client uploads each chunk DataBlob here before associating it with an
+// index position via PUT /fixed_index. The server:
+//  1. Validates query parameters and body size.
+//  2. Parses the body as a DataBlob.
+//  3. Verifies SHA256(plaintext) == digest for unencrypted blobs.
+//  4. Writes the DataBlob into the content-addressed chunk store.
+//  5. Registers the chunk in the session's known_chunks map.
+package fixedchunk
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/chunkstore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datablob"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+const (
+	maxChunkPlaintext = 16 * 1024 * 1024
+	maxBlobEncoded    = maxChunkPlaintext + 44 // 44 = encrypted header overhead
+	minBlobEncoded    = 13                     // 12-byte unencrypted header + 1 byte payload
+)
+
+// Handler implements POST /fixed_chunk.
+type Handler struct{}
+
+// NewHandler constructs a fixedchunk handler.
+func NewHandler() *Handler { return &Handler{} }
+
+// ServeHTTP routes POST /fixed_chunk → upload; any other method → 405.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil {
+		slog.Error("fixedchunk handler invoked without streamctx")
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	wid, digest, plainSize, encodedSize, err := parseQuery(r.URL.Query())
+	if err != nil {
+		slog.Info("fixed_chunk rejected: bad params", "reason", err.Error(), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Read body up to encodedSize+1 to detect oversized payloads.
+	limited := io.LimitReader(r.Body, int64(encodedSize)+1)
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		slog.Error("fixed_chunk body read failed", "error", err, "session_id", sc.SessionID)
+		writeError(w, http.StatusInternalServerError, "read failed")
+		return
+	}
+	if int64(len(raw)) != int64(encodedSize) {
+		slog.Info("fixed_chunk rejected: body size mismatch",
+			"want", encodedSize, "got", len(raw), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("body length %d does not match encoded-size %d", len(raw), encodedSize))
+		return
+	}
+
+	blob, err := datablob.Parse(raw)
+	if err != nil {
+		slog.Info("fixed_chunk rejected: bad DataBlob", "reason", err.Error(), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid DataBlob: %s", err.Error()))
+		return
+	}
+
+	if err := blob.VerifyUnencrypted(plainSize, digest); err != nil {
+		slog.Info("fixed_chunk rejected: verification failed",
+			"reason", err.Error(), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("chunk verification failed: %s", err.Error()))
+		return
+	}
+
+	cs, err := chunkstore.New(sc.DatastoreRoot)
+	if err != nil {
+		slog.Error("chunk store init failed",
+			"error", err, "session_id", sc.SessionID, "datastore_root", sc.DatastoreRoot)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	isDuplicate, _, err := cs.Insert(digest, raw)
+	if err != nil {
+		slog.Error("chunk insert failed", "error", err, "session_id", sc.SessionID)
+		writeError(w, http.StatusInternalServerError, "chunk write failed")
+		return
+	}
+
+	if err := sc.WriterState.RegisterFixedChunk(wid, digest, plainSize, isDuplicate); err != nil {
+		slog.Info("fixed_chunk rejected: register failed",
+			"reason", err.Error(), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	slog.Info("fixed_chunk uploaded",
+		"session_id", sc.SessionID,
+		"wid", wid,
+		"digest", hex.EncodeToString(digest[:]),
+		"size", plainSize,
+		"duplicate", isDuplicate,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"data": hex.EncodeToString(digest[:])})
+}
+
+// parseQuery validates and extracts query parameters.
+func parseQuery(q map[string][]string) (wid int, digest [32]byte, plainSize uint32, encodedSize int64, err error) {
+	get := func(k string) string {
+		if v := q[k]; len(v) > 0 {
+			return v[0]
+		}
+		return ""
+	}
+
+	widRaw := get("wid")
+	if widRaw == "" {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("missing required parameter \"wid\"")
+	}
+	widI, e := strconv.Atoi(widRaw)
+	if e != nil || widI < 1 || widI > 256 {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("invalid \"wid\": must be 1..256")
+	}
+
+	digestHex := get("digest")
+	if len(digestHex) != 64 {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("invalid \"digest\": must be 64 hex chars")
+	}
+	digestBytes, e := hex.DecodeString(digestHex)
+	if e != nil {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("invalid \"digest\": not valid hex")
+	}
+	var d [32]byte
+	copy(d[:], digestBytes)
+
+	sizeRaw := get("size")
+	if sizeRaw == "" {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("missing required parameter \"size\"")
+	}
+	sizeI, e := strconv.ParseInt(sizeRaw, 10, 64)
+	if e != nil || sizeI < 1 || sizeI > maxChunkPlaintext {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("invalid \"size\": must be 1..%d", maxChunkPlaintext)
+	}
+
+	encSizeRaw := get("encoded-size")
+	if encSizeRaw == "" {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("missing required parameter \"encoded-size\"")
+	}
+	encSizeI, e := strconv.ParseInt(encSizeRaw, 10, 64)
+	if e != nil || encSizeI < minBlobEncoded || encSizeI > maxBlobEncoded {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("invalid \"encoded-size\": must be %d..%d", minBlobEncoded, maxBlobEncoded)
+	}
+
+	return widI, d, uint32(sizeI), encSizeI, nil
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/fixedchunk/fixedchunk_test.go
+++ b/services/backupos-pbs/internal/fixedchunk/fixedchunk_test.go
@@ -1,0 +1,188 @@
+package fixedchunk
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datablob"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
+)
+
+func injectCtx(sc *streamctx.SessionContext, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sc)))
+	})
+}
+
+// setupSC creates a SessionContext with a wstate that has one registered writer.
+// Returns the sc, the wid, and the datastore root.
+func setupSC(t *testing.T) (*streamctx.SessionContext, int, string) {
+	t.Helper()
+	root := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(root, ".chunks"), 0o755)
+
+	ws := wstate.New()
+	// fakeFidx for wstate — we need a FixedIndexWriter interface impl.
+	// We use a minimal anonymous struct via adapter below.
+	fi := &testFidx{}
+	size := uint64(4 * 1024 * 1024)
+	wid, err := ws.RegisterFixedWriter("drive-0.fidx", fi, &size, 4*1024*1024, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sc := &streamctx.SessionContext{
+		SessionID:     "sess-test",
+		DatastoreRoot: root,
+		BackupType:    "vm",
+		BackupID:      "100",
+		BackupTime:    time.Unix(1735000000, 0),
+		WriterState:   ws,
+	}
+	return sc, wid, root
+}
+
+// testFidx is a no-op FixedIndexWriter for handler tests.
+type testFidx struct{}
+
+func (f *testFidx) AddChunk(_ uint64, _ uint32, _ [32]byte) error { return nil }
+func (f *testFidx) IndexLength() uint64                           { return 0 }
+func (f *testFidx) Close() ([32]byte, error)                      { return [32]byte{}, nil }
+func (f *testFidx) UUID() [16]byte                                { return [16]byte{} }
+func (f *testFidx) Drop()                                         {}
+
+// makeBlob builds an uncompressed DataBlob from data.
+func makeBlob(data []byte) []byte {
+	blob := make([]byte, 12+len(data))
+	copy(blob[0:8], datablob.MagicUncompressed[:])
+	copy(blob[12:], data)
+	return blob
+}
+
+func TestFixedChunk_WrongMethod_Returns405(t *testing.T) {
+	sc, _, _ := setupSC(t)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/fixed_chunk", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedChunk_MissingStreamCtx_Returns500(t *testing.T) {
+	srv := httptest.NewServer(NewHandler())
+	defer srv.Close()
+
+	resp, _ := http.Post(srv.URL+"/fixed_chunk", "", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedChunk_MissingParams_Returns400(t *testing.T) {
+	sc, _, _ := setupSC(t)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	// No query params at all.
+	resp, _ := http.Post(srv.URL+"/fixed_chunk", "", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing params, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedChunk_BadDigestHex_Returns400(t *testing.T) {
+	sc, wid, _ := setupSC(t)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	url := fmt.Sprintf("%s/fixed_chunk?wid=%d&digest=notvalidhex&size=4&encoded-size=16", srv.URL, wid)
+	resp, _ := http.Post(url, "application/octet-stream", bytes.NewReader(make([]byte, 16)))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for bad digest, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedChunk_DigestMismatch_Returns400(t *testing.T) {
+	sc, wid, root := setupSC(t)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	payload := []byte("test payload")
+	blob := makeBlob(payload)
+	realDigest := sha256.Sum256(payload)
+
+	// Create shard dir for real digest.
+	prefix := hex.EncodeToString(realDigest[:])[:4]
+	_ = os.MkdirAll(filepath.Join(root, ".chunks", prefix), 0o755)
+
+	// Claim a WRONG digest.
+	var wrongDigest [32]byte
+	wrongDigest[0] = 0xFF
+	url := fmt.Sprintf("%s/fixed_chunk?wid=%d&digest=%s&size=%d&encoded-size=%d",
+		srv.URL, wid, hex.EncodeToString(wrongDigest[:]), len(payload), len(blob))
+	resp, _ := http.Post(url, "application/octet-stream", bytes.NewReader(blob))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for digest mismatch, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedChunk_HappyPath(t *testing.T) {
+	sc, wid, root := setupSC(t)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	payload := []byte("chunk payload for happy path test")
+	blob := makeBlob(payload)
+	digest := sha256.Sum256(payload)
+	digestHex := hex.EncodeToString(digest[:])
+
+	// Pre-create the shard dir for this digest.
+	prefix := digestHex[:4]
+	_ = os.MkdirAll(filepath.Join(root, ".chunks", prefix), 0o755)
+
+	url := fmt.Sprintf("%s/fixed_chunk?wid=%d&digest=%s&size=%d&encoded-size=%d",
+		srv.URL, wid, digestHex, len(payload), len(blob))
+	resp, err := http.Post(url, "application/octet-stream", bytes.NewReader(blob))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// Chunk must be registered in known_chunks.
+	size, ok := sc.WriterState.LookupChunk(digest)
+	if !ok {
+		t.Error("chunk not registered in known_chunks after upload")
+	}
+	if size != uint32(len(payload)) {
+		t.Errorf("known_chunks size: got %d, want %d", size, len(payload))
+	}
+
+	// Chunk file must exist on disk.
+	chunkPath := filepath.Join(root, ".chunks", prefix, digestHex)
+	if _, err := os.Stat(chunkPath); err != nil {
+		t.Errorf("chunk file not found on disk: %v", err)
+	}
+}

--- a/services/backupos-pbs/internal/fixedclose/fixedclose.go
+++ b/services/backupos-pbs/internal/fixedclose/fixedclose.go
@@ -1,0 +1,125 @@
+// Package fixedclose implements the POST /fixed_close H2 endpoint.
+//
+// The client calls POST /fixed_close after all chunks have been uploaded and
+// associated via PUT /fixed_index. The server validates:
+//  1. chunk-count matches the number of FixedWriterAppendChunk calls
+//  2. size matches the known content size (non-incremental)
+//  3. The server-computed index checksum matches the client-provided csum
+//
+// On success the .fidx file is atomically finalised on disk.
+package fixedclose
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+// Handler implements POST /fixed_close.
+type Handler struct{}
+
+// NewHandler constructs a fixedclose handler.
+func NewHandler() *Handler { return &Handler{} }
+
+// ServeHTTP routes POST /fixed_close → finalise; any other method → 405.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil {
+		slog.Error("fixedclose handler invoked without streamctx")
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	wid, chunkCount, size, csum, err := parseQuery(r.URL.Query())
+	if err != nil {
+		slog.Info("fixed_close rejected: bad params", "reason", err.Error(), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	_, err = sc.WriterState.FixedWriterClose(wid, chunkCount, size, csum)
+	if err != nil {
+		slog.Info("fixed_close failed",
+			"reason", err.Error(), "session_id", sc.SessionID, "wid", wid)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	slog.Info("fixed_close finalised",
+		"session_id", sc.SessionID,
+		"wid", wid,
+		"chunk_count", chunkCount,
+		"size", size,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"data":null}`))
+}
+
+// parseQuery validates and extracts query parameters.
+func parseQuery(q map[string][]string) (wid int, chunkCount uint64, size uint64, csum [32]byte, err error) {
+	get := func(k string) string {
+		if v := q[k]; len(v) > 0 {
+			return v[0]
+		}
+		return ""
+	}
+
+	widRaw := get("wid")
+	if widRaw == "" {
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("missing required parameter \"wid\"")
+	}
+	widI, e := strconv.Atoi(widRaw)
+	if e != nil || widI < 1 || widI > 256 {
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("invalid \"wid\": must be 1..256")
+	}
+
+	ccRaw := get("chunk-count")
+	if ccRaw == "" {
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("missing required parameter \"chunk-count\"")
+	}
+	ccI, e := strconv.ParseUint(ccRaw, 10, 64)
+	if e != nil {
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("invalid \"chunk-count\"")
+	}
+
+	sizeRaw := get("size")
+	if sizeRaw == "" {
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("missing required parameter \"size\"")
+	}
+	sizeI, e := strconv.ParseUint(sizeRaw, 10, 64)
+	if e != nil {
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("invalid \"size\"")
+	}
+
+	csumHex := get("csum")
+	if len(csumHex) != 64 {
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("invalid \"csum\": must be 64 hex chars")
+	}
+	csumBytes, e := hex.DecodeString(csumHex)
+	if e != nil {
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("invalid \"csum\": not valid hex")
+	}
+	var c [32]byte
+	copy(c[:], csumBytes)
+
+	return widI, ccI, sizeI, c, nil
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/fixedclose/fixedclose_test.go
+++ b/services/backupos-pbs/internal/fixedclose/fixedclose_test.go
@@ -1,0 +1,150 @@
+package fixedclose
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
+)
+
+func injectCtx(sc *streamctx.SessionContext, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sc)))
+	})
+}
+
+type testFidx struct {
+	chunks      int
+	closeReturn [32]byte
+}
+
+func (f *testFidx) AddChunk(_ uint64, _ uint32, _ [32]byte) error {
+	f.chunks++
+	return nil
+}
+func (f *testFidx) IndexLength() uint64      { return uint64(f.chunks) }
+func (f *testFidx) Close() ([32]byte, error) { return f.closeReturn, nil }
+func (f *testFidx) UUID() [16]byte           { return [16]byte{} }
+func (f *testFidx) Drop()                    {}
+
+func setupSC(t *testing.T, serverCsum [32]byte) (*streamctx.SessionContext, int) {
+	t.Helper()
+	ws := wstate.New()
+	fi := &testFidx{closeReturn: serverCsum}
+	size := uint64(4 * 1024 * 1024)
+	wid, _ := ws.RegisterFixedWriter("drive-0.fidx", fi, &size, 4*1024*1024, false)
+
+	// Append one chunk so server chunk count = 1.
+	var digest [32]byte
+	_ = ws.FixedWriterAppendChunk(wid, 4194304, 4194304, digest)
+
+	sc := &streamctx.SessionContext{
+		SessionID:   "sess-test",
+		WriterState: ws,
+		BackupType:  "vm",
+		BackupID:    "100",
+		BackupTime:  time.Unix(1735000000, 0),
+	}
+	return sc, wid
+}
+
+func closeURL(base string, wid int, chunkCount uint64, size uint64, csum [32]byte) string {
+	return fmt.Sprintf("%s/fixed_close?wid=%d&chunk-count=%d&size=%d&csum=%s",
+		base, wid, chunkCount, size, hex.EncodeToString(csum[:]))
+}
+
+func TestFixedClose_WrongMethod_Returns405(t *testing.T) {
+	var csum [32]byte
+	sc, wid := setupSC(t, csum)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, closeURL(srv.URL, wid, 1, 4194304, csum), nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedClose_MissingStreamCtx_Returns500(t *testing.T) {
+	srv := httptest.NewServer(NewHandler())
+	defer srv.Close()
+
+	var csum [32]byte
+	resp, _ := http.Post(closeURL(srv.URL, 1, 0, 0, csum), "", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedClose_WrongChunkCount_Returns400(t *testing.T) {
+	var serverCsum [32]byte
+	sc, wid := setupSC(t, serverCsum)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	// Server appended 1 chunk; client claims 2.
+	resp, _ := http.Post(closeURL(srv.URL, wid, 2, 4194304, serverCsum), "", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for chunk count mismatch, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedClose_CsumMismatch_Returns400(t *testing.T) {
+	var serverCsum [32]byte
+	serverCsum[0] = 0xAA
+	sc, wid := setupSC(t, serverCsum)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	var wrongCsum [32]byte
+	wrongCsum[0] = 0xBB
+	resp, _ := http.Post(closeURL(srv.URL, wid, 1, 4194304, wrongCsum), "", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for csum mismatch, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedClose_HappyPath_Returns200(t *testing.T) {
+	var serverCsum [32]byte
+	for i := range serverCsum {
+		serverCsum[i] = byte(i)
+	}
+	sc, wid := setupSC(t, serverCsum)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	resp, err := http.Post(closeURL(srv.URL, wid, 1, 4194304, serverCsum), "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedClose_MissingParams_Returns400(t *testing.T) {
+	var csum [32]byte
+	sc, _ := setupSC(t, csum)
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	resp, _ := http.Post(srv.URL+"/fixed_close", "", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing params, got %d", resp.StatusCode)
+	}
+}

--- a/services/backupos-pbs/internal/fixedindex/fixedindex.go
+++ b/services/backupos-pbs/internal/fixedindex/fixedindex.go
@@ -1,0 +1,135 @@
+// Package fixedindex implements the POST /fixed_index H2 endpoint.
+//
+// The client calls POST /fixed_index once per .fidx file it wants to create.
+// The server creates the .fidx writer, registers it in the session WriterState,
+// and returns the writer ID (wid) for use in subsequent PUT /fixed_index and
+// POST /fixed_close calls.
+package fixedindex
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strconv"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fidx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snapshot"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+// chunkSize is hardcoded to 4 MiB per the PBS reference implementation.
+// It is NOT exposed as a query parameter.
+const chunkSize = 4 * 1024 * 1024
+
+// archiveNameRegex matches valid .fidx archive names.
+var archiveNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_.-]+\.fidx$`)
+
+// Handler implements POST /fixed_index.
+type Handler struct{}
+
+// NewHandler constructs a fixedindex handler.
+func NewHandler() *Handler { return &Handler{} }
+
+// ServeHTTP routes POST /fixed_index → create writer; any other method → 405.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil {
+		slog.Error("fixedindex handler invoked without streamctx")
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	archiveName, size, err := parseQuery(r.URL.Query())
+	if err != nil {
+		slog.Info("fixed_index rejected", "reason", err.Error(), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	snapDir, err := snapshot.EnsureDir(sc.DatastoreRoot, sc.BackupType, sc.BackupID, sc.BackupTime)
+	if err != nil {
+		slog.Error("snapshot dir ensure failed",
+			"error", err, "session_id", sc.SessionID, "datastore_root", sc.DatastoreRoot)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	finalPath := snapDir + "/" + archiveName
+	fw, err := fidx.Create(finalPath, size, chunkSize)
+	if err != nil {
+		slog.Error("fidx create failed",
+			"error", err, "session_id", sc.SessionID, "archive_name", archiveName)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	sizeVal := size
+	wid, err := sc.WriterState.RegisterFixedWriter(archiveName, fw, &sizeVal, chunkSize, false)
+	if err != nil {
+		fw.Drop()
+		slog.Error("register fixed writer failed",
+			"error", err, "session_id", sc.SessionID, "archive_name", archiveName)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	slog.Info("fixed_index created",
+		"session_id", sc.SessionID,
+		"archive_name", archiveName,
+		"size", size,
+		"wid", wid,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]int{"data": wid})
+}
+
+// parseQuery validates and extracts query parameters.
+func parseQuery(q map[string][]string) (archiveName string, size uint64, err error) {
+	get := func(k string) string {
+		if v := q[k]; len(v) > 0 {
+			return v[0]
+		}
+		return ""
+	}
+
+	if get("reuse-csum") != "" {
+		return "", 0, fmt.Errorf("incremental backups (reuse-csum) not supported in V1")
+	}
+
+	archiveName = get("archive-name")
+	if archiveName == "" {
+		return "", 0, fmt.Errorf("missing required parameter \"archive-name\"")
+	}
+	if len(archiveName) > 64 {
+		return "", 0, fmt.Errorf("\"archive-name\" too long (max 64 chars)")
+	}
+	if !archiveNameRegex.MatchString(archiveName) {
+		return "", 0, fmt.Errorf("invalid \"archive-name\": must match [A-Za-z0-9_.-]+\\.fidx")
+	}
+
+	sizeRaw := get("size")
+	if sizeRaw == "" {
+		return "", 0, fmt.Errorf("missing required parameter \"size\" (growable .fidx not supported in V1)")
+	}
+	sizeI, err2 := strconv.ParseUint(sizeRaw, 10, 64)
+	if err2 != nil || sizeI == 0 {
+		return "", 0, fmt.Errorf("invalid \"size\": must be a positive integer")
+	}
+	return archiveName, sizeI, nil
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/fixedindex/fixedindex_test.go
+++ b/services/backupos-pbs/internal/fixedindex/fixedindex_test.go
@@ -1,0 +1,161 @@
+package fixedindex
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
+)
+
+func injectCtx(sc *streamctx.SessionContext, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sc)))
+	})
+}
+
+func newTestSC(t *testing.T, root string) *streamctx.SessionContext {
+	t.Helper()
+	return &streamctx.SessionContext{
+		SessionID:     "sess-test",
+		DatastoreRoot: root,
+		BackupType:    "vm",
+		BackupID:      "100",
+		BackupTime:    time.Unix(1735000000, 0),
+		WriterState:   wstate.New(),
+	}
+}
+
+func TestFixedIndex_WrongMethod_Returns405(t *testing.T) {
+	sc := newTestSC(t, t.TempDir())
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/fixed_index?archive-name=drive-0.fidx&size=8388608")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedIndex_MissingStreamCtx_Returns500(t *testing.T) {
+	srv := httptest.NewServer(NewHandler()) // no ctx injected
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/fixed_index?archive-name=drive-0.fidx&size=8388608", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedIndex_MissingArchiveName_Returns400(t *testing.T) {
+	sc := newTestSC(t, t.TempDir())
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/fixed_index?size=8388608", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedIndex_BadExtension_Returns400(t *testing.T) {
+	sc := newTestSC(t, t.TempDir())
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/fixed_index?archive-name=drive.blob&size=8388608", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for non-.fidx name, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedIndex_ReuseCsum_Returns400(t *testing.T) {
+	sc := newTestSC(t, t.TempDir())
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/fixed_index?archive-name=drive-0.fidx&size=8388608&reuse-csum=aabbcc", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for reuse-csum, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedIndex_MissingSize_Returns400(t *testing.T) {
+	sc := newTestSC(t, t.TempDir())
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/fixed_index?archive-name=drive-0.fidx", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing size, got %d", resp.StatusCode)
+	}
+}
+
+func TestFixedIndex_HappyPath_ReturnsWid(t *testing.T) {
+	sc := newTestSC(t, t.TempDir())
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/fixed_index?archive-name=drive-0.fidx&size=8388608", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Data int `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Data != 1 {
+		t.Errorf("expected wid=1, got %d", body.Data)
+	}
+}
+
+func TestFixedIndex_SecondCall_ReturnsWid2(t *testing.T) {
+	sc := newTestSC(t, t.TempDir())
+	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
+	defer srv.Close()
+
+	for i := 1; i <= 2; i++ {
+		url := srv.URL + "/fixed_index?archive-name=drive-" + string(rune('0'+i-1)) + ".fidx&size=4194304"
+		resp, _ := http.Post(url, "", nil)
+		defer resp.Body.Close()
+		var body struct{ Data int `json:"data"` }
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		if body.Data != i {
+			t.Errorf("call %d: expected wid=%d, got %d", i, i, body.Data)
+		}
+	}
+}

--- a/services/backupos-pbs/internal/streamctx/streamctx.go
+++ b/services/backupos-pbs/internal/streamctx/streamctx.go
@@ -13,19 +13,22 @@ import (
 	"context"
 	"net/http"
 	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
 )
 
 // SessionContext holds everything a per-stream handler needs to know about
 // the session it's serving. Once the upgrade handshake completes, this is
 // constant for the lifetime of the H2 connection.
 type SessionContext struct {
-	SessionID     string    // pbs_active_sessions.id (UUID)
-	DatastoreID   string    // pbs_datastores.id
-	DatastoreRoot string    // absolute filesystem path of the datastore
-	BackupType    string    // "vm" | "ct" | "host"
-	BackupID      string    // e.g. "100"
-	BackupTime    time.Time // backup-time
-	Namespace     string    // optional, "" if none
+	SessionID     string       // pbs_active_sessions.id (UUID)
+	DatastoreID   string       // pbs_datastores.id
+	DatastoreRoot string       // absolute filesystem path of the datastore
+	BackupType    string       // "vm" | "ct" | "host"
+	BackupID      string       // e.g. "100"
+	BackupTime    time.Time    // backup-time
+	Namespace     string       // optional, "" if none
+	WriterState   *wstate.State // per-session writer state (fixed/dynamic index maps)
 }
 
 type ctxKey struct{}

--- a/services/backupos-pbs/internal/upgrade/handler.go
+++ b/services/backupos-pbs/internal/upgrade/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
 )
 
 // UpgradeToken is the custom Upgrade header value PVE sends for backup
@@ -36,31 +37,44 @@ const UpgradeToken = "proxmox-backup-protocol-v1"
 // is expected to wrap this with the requireAuth middleware, which also
 // attaches the Identity to the request context via auth.WithIdentity.
 type Handler struct {
-	datastores    *datastore.Lookup
-	sessions      *session.Store
-	blobHandler   http.Handler
-	finishHandler http.Handler
-	streamHandler http.Handler // fallback 501-stub for unimplemented H2 paths
+	datastores         *datastore.Lookup
+	sessions           *session.Store
+	blobHandler        http.Handler
+	finishHandler      http.Handler
+	fixedIndexHandler  http.Handler
+	fixedChunkHandler  http.Handler
+	fixedAppendHandler http.Handler
+	fixedCloseHandler  http.Handler
+	streamHandler      http.Handler // fallback 501-stub for unimplemented H2 paths
 }
 
 // NewHandler constructs a new upgrade Handler.
 //
 // blobHandler handles POST /blob; finishHandler handles POST /finish.
-// streamHandler is the fallback invoked for all other H2 paths (501 stub until
-// M4c-go-fixed-index, etc. land).
+// fixedIndexHandler, fixedChunkHandler, fixedAppendHandler, fixedCloseHandler
+// handle the fixed-index lifecycle.
+// streamHandler is the fallback invoked for all other H2 paths (501 stub).
 func NewHandler(
 	datastores *datastore.Lookup,
 	sessions *session.Store,
 	blobHandler http.Handler,
 	finishHandler http.Handler,
+	fixedIndexHandler http.Handler,
+	fixedChunkHandler http.Handler,
+	fixedAppendHandler http.Handler,
+	fixedCloseHandler http.Handler,
 	streamHandler http.Handler,
 ) *Handler {
 	return &Handler{
-		datastores:    datastores,
-		sessions:      sessions,
-		blobHandler:   blobHandler,
-		finishHandler: finishHandler,
-		streamHandler: streamHandler,
+		datastores:         datastores,
+		sessions:           sessions,
+		blobHandler:        blobHandler,
+		finishHandler:      finishHandler,
+		fixedIndexHandler:  fixedIndexHandler,
+		fixedChunkHandler:  fixedChunkHandler,
+		fixedAppendHandler: fixedAppendHandler,
+		fixedCloseHandler:  fixedCloseHandler,
+		streamHandler:      streamHandler,
 	}
 }
 
@@ -97,7 +111,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if errors.Is(err, datastore.ErrInvalidName) {
-		// Should be caught by ParseParams; defensive.
 		writeUpgradeError(w, http.StatusBadRequest, "invalid datastore name")
 		return
 	}
@@ -110,8 +123,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Step 4: Begin session row (token from context, set by requireAuth).
 	identity := auth.FromContext(r.Context())
 	if identity == nil {
-		// Should be impossible — requireAuth always attaches identity.
-		// Defensive: refuse the upgrade rather than insert a row with NULL token_id.
 		slog.Error("upgrade reached without auth identity in context")
 		writeUpgradeError(w, http.StatusInternalServerError, "internal error")
 		return
@@ -139,7 +150,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Step 5: Hijack the connection.
 	hj, ok := w.(http.Hijacker)
 	if !ok {
-		// Should never happen with the standard http.Server.
 		slog.Error("ResponseWriter does not support hijacking")
 		writeUpgradeError(w, http.StatusInternalServerError, "hijack not supported")
 		_, _ = h.sessions.Finalize(sessionID)
@@ -176,9 +186,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Step 7: Hand off to http2.Server with a per-session router.
 	//
-	// Every H2 stream on this connection shares the same session context
-	// (datastore, backup-type/id/time). We build a per-session router that
-	// attaches that context to each stream's request before dispatching.
+	// Each H2 connection gets its own WriterState for in-memory fixed/dynamic
+	// index writer maps. Cleanup drops any open writers when the connection closes.
+	ws := wstate.New()
+	defer ws.Cleanup()
+
 	sessionCtx := &streamctx.SessionContext{
 		SessionID:     sessionID,
 		DatastoreID:   ds.ID,
@@ -187,8 +199,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		BackupID:      params.BackupID,
 		BackupTime:    params.BackupTime,
 		Namespace:     params.Namespace,
+		WriterState:   ws,
 	}
-	sessionRouter := buildSessionRouter(h.blobHandler, h.finishHandler, h.streamHandler)
+	sessionRouter := buildSessionRouter(
+		h.blobHandler, h.finishHandler,
+		h.fixedIndexHandler, h.fixedChunkHandler,
+		h.fixedAppendHandler, h.fixedCloseHandler,
+		h.streamHandler,
+	)
 	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sessionRouter.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sessionCtx)))
 	})
@@ -196,13 +214,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h2srv := &http2.Server{}
 	h2srv.ServeConn(conn, &http2.ServeConnOpts{
 		Handler: wrapped,
-		// We intentionally do NOT set UpgradeRequest — that's specifically
-		// for h2c upgrades where the original HTTP/1.1 request becomes the
-		// first H2 stream. PBS doesn't work that way; the upgrade response
-		// is ack-only and the client opens new streams.
-		// SawClientPreface stays false — the client preface arrives after
-		// our 101 over the same connection, which is what http2.Server
-		// expects as its default state.
 	})
 
 	// Step 8: Finalize on connection close.
@@ -270,13 +281,30 @@ func identifyKind(path string) string {
 }
 
 // buildSessionRouter routes H2 streams to the appropriate handler.
-func buildSessionRouter(blobHandler, finishHandler, fallback http.Handler) http.Handler {
+// /fixed_index dispatches POST→fixedIndex and PUT→fixedAppend.
+func buildSessionRouter(blobHandler, finishHandler, fixedIndexHandler, fixedChunkHandler, fixedAppendHandler, fixedCloseHandler, fallback http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/blob":
 			blobHandler.ServeHTTP(w, r)
 		case "/finish":
 			finishHandler.ServeHTTP(w, r)
+		case "/fixed_index":
+			switch r.Method {
+			case http.MethodPost:
+				fixedIndexHandler.ServeHTTP(w, r)
+			case http.MethodPut:
+				fixedAppendHandler.ServeHTTP(w, r)
+			default:
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Allow", "POST, PUT")
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "method not allowed"})
+			}
+		case "/fixed_chunk":
+			fixedChunkHandler.ServeHTTP(w, r)
+		case "/fixed_close":
+			fixedCloseHandler.ServeHTTP(w, r)
 		default:
 			fallback.ServeHTTP(w, r)
 		}

--- a/services/backupos-pbs/internal/upgrade/handler_test.go
+++ b/services/backupos-pbs/internal/upgrade/handler_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/blob"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/finish"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedappend"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedchunk"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedclose"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedindex"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 )
 
@@ -60,9 +64,7 @@ func setupTestDB(t *testing.T) *sql.DB {
 }
 
 // wrapWithTestIdentity injects a synthetic auth.Identity into the request
-// context, simulating what requireAuth does in production. Tests that bypass
-// the auth middleware need this wrapper so the upgrade handler can read the
-// identity for session row creation.
+// context, simulating what requireAuth does in production.
 func wrapWithTestIdentity(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := auth.WithIdentity(r.Context(), &auth.Identity{
@@ -75,9 +77,24 @@ func wrapWithTestIdentity(h http.Handler) http.Handler {
 	})
 }
 
+// newTestHandler constructs a Handler with all real sub-handlers and stub fallback.
+func newTestHandler(db *sql.DB) *Handler {
+	return NewHandler(
+		datastore.NewLookup(db),
+		session.NewStore(db),
+		blob.NewHandler(),
+		finish.NewHandler(session.NewStore(db)),
+		fixedindex.NewHandler(),
+		fixedchunk.NewHandler(),
+		fixedappend.NewHandler(),
+		fixedclose.NewHandler(),
+		StubStreamHandler(),
+	)
+}
+
 func TestHandler_NoUpgradeHeaders_Returns501(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), finish.NewHandler(session.NewStore(db)), StubStreamHandler())
+	h := newTestHandler(db)
 
 	srv := httptest.NewServer(wrapWithTestIdentity(h))
 	defer srv.Close()
@@ -95,7 +112,7 @@ func TestHandler_NoUpgradeHeaders_Returns501(t *testing.T) {
 
 func TestHandler_InvalidParams_Returns400(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), finish.NewHandler(session.NewStore(db)), StubStreamHandler())
+	h := newTestHandler(db)
 
 	srv := httptest.NewServer(wrapWithTestIdentity(h))
 	defer srv.Close()
@@ -116,7 +133,7 @@ func TestHandler_InvalidParams_Returns400(t *testing.T) {
 
 func TestHandler_DatastoreNotFound_Returns404(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), finish.NewHandler(session.NewStore(db)), StubStreamHandler())
+	h := newTestHandler(db)
 
 	srv := httptest.NewServer(wrapWithTestIdentity(h))
 	defer srv.Close()
@@ -147,7 +164,7 @@ func TestHandler_DatastoreNotFound_Returns404(t *testing.T) {
 // crashed Node in PR #244.
 func TestHandler_FullUpgradeDance(t *testing.T) {
 	db := setupTestDB(t)
-	h := NewHandler(datastore.NewLookup(db), session.NewStore(db), blob.NewHandler(), finish.NewHandler(session.NewStore(db)), StubStreamHandler())
+	h := newTestHandler(db)
 
 	// Use a TLS test server. EnableHTTP2=false so the test server doesn't
 	// negotiate H2 via ALPN — we want to drive the upgrade manually.

--- a/services/backupos-pbs/internal/wstate/wstate.go
+++ b/services/backupos-pbs/internal/wstate/wstate.go
@@ -1,0 +1,218 @@
+// Package wstate holds per-session writer state shared between H2 stream
+// handlers. This mirrors the Rust SharedBackupState in environment.rs.
+//
+// All fields are protected by a single mutex.
+package wstate
+
+import (
+	"fmt"
+	"sync"
+)
+
+// BackupPhase tracks whether the session is still accepting writes.
+type BackupPhase int
+
+const (
+	PhaseActive BackupPhase = iota
+	PhaseFinishing
+	PhaseFinished
+)
+
+// FixedIndexWriter is the contract wstate needs from a fidx writer.
+// Concrete implementation lives in internal/fidx.
+type FixedIndexWriter interface {
+	AddChunk(offset uint64, size uint32, digest [32]byte) error
+	IndexLength() uint64
+	Close() ([32]byte, error)
+	UUID() [16]byte
+	Drop()
+}
+
+// FixedWriter holds mutable state for one open .fidx writer.
+type FixedWriter struct {
+	Name            string
+	Index           FixedIndexWriter
+	Size            *uint64
+	ChunkSize       uint32
+	ChunkCount      uint64
+	SmallChunkCount int
+	Incremental     bool
+	Closed          bool
+}
+
+// DynamicWriter is a placeholder for future dynamic-index support.
+type DynamicWriter struct{}
+
+// State is the per-session shared writer state.
+type State struct {
+	mu             sync.Mutex
+	finished       BackupPhase
+	widCounter     int
+	fixedWriters   map[int]*FixedWriter
+	dynamicWriters map[int]*DynamicWriter
+	knownChunks    map[[32]byte]uint32
+}
+
+// New allocates a fresh State for a new backup session.
+func New() *State {
+	return &State{
+		finished:       PhaseActive,
+		fixedWriters:   make(map[int]*FixedWriter),
+		dynamicWriters: make(map[int]*DynamicWriter),
+		knownChunks:    make(map[[32]byte]uint32),
+	}
+}
+
+// EnsureUnfinished returns an error if the session is no longer active.
+// Caller must hold s.mu.
+func (s *State) EnsureUnfinished() error {
+	if s.finished != PhaseActive {
+		return fmt.Errorf("backup session already finishing or finished")
+	}
+	return nil
+}
+
+// nextWid increments and returns the next writer ID.
+// Caller must hold s.mu.
+func (s *State) nextWid() (int, error) {
+	s.widCounter++
+	if s.widCounter > 256 {
+		return 0, fmt.Errorf("too many writers in session (max 256)")
+	}
+	return s.widCounter, nil
+}
+
+// RegisterFixedWriter inserts a new FixedWriter and returns its wid.
+func (s *State) RegisterFixedWriter(name string, index FixedIndexWriter, size *uint64, chunkSize uint32, incremental bool) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.EnsureUnfinished(); err != nil {
+		return 0, err
+	}
+	wid, err := s.nextWid()
+	if err != nil {
+		return 0, err
+	}
+	s.fixedWriters[wid] = &FixedWriter{
+		Name:        name,
+		Index:       index,
+		Size:        size,
+		ChunkSize:   chunkSize,
+		Incremental: incremental,
+	}
+	return wid, nil
+}
+
+// LookupChunk returns the plaintext size of a previously uploaded chunk, if any.
+func (s *State) LookupChunk(digest [32]byte) (uint32, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	size, ok := s.knownChunks[digest]
+	return size, ok
+}
+
+// RegisterFixedChunk records a successfully uploaded chunk in the known_chunks
+// map and validates size constraints for the associated writer.
+func (s *State) RegisterFixedChunk(wid int, digest [32]byte, size uint32, isDuplicate bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.EnsureUnfinished(); err != nil {
+		return err
+	}
+	w, ok := s.fixedWriters[wid]
+	if !ok {
+		return fmt.Errorf("fixed writer %d not registered", wid)
+	}
+	if w.Closed {
+		return fmt.Errorf("fixed writer %q already closed", w.Name)
+	}
+	if size > w.ChunkSize {
+		return fmt.Errorf("fixed writer %q got chunk too large (%d > %d)", w.Name, size, w.ChunkSize)
+	}
+	if size < w.ChunkSize {
+		w.SmallChunkCount++
+		if w.SmallChunkCount > 1 {
+			return fmt.Errorf("fixed writer %q got multiple small chunks", w.Name)
+		}
+	}
+	s.knownChunks[digest] = size
+	_ = isDuplicate
+	return nil
+}
+
+// FixedWriterAppendChunk associates an uploaded chunk with a position in the
+// .fidx index. The digest must already be in known_chunks (checked by caller).
+func (s *State) FixedWriterAppendChunk(wid int, offset uint64, size uint32, digest [32]byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.EnsureUnfinished(); err != nil {
+		return err
+	}
+	w, ok := s.fixedWriters[wid]
+	if !ok {
+		return fmt.Errorf("fixed writer %d not registered", wid)
+	}
+	if w.Closed {
+		return fmt.Errorf("fixed writer %q already closed", w.Name)
+	}
+	if err := w.Index.AddChunk(offset, size, digest); err != nil {
+		return fmt.Errorf("fixed writer %q add_chunk failed: %w", w.Name, err)
+	}
+	w.ChunkCount++
+	return nil
+}
+
+// FixedWriterClose finalises a writer, verifying chunk count and checksums.
+// Returns the server-computed index checksum on success.
+func (s *State) FixedWriterClose(wid int, chunkCount uint64, size uint64, csum [32]byte) ([32]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.EnsureUnfinished(); err != nil {
+		return [32]byte{}, err
+	}
+	w, ok := s.fixedWriters[wid]
+	if !ok {
+		return [32]byte{}, fmt.Errorf("fixed writer %d not registered", wid)
+	}
+	if w.Closed {
+		return [32]byte{}, fmt.Errorf("fixed writer %q already closed", w.Name)
+	}
+	if w.ChunkCount != chunkCount {
+		return [32]byte{}, fmt.Errorf("fixed writer %q close: server saw %d chunks, client expected %d",
+			w.Name, w.ChunkCount, chunkCount)
+	}
+	if !w.Incremental {
+		expectedCount := w.Index.IndexLength()
+		if chunkCount != expectedCount {
+			return [32]byte{}, fmt.Errorf("fixed writer %q close: index_length=%d, chunk_count=%d",
+				w.Name, expectedCount, chunkCount)
+		}
+		if w.Size != nil && *w.Size != size {
+			return [32]byte{}, fmt.Errorf("fixed writer %q close: known_size=%d, client_size=%d",
+				w.Name, *w.Size, size)
+		}
+	}
+
+	gotCsum, err := w.Index.Close()
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("fixed writer %q close failed: %w", w.Name, err)
+	}
+	if gotCsum != csum {
+		return [32]byte{}, fmt.Errorf("fixed writer %q close: server csum != client csum", w.Name)
+	}
+	w.Closed = true
+	return gotCsum, nil
+}
+
+// Cleanup drops any open writers (frees mmap/tmpfile) and marks the session
+// finished. Called from the upgrade handler after ServeConn returns.
+func (s *State) Cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, w := range s.fixedWriters {
+		if !w.Closed {
+			w.Index.Drop()
+		}
+	}
+	s.finished = PhaseFinished
+}

--- a/services/backupos-pbs/internal/wstate/wstate_test.go
+++ b/services/backupos-pbs/internal/wstate/wstate_test.go
@@ -1,0 +1,260 @@
+package wstate
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeFidx is a FixedIndexWriter stub for test isolation.
+type fakeFidx struct {
+	chunks      []chunkEntry
+	dropCalled  bool
+	closeReturn [32]byte
+	closeErr    error
+}
+
+type chunkEntry struct {
+	offset uint64
+	size   uint32
+	digest [32]byte
+}
+
+func (f *fakeFidx) AddChunk(offset uint64, size uint32, digest [32]byte) error {
+	f.chunks = append(f.chunks, chunkEntry{offset, size, digest})
+	return nil
+}
+func (f *fakeFidx) IndexLength() uint64  { return uint64(len(f.chunks)) }
+func (f *fakeFidx) Close() ([32]byte, error) {
+	return f.closeReturn, f.closeErr
+}
+func (f *fakeFidx) UUID() [16]byte { return [16]byte{} }
+func (f *fakeFidx) Drop()          { f.dropCalled = true }
+
+// errFidx returns an error from AddChunk for error-propagation tests.
+type errFidx struct{ addErr error }
+
+func (f *errFidx) AddChunk(_ uint64, _ uint32, _ [32]byte) error { return f.addErr }
+func (f *errFidx) IndexLength() uint64                           { return 0 }
+func (f *errFidx) Close() ([32]byte, error)                      { return [32]byte{}, nil }
+func (f *errFidx) UUID() [16]byte                                { return [16]byte{} }
+func (f *errFidx) Drop()                                         {}
+
+func ptrU64(v uint64) *uint64 { return &v }
+
+// ---- RegisterFixedWriter ----
+
+func TestRegisterFixedWriter_AssignsMonotonicWids(t *testing.T) {
+	ws := New()
+	wid1, err := ws.RegisterFixedWriter("a.fidx", &fakeFidx{}, ptrU64(4194304), 4194304, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wid2, err := ws.RegisterFixedWriter("b.fidx", &fakeFidx{}, ptrU64(4194304), 4194304, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wid1 != 1 {
+		t.Errorf("first wid: got %d, want 1", wid1)
+	}
+	if wid2 != 2 {
+		t.Errorf("second wid: got %d, want 2", wid2)
+	}
+}
+
+func TestRegisterFixedWriter_RejectsAfterCleanup(t *testing.T) {
+	ws := New()
+	ws.Cleanup()
+	_, err := ws.RegisterFixedWriter("a.fidx", &fakeFidx{}, ptrU64(4194304), 4194304, false)
+	if err == nil {
+		t.Error("expected error registering after cleanup, got nil")
+	}
+}
+
+// ---- RegisterFixedChunk ----
+
+func TestRegisterFixedChunk_AddsToKnownChunks(t *testing.T) {
+	ws := New()
+	wid, _ := ws.RegisterFixedWriter("a.fidx", &fakeFidx{}, ptrU64(4194304), 4194304, false)
+	var digest [32]byte
+	digest[0] = 0xab
+	if err := ws.RegisterFixedChunk(wid, digest, 4194304, false); err != nil {
+		t.Fatal(err)
+	}
+	size, ok := ws.LookupChunk(digest)
+	if !ok {
+		t.Fatal("chunk not found in knownChunks")
+	}
+	if size != 4194304 {
+		t.Errorf("size: got %d, want 4194304", size)
+	}
+}
+
+func TestRegisterFixedChunk_RejectsOversize(t *testing.T) {
+	ws := New()
+	wid, _ := ws.RegisterFixedWriter("a.fidx", &fakeFidx{}, ptrU64(8388608), 4194304, false)
+	var digest [32]byte
+	err := ws.RegisterFixedChunk(wid, digest, 4194305, false) // one byte over
+	if err == nil {
+		t.Error("expected error for oversized chunk, got nil")
+	}
+}
+
+func TestRegisterFixedChunk_AllowsOneSmallChunk(t *testing.T) {
+	ws := New()
+	wid, _ := ws.RegisterFixedWriter("a.fidx", &fakeFidx{}, ptrU64(5*1024*1024), 4194304, false)
+	var d1 [32]byte
+	d1[0] = 1
+	if err := ws.RegisterFixedChunk(wid, d1, 4194304, false); err != nil {
+		t.Fatalf("full chunk: %v", err)
+	}
+	var d2 [32]byte
+	d2[0] = 2
+	if err := ws.RegisterFixedChunk(wid, d2, 1048576, false); err != nil { // 1 MiB < 4 MiB
+		t.Fatalf("small last chunk: %v", err)
+	}
+}
+
+func TestRegisterFixedChunk_RejectsMultipleSmallChunks(t *testing.T) {
+	ws := New()
+	wid, _ := ws.RegisterFixedWriter("a.fidx", &fakeFidx{}, ptrU64(8*1024*1024), 4194304, false)
+	for i := 0; i < 2; i++ {
+		var d [32]byte
+		d[0] = byte(i + 1)
+		_ = ws.RegisterFixedChunk(wid, d, 1, false) // 1 byte < chunk_size
+	}
+	var d3 [32]byte
+	d3[0] = 3
+	err := ws.RegisterFixedChunk(wid, d3, 1, false)
+	if err == nil {
+		t.Error("expected error for third small chunk, got nil")
+	}
+}
+
+// ---- FixedWriterAppendChunk ----
+
+func TestFixedWriterAppendChunk_IncrementsChunkCount(t *testing.T) {
+	ws := New()
+	fi := &fakeFidx{}
+	wid, _ := ws.RegisterFixedWriter("a.fidx", fi, ptrU64(4194304), 4194304, false)
+
+	var digest [32]byte
+	if err := ws.FixedWriterAppendChunk(wid, 4194304, 4194304, digest); err != nil {
+		t.Fatal(err)
+	}
+	// ChunkCount is not exported, but we can verify via FixedWriterClose validation.
+	// Here we just check there's no error and the fakeFidx received the call.
+	if len(fi.chunks) != 1 {
+		t.Errorf("expected 1 chunk in fakeFidx, got %d", len(fi.chunks))
+	}
+	if fi.chunks[0].offset != 4194304 {
+		t.Errorf("offset: got %d, want 4194304", fi.chunks[0].offset)
+	}
+}
+
+func TestFixedWriterAppendChunk_PropagatesAddChunkError(t *testing.T) {
+	ws := New()
+	want := errors.New("disk full")
+	ef := &errFidx{addErr: want}
+	wid, _ := ws.RegisterFixedWriter("a.fidx", ef, ptrU64(4194304), 4194304, false)
+
+	var digest [32]byte
+	err := ws.FixedWriterAppendChunk(wid, 4194304, 4194304, digest)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("error chain: got %v, want to contain %v", err, want)
+	}
+}
+
+// ---- FixedWriterClose ----
+
+func TestFixedWriterClose_HappyPath(t *testing.T) {
+	ws := New()
+	var expectedCsum [32]byte
+	for i := range expectedCsum {
+		expectedCsum[i] = byte(i)
+	}
+	fi := &fakeFidx{closeReturn: expectedCsum}
+	size := uint64(4194304)
+	wid, _ := ws.RegisterFixedWriter("a.fidx", fi, &size, 4194304, false)
+
+	var digest [32]byte
+	_ = ws.FixedWriterAppendChunk(wid, 4194304, 4194304, digest)
+
+	got, err := ws.FixedWriterClose(wid, 1, size, expectedCsum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != expectedCsum {
+		t.Errorf("returned csum mismatch")
+	}
+}
+
+func TestFixedWriterClose_ChunkCountMismatch(t *testing.T) {
+	ws := New()
+	fi := &fakeFidx{}
+	size := uint64(4194304)
+	wid, _ := ws.RegisterFixedWriter("a.fidx", fi, &size, 4194304, false)
+	// No AppendChunk calls — server count is 0, client claims 1.
+	_, err := ws.FixedWriterClose(wid, 1, size, [32]byte{})
+	if err == nil {
+		t.Error("expected error for chunk count mismatch, got nil")
+	}
+}
+
+func TestFixedWriterClose_CsumMismatch(t *testing.T) {
+	ws := New()
+	var serverCsum [32]byte
+	serverCsum[0] = 0xAA
+	fi := &fakeFidx{closeReturn: serverCsum}
+	size := uint64(0)
+	wid, _ := ws.RegisterFixedWriter("a.fidx", fi, &size, 4194304, false)
+	// 0 chunks, 0 size — valid close but wrong csum from client.
+	var wrongCsum [32]byte
+	wrongCsum[0] = 0xBB
+	_, err := ws.FixedWriterClose(wid, 0, 0, wrongCsum)
+	if err == nil {
+		t.Error("expected error for csum mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "csum") {
+		t.Errorf("error should mention csum, got: %v", err)
+	}
+}
+
+// ---- Cleanup ----
+
+func TestCleanup_DropsOpenWriters(t *testing.T) {
+	ws := New()
+	fi := &fakeFidx{}
+	_, _ = ws.RegisterFixedWriter("open.fidx", fi, ptrU64(4194304), 4194304, false)
+	ws.Cleanup()
+	if !fi.dropCalled {
+		t.Error("Drop not called on open writer during Cleanup")
+	}
+}
+
+func TestCleanup_SkipsClosedWriters(t *testing.T) {
+	ws := New()
+	fi := &fakeFidx{} // closeReturn is zero [32]byte
+	size := uint64(0)
+	wid, _ := ws.RegisterFixedWriter("closed.fidx", fi, &size, 4194304, false)
+	// Close with 0 chunks, 0 size, zero csum (matches fi.closeReturn).
+	if _, err := ws.FixedWriterClose(wid, 0, 0, [32]byte{}); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	ws.Cleanup()
+	if fi.dropCalled {
+		t.Error("Drop called on already-closed writer during Cleanup")
+	}
+}
+
+func TestCleanup_RejectsSubsequentRegistration(t *testing.T) {
+	ws := New()
+	ws.Cleanup()
+	_, err := ws.RegisterFixedWriter("new.fidx", &fakeFidx{}, ptrU64(4194304), 4194304, false)
+	if err == nil {
+		t.Error("expected error registering after Cleanup, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Four new H2 endpoints completing the fixed-index backup lifecycle
- `POST /fixed_index` — creates a `.fidx` writer, returns `wid`
- `POST /fixed_chunk` — uploads DataBlob to chunk store, registers in `known_chunks`
- `PUT /fixed_index` — batch-associates uploaded digests with index positions (verifies digest in `known_chunks` first)
- `POST /fixed_close` — validates chunk count + server/client csum agreement, atomically finalises `.fidx`

After this PR, a real PVE client can complete a VM disk backup against backupos-pbs.

## New packages

| Package | Responsibility |
|---------|---------------|
| `internal/wstate` | Per-session SharedBackupState: writer maps, known_chunks, wid counter |
| `internal/datablob` | Parse + verify PBS DataBlob wire format (magic, SHA256 plaintext verification) |
| `internal/chunkstore` | Content-addressed chunk store at `.chunks/<prefix4>/<hexdigest>` |
| `internal/fidx` | mmap-based `.fidx` writer — byte-exact 4096-byte header + digest array |
| `internal/fixedindex` | POST /fixed_index handler |
| `internal/fixedchunk` | POST /fixed_chunk handler |
| `internal/fixedappend` | PUT /fixed_index handler |
| `internal/fixedclose` | POST /fixed_close handler |

## Deferred

- Incremental backups (`reuse-csum`) — returns 400
- Dynamic indexes (next PR)
- Growable `.fidx` (size required in V1)
- `pbs_active_writes` DB writes

## Test plan

- [ ] `go mod tidy && go test -count=1 ./...` on Linux server — all packages green
- [ ] `go build ./cmd/backupos-pbs` clean
- [ ] `internal/fidx` byte-exact test verifies magic, uuid, ctime, index_csum, size, chunk_size, digest positions against spec
- [ ] `TestHandler_FullUpgradeDance` still passes with 9-arg NewHandler

🤖 Generated with [Claude Code](https://claude.com/claude-code)