### PR TITLE
feat(pbs): dynamic-index lifecycle — M4c-go-dynamic-index

### DIFF
--- a/services/backupos-pbs/README.md
+++ b/services/backupos-pbs/README.md
@@ -45,7 +45,7 @@ go run ./cmd/backupos-pbs \
 go test ./...
 ```
 
-## Endpoints (M4c-go-fixed-index)
+## Endpoints (M4c-go-dynamic-index)
 
 ### HTTP/1.1 surface (upgrade handshake)
 
@@ -70,7 +70,11 @@ go test ./...
 | PUT | /fixed_index | JSON `{wid, digest-list, offset-list}` | 200, batch-associate digests with positions |
 | POST | /fixed_chunk | `wid=N&digest=H&size=N&encoded-size=N` body=DataBlob | 200, chunk stored, registered in known_chunks |
 | POST | /fixed_close | `wid=N&chunk-count=N&size=N&csum=H` | 200, validates and finalises .fidx file |
-| any other | (any) | | 501 stub (M4c-go-dynamic-index follows) |
+| POST | /dynamic_index | `archive-name=X.didx` | 200, creates .didx writer, returns wid |
+| PUT | /dynamic_index | JSON `{wid, digest-list, offset-list}` | 200, batch-associate digests with positions |
+| POST | /dynamic_chunk | `wid=N&digest=H&size=N&encoded-size=N` body=DataBlob | 200, chunk stored, registered in known_chunks |
+| POST | /dynamic_close | `wid=N&chunk-count=N&csum=H` | 200, validates and finalises .didx file |
+| any other | (any) | | 501 stub (M5-go-reader follows) |
 
 Session lifecycle: a clean session ends with `POST /finish`, which transitions
 state from `backup`/`reader` to `finished`. If the connection closes without

--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -34,6 +34,10 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/blob"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/db"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/dynamicappend"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/dynamicchunk"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/dynamicclose"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/dynamicindex"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/finish"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedappend"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedchunk"
@@ -95,6 +99,10 @@ func main() {
 		fixedchunk.NewHandler(),
 		fixedappend.NewHandler(),
 		fixedclose.NewHandler(),
+		dynamicindex.NewHandler(),
+		dynamicchunk.NewHandler(),
+		dynamicappend.NewHandler(),
+		dynamicclose.NewHandler(),
 		upgrade.StubStreamHandler(),
 	)
 

--- a/services/backupos-pbs/internal/didx/didx.go
+++ b/services/backupos-pbs/internal/didx/didx.go
@@ -1,0 +1,162 @@
+// Package didx writes PBS dynamic-index (.didx) files.
+//
+// The .didx format stores variable-size chunks for file archive backups
+// (.pxar). Unlike .fidx (which is mmap'd because the total size is known
+// upfront), .didx uses a buffered writer because the number of chunks is
+// unknown at creation time.
+//
+// Wire format:
+//
+//	Header (4096 bytes):
+//	  [0:8]   magic
+//	  [8:24]  uuid (random)
+//	  [24:32] ctime (Unix seconds, little-endian int64)
+//	  [32:64] index_csum (SHA256; written at Close)
+//	  [64:]   reserved (zeros)
+//
+//	Body (40 bytes per chunk):
+//	  [0:8]   end offset of chunk (little-endian uint64)
+//	  [8:40]  SHA256 digest of plaintext chunk
+//
+// index_csum = SHA256(entry_1 || entry_2 || …) where each entry is the
+// full 40-byte body record.
+package didx
+
+import (
+	"bufio"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"os"
+	"time"
+)
+
+// Magic is the .didx file magic, matching DynamicIndexMagic in Proxmox.
+var Magic = [8]byte{28, 145, 78, 165, 25, 186, 179, 205}
+
+const headerSize = 4096
+const csumOffset = 32
+
+// Writer is an open .didx file being assembled.
+type Writer struct {
+	tmpPath   string
+	finalPath string
+	f         *os.File
+	bw        *bufio.Writer
+	uuid      [16]byte
+	hasher    hash.Hash
+	count     uint64
+	closed    bool
+	dropped   bool
+}
+
+// Create opens a new temporary .didx file and writes the header.
+// The final file is not visible until Close succeeds.
+func Create(finalPath string) (*Writer, error) {
+	tmpPath := finalPath + ".tmp"
+	f, err := os.OpenFile(tmpPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("didx create %q: %w", tmpPath, err)
+	}
+
+	var uuid [16]byte
+	if _, err := rand.Read(uuid[:]); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return nil, fmt.Errorf("didx uuid: %w", err)
+	}
+
+	ctime := time.Now().Unix()
+
+	var header [headerSize]byte
+	copy(header[0:8], Magic[:])
+	copy(header[8:24], uuid[:])
+	binary.LittleEndian.PutUint64(header[24:32], uint64(ctime))
+	// index_csum at [32:64] is zero-initialised; written at Close.
+
+	bw := bufio.NewWriterSize(f, 64*1024)
+	if _, err := bw.Write(header[:]); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return nil, fmt.Errorf("didx write header: %w", err)
+	}
+
+	return &Writer{
+		tmpPath:   tmpPath,
+		finalPath: finalPath,
+		f:         f,
+		bw:        bw,
+		uuid:      uuid,
+		hasher:    sha256.New(),
+	}, nil
+}
+
+// AddChunk appends a 40-byte entry (end_offset || digest) to the index.
+// offset is the cumulative end offset of this chunk (PBS convention).
+func (w *Writer) AddChunk(offset uint64, digest [32]byte) error {
+	if w.closed || w.dropped {
+		return fmt.Errorf("didx writer already closed or dropped")
+	}
+	var entry [40]byte
+	binary.LittleEndian.PutUint64(entry[0:8], offset)
+	copy(entry[8:40], digest[:])
+	if _, err := w.bw.Write(entry[:]); err != nil {
+		return fmt.Errorf("didx write entry: %w", err)
+	}
+	_, _ = w.hasher.Write(entry[:])
+	w.count++
+	return nil
+}
+
+// IndexLength returns the number of chunks written so far.
+func (w *Writer) IndexLength() uint64 { return w.count }
+
+// UUID returns the UUID embedded in the file header.
+func (w *Writer) UUID() [16]byte { return w.uuid }
+
+// Close flushes all buffered data, seeks back to write the index checksum,
+// fsyncs, and atomically renames the temp file to the final path.
+func (w *Writer) Close() ([32]byte, error) {
+	if w.closed || w.dropped {
+		return [32]byte{}, fmt.Errorf("didx writer already closed or dropped")
+	}
+
+	if err := w.bw.Flush(); err != nil {
+		return [32]byte{}, fmt.Errorf("didx flush: %w", err)
+	}
+
+	var csum [32]byte
+	copy(csum[:], w.hasher.Sum(nil))
+
+	if _, err := w.f.Seek(csumOffset, 0); err != nil {
+		return [32]byte{}, fmt.Errorf("didx seek for csum: %w", err)
+	}
+	if _, err := w.f.Write(csum[:]); err != nil {
+		return [32]byte{}, fmt.Errorf("didx write csum: %w", err)
+	}
+
+	if err := w.f.Sync(); err != nil {
+		return [32]byte{}, fmt.Errorf("didx fsync: %w", err)
+	}
+	if err := w.f.Close(); err != nil {
+		return [32]byte{}, fmt.Errorf("didx close file: %w", err)
+	}
+	w.closed = true
+
+	if err := os.Rename(w.tmpPath, w.finalPath); err != nil {
+		return [32]byte{}, fmt.Errorf("didx rename: %w", err)
+	}
+	return csum, nil
+}
+
+// Drop aborts the writer: closes and removes the temp file.
+func (w *Writer) Drop() {
+	if w.closed || w.dropped {
+		return
+	}
+	w.dropped = true
+	_ = w.f.Close()
+	_ = os.Remove(w.tmpPath)
+}

--- a/services/backupos-pbs/internal/didx/didx_test.go
+++ b/services/backupos-pbs/internal/didx/didx_test.go
@@ -1,0 +1,182 @@
+package didx
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreate_WritesCorrectMagic(t *testing.T) {
+	dir := t.TempDir()
+	w, err := Create(filepath.Join(dir, "test.didx"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Drop()
+
+	// tmp file should be gone after Drop
+	if _, err := os.Stat(filepath.Join(dir, "test.didx.tmp")); !os.IsNotExist(err) {
+		t.Error("tmp file still exists after Drop")
+	}
+}
+
+func TestAddChunk_AndClose_ByteExact(t *testing.T) {
+	dir := t.TempDir()
+	finalPath := filepath.Join(dir, "out.didx")
+	w, err := Create(finalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var digest1 [32]byte
+	for i := range digest1 {
+		digest1[i] = byte(i + 1)
+	}
+	var digest2 [32]byte
+	for i := range digest2 {
+		digest2[i] = byte(i + 0x80)
+	}
+
+	offset1 := uint64(65536)
+	offset2 := uint64(131072)
+
+	if err := w.AddChunk(offset1, digest1); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.AddChunk(offset2, digest2); err != nil {
+		t.Fatal(err)
+	}
+
+	gotCsum, err := w.Close()
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Compute expected index_csum manually.
+	h := sha256.New()
+	var e1, e2 [40]byte
+	binary.LittleEndian.PutUint64(e1[0:8], offset1)
+	copy(e1[8:], digest1[:])
+	binary.LittleEndian.PutUint64(e2[0:8], offset2)
+	copy(e2[8:], digest2[:])
+	h.Write(e1[:])
+	h.Write(e2[:])
+	var wantCsum [32]byte
+	copy(wantCsum[:], h.Sum(nil))
+
+	if gotCsum != wantCsum {
+		t.Errorf("csum mismatch:\n  got  %x\n  want %x", gotCsum, wantCsum)
+	}
+
+	// Read the final file and verify byte layout.
+	raw, err := os.ReadFile(finalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != headerSize+2*40 {
+		t.Fatalf("file size: got %d, want %d", len(raw), headerSize+2*40)
+	}
+
+	// Magic at [0:8]
+	if [8]byte(raw[0:8]) != Magic {
+		t.Errorf("magic mismatch: got %v", raw[0:8])
+	}
+
+	// index_csum at [32:64]
+	var fileCsum [32]byte
+	copy(fileCsum[:], raw[32:64])
+	if fileCsum != wantCsum {
+		t.Errorf("on-disk csum mismatch")
+	}
+
+	// First entry at [4096:4136]
+	off1 := binary.LittleEndian.Uint64(raw[4096:4104])
+	if off1 != offset1 {
+		t.Errorf("entry[0] offset: got %d, want %d", off1, offset1)
+	}
+	var d1 [32]byte
+	copy(d1[:], raw[4104:4136])
+	if d1 != digest1 {
+		t.Errorf("entry[0] digest mismatch")
+	}
+
+	// Second entry at [4136:4176]
+	off2 := binary.LittleEndian.Uint64(raw[4136:4144])
+	if off2 != offset2 {
+		t.Errorf("entry[1] offset: got %d, want %d", off2, offset2)
+	}
+	var d2 [32]byte
+	copy(d2[:], raw[4144:4176])
+	if d2 != digest2 {
+		t.Errorf("entry[1] digest mismatch")
+	}
+}
+
+func TestIndexLength_TracksChunkCount(t *testing.T) {
+	dir := t.TempDir()
+	w, err := Create(filepath.Join(dir, "test.didx"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Drop()
+
+	if w.IndexLength() != 0 {
+		t.Errorf("initial IndexLength: got %d, want 0", w.IndexLength())
+	}
+	var d [32]byte
+	_ = w.AddChunk(1000, d)
+	if w.IndexLength() != 1 {
+		t.Errorf("after one chunk: got %d, want 1", w.IndexLength())
+	}
+}
+
+func TestClose_TmpFileGoneOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	finalPath := filepath.Join(dir, "out.didx")
+	w, err := Create(finalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(finalPath + ".tmp"); !os.IsNotExist(err) {
+		t.Error("tmp file still present after successful Close")
+	}
+	if _, err := os.Stat(finalPath); err != nil {
+		t.Errorf("final file missing: %v", err)
+	}
+}
+
+func TestDrop_AfterClose_IsNoop(t *testing.T) {
+	dir := t.TempDir()
+	finalPath := filepath.Join(dir, "out.didx")
+	w, err := Create(finalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	w.Drop() // must not panic or delete the final file
+	if _, err := os.Stat(finalPath); err != nil {
+		t.Errorf("final file deleted by Drop after Close: %v", err)
+	}
+}
+
+func TestAddChunk_AfterClose_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	w, err := Create(filepath.Join(dir, "test.didx"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var d [32]byte
+	if err := w.AddChunk(100, d); err == nil {
+		t.Error("expected error adding chunk after Close, got nil")
+	}
+}

--- a/services/backupos-pbs/internal/dynamicappend/dynamicappend.go
+++ b/services/backupos-pbs/internal/dynamicappend/dynamicappend.go
@@ -1,0 +1,110 @@
+// Package dynamicappend implements the PUT /dynamic_index H2 endpoint.
+//
+// The client sends a batch of (digest, offset) pairs to associate with an open
+// .didx writer. Each digest must already be in the session's known_chunks map
+// (populated by POST /dynamic_chunk). Unlike PUT /fixed_index, no size is
+// passed to the index writer — dynamic index entries are (end_offset, digest).
+package dynamicappend
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+// appendRequest is the JSON body for PUT /dynamic_index.
+type appendRequest struct {
+	Wid        int      `json:"wid"`
+	DigestList []string `json:"digest-list"`
+	OffsetList []uint64 `json:"offset-list"`
+}
+
+// Handler implements PUT /dynamic_index.
+type Handler struct{}
+
+// NewHandler constructs a dynamicappend handler.
+func NewHandler() *Handler { return &Handler{} }
+
+// ServeHTTP routes PUT /dynamic_index → batch append; any other method → 405.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		w.Header().Set("Allow", http.MethodPut)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil {
+		slog.Error("dynamicappend handler invoked without streamctx")
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	var req appendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON body: %s", err.Error()))
+		return
+	}
+
+	if req.Wid < 1 || req.Wid > 256 {
+		writeError(w, http.StatusBadRequest, "invalid \"wid\": must be 1..256")
+		return
+	}
+	if len(req.DigestList) != len(req.OffsetList) {
+		writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("digest-list length %d != offset-list length %d",
+				len(req.DigestList), len(req.OffsetList)))
+		return
+	}
+
+	for i, digestHex := range req.DigestList {
+		offset := req.OffsetList[i]
+
+		if len(digestHex) != 64 {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("digest-list[%d]: must be 64 hex chars", i))
+			return
+		}
+		digestBytes, err := hex.DecodeString(digestHex)
+		if err != nil {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("digest-list[%d]: invalid hex", i))
+			return
+		}
+		var digest [32]byte
+		copy(digest[:], digestBytes)
+
+		if _, ok := sc.WriterState.LookupChunk(digest); !ok {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("digest-list[%d]: chunk %s not uploaded in this session", i, digestHex[:16]+"..."))
+			return
+		}
+
+		if err := sc.WriterState.DynamicWriterAppendChunk(req.Wid, offset, digest); err != nil {
+			slog.Info("dynamicappend chunk append failed",
+				"reason", err.Error(), "session_id", sc.SessionID, "index", i)
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
+	slog.Info("dynamic_index appended",
+		"session_id", sc.SessionID,
+		"wid", req.Wid,
+		"count", len(req.DigestList),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"data":null}`))
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/dynamicappend/dynamicappend_test.go
+++ b/services/backupos-pbs/internal/dynamicappend/dynamicappend_test.go
@@ -1,0 +1,166 @@
+package dynamicappend
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
+)
+
+// fakeDynIdx is a minimal DynamicIndexWriter stub.
+type fakeDynIdx struct{ count uint64 }
+
+func (f *fakeDynIdx) AddChunk(_ uint64, _ [32]byte) error { f.count++; return nil }
+func (f *fakeDynIdx) IndexLength() uint64                 { return f.count }
+func (f *fakeDynIdx) Close() ([32]byte, error)            { return [32]byte{}, nil }
+func (f *fakeDynIdx) UUID() [16]byte                      { return [16]byte{} }
+func (f *fakeDynIdx) Drop()                               {}
+
+func makeState(t *testing.T) (*wstate.State, int) {
+	t.Helper()
+	ws := wstate.New()
+	wid, err := ws.RegisterDynamicWriter("test.didx", &fakeDynIdx{})
+	if err != nil {
+		t.Fatalf("RegisterDynamicWriter: %v", err)
+	}
+	return ws, wid
+}
+
+func makeSessionCtx(ws *wstate.State) *streamctx.SessionContext {
+	return &streamctx.SessionContext{
+		SessionID:   "test-session",
+		BackupType:  "vm",
+		BackupID:    "100",
+		BackupTime:  time.Unix(1735000000, 0).UTC(),
+		WriterState: ws,
+	}
+}
+
+func injectCtx(sc *streamctx.SessionContext) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sc)))
+		})
+	}
+}
+
+func jsonBody(v any) *bytes.Reader {
+	b, _ := json.Marshal(v)
+	return bytes.NewReader(b)
+}
+
+func TestHandler_WrongMethod_Returns405(t *testing.T) {
+	ws, _ := makeState(t)
+	h := injectCtx(makeSessionCtx(ws))(NewHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/dynamic_index", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestHandler_MismatchedLists_Returns400(t *testing.T) {
+	ws, wid := makeState(t)
+	h := injectCtx(makeSessionCtx(ws))(NewHandler())
+
+	body := appendRequest{
+		Wid:        wid,
+		DigestList: []string{"aa"},
+		OffsetList: []uint64{},
+	}
+	req := httptest.NewRequest(http.MethodPut, "/dynamic_index", jsonBody(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestHandler_UnknownChunk_Returns400(t *testing.T) {
+	ws, wid := makeState(t)
+	h := injectCtx(makeSessionCtx(ws))(NewHandler())
+
+	body := appendRequest{
+		Wid:        wid,
+		DigestList: []string{"aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"},
+		OffsetList: []uint64{65536},
+	}
+	req := httptest.NewRequest(http.MethodPut, "/dynamic_index", jsonBody(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for unknown chunk, got %d", rr.Code)
+	}
+}
+
+func TestHandler_HappyPath_Returns200(t *testing.T) {
+	ws, wid := makeState(t)
+
+	// Register a chunk into knownChunks first.
+	var digest [32]byte
+	digest[0] = 0xDE
+	digest[1] = 0xAD
+	if err := ws.RegisterDynamicChunk(wid, digest, 4096, false); err != nil {
+		t.Fatalf("RegisterDynamicChunk: %v", err)
+	}
+
+	h := injectCtx(makeSessionCtx(ws))(NewHandler())
+
+	digestHex := make([]byte, 32)
+	digestHex[0] = 0xDE
+	digestHex[1] = 0xAD
+	var d [32]byte
+	copy(d[:], digestHex)
+
+	body := appendRequest{
+		Wid:        wid,
+		DigestList: []string{"dead" + "000000000000000000000000000000000000000000000000000000000000"},
+		OffsetList: []uint64{65536},
+	}
+	// Fix digest hex to be exactly 64 chars matching the registered digest.
+	hexStr := make([]byte, 64)
+	for i := range hexStr {
+		hexStr[i] = '0'
+	}
+	hexStr[0] = 'd'
+	hexStr[1] = 'e'
+	hexStr[2] = 'a'
+	hexStr[3] = 'd'
+	body.DigestList = []string{string(hexStr)}
+
+	req := httptest.NewRequest(http.MethodPut, "/dynamic_index", jsonBody(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandler_InvalidWid_Returns400(t *testing.T) {
+	ws, _ := makeState(t)
+	h := injectCtx(makeSessionCtx(ws))(NewHandler())
+
+	body := appendRequest{
+		Wid:        0, // invalid
+		DigestList: []string{},
+		OffsetList: []uint64{},
+	}
+	req := httptest.NewRequest(http.MethodPut, "/dynamic_index", jsonBody(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}

--- a/services/backupos-pbs/internal/dynamicchunk/dynamicchunk.go
+++ b/services/backupos-pbs/internal/dynamicchunk/dynamicchunk.go
@@ -1,0 +1,174 @@
+// Package dynamicchunk implements the POST /dynamic_chunk H2 endpoint.
+//
+// Identical protocol to POST /fixed_chunk, but registers the chunk with a
+// dynamic writer (no chunk-size constraint). The client uploads each chunk
+// DataBlob here before associating it via PUT /dynamic_index.
+package dynamicchunk
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/chunkstore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datablob"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+const (
+	maxChunkPlaintext = 16 * 1024 * 1024
+	maxBlobEncoded    = maxChunkPlaintext + 44
+	minBlobEncoded    = 13
+)
+
+// Handler implements POST /dynamic_chunk.
+type Handler struct{}
+
+// NewHandler constructs a dynamicchunk handler.
+func NewHandler() *Handler { return &Handler{} }
+
+// ServeHTTP routes POST /dynamic_chunk → upload; any other method → 405.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil {
+		slog.Error("dynamicchunk handler invoked without streamctx")
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	wid, digest, plainSize, encodedSize, err := parseQuery(r.URL.Query())
+	if err != nil {
+		slog.Info("dynamic_chunk rejected: bad params", "reason", err.Error(), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	limited := io.LimitReader(r.Body, int64(encodedSize)+1)
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		slog.Error("dynamic_chunk body read failed", "error", err, "session_id", sc.SessionID)
+		writeError(w, http.StatusInternalServerError, "read failed")
+		return
+	}
+	if int64(len(raw)) != int64(encodedSize) {
+		slog.Info("dynamic_chunk rejected: body size mismatch",
+			"want", encodedSize, "got", len(raw), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("body length %d does not match encoded-size %d", len(raw), encodedSize))
+		return
+	}
+
+	blob, err := datablob.Parse(raw)
+	if err != nil {
+		slog.Info("dynamic_chunk rejected: bad DataBlob", "reason", err.Error(), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid DataBlob: %s", err.Error()))
+		return
+	}
+
+	if err := blob.VerifyUnencrypted(plainSize, digest); err != nil {
+		slog.Info("dynamic_chunk rejected: verification failed",
+			"reason", err.Error(), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("chunk verification failed: %s", err.Error()))
+		return
+	}
+
+	cs, err := chunkstore.New(sc.DatastoreRoot)
+	if err != nil {
+		slog.Error("chunk store init failed",
+			"error", err, "session_id", sc.SessionID, "datastore_root", sc.DatastoreRoot)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	isDuplicate, _, err := cs.Insert(digest, raw)
+	if err != nil {
+		slog.Error("chunk insert failed", "error", err, "session_id", sc.SessionID)
+		writeError(w, http.StatusInternalServerError, "chunk write failed")
+		return
+	}
+
+	if err := sc.WriterState.RegisterDynamicChunk(wid, digest, plainSize, isDuplicate); err != nil {
+		slog.Info("dynamic_chunk rejected: register failed",
+			"reason", err.Error(), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	slog.Info("dynamic_chunk uploaded",
+		"session_id", sc.SessionID,
+		"wid", wid,
+		"digest", hex.EncodeToString(digest[:]),
+		"size", plainSize,
+		"duplicate", isDuplicate,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"data": hex.EncodeToString(digest[:])})
+}
+
+// parseQuery validates and extracts query parameters.
+func parseQuery(q map[string][]string) (wid int, digest [32]byte, plainSize uint32, encodedSize int64, err error) {
+	get := func(k string) string {
+		if v := q[k]; len(v) > 0 {
+			return v[0]
+		}
+		return ""
+	}
+
+	widRaw := get("wid")
+	if widRaw == "" {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("missing required parameter \"wid\"")
+	}
+	widI, e := strconv.Atoi(widRaw)
+	if e != nil || widI < 1 || widI > 256 {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("invalid \"wid\": must be 1..256")
+	}
+
+	digestHex := get("digest")
+	if len(digestHex) != 64 {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("invalid \"digest\": must be 64 hex chars")
+	}
+	digestBytes, e := hex.DecodeString(digestHex)
+	if e != nil {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("invalid \"digest\": not valid hex")
+	}
+	var d [32]byte
+	copy(d[:], digestBytes)
+
+	sizeRaw := get("size")
+	if sizeRaw == "" {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("missing required parameter \"size\"")
+	}
+	sizeI, e := strconv.ParseInt(sizeRaw, 10, 64)
+	if e != nil || sizeI < 1 || sizeI > maxChunkPlaintext {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("invalid \"size\": must be 1..%d", maxChunkPlaintext)
+	}
+
+	encSizeRaw := get("encoded-size")
+	if encSizeRaw == "" {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("missing required parameter \"encoded-size\"")
+	}
+	encSizeI, e := strconv.ParseInt(encSizeRaw, 10, 64)
+	if e != nil || encSizeI < minBlobEncoded || encSizeI > maxBlobEncoded {
+		return 0, [32]byte{}, 0, 0, fmt.Errorf("invalid \"encoded-size\": must be %d..%d", minBlobEncoded, maxBlobEncoded)
+	}
+
+	return widI, d, uint32(sizeI), encSizeI, nil
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/dynamicchunk/dynamicchunk_test.go
+++ b/services/backupos-pbs/internal/dynamicchunk/dynamicchunk_test.go
@@ -1,0 +1,135 @@
+package dynamicchunk
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
+)
+
+func makeSessionCtx(datastoreRoot string) *streamctx.SessionContext {
+	return &streamctx.SessionContext{
+		SessionID:     "test-session",
+		DatastoreID:   "ds-1",
+		DatastoreRoot: datastoreRoot,
+		BackupType:    "vm",
+		BackupID:      "100",
+		BackupTime:    time.Unix(1735000000, 0).UTC(),
+		WriterState:   wstate.New(),
+	}
+}
+
+func injectCtx(sc *streamctx.SessionContext) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sc)))
+		})
+	}
+}
+
+// makeUncompressedBlob builds a minimal valid DataBlob (uncompressed magic).
+func makeUncompressedBlob(payload []byte) []byte {
+	magic := [8]byte{66, 171, 56, 7, 190, 131, 112, 161}
+	var buf bytes.Buffer
+	buf.Write(magic[:])
+	var crc [4]byte
+	binary.LittleEndian.PutUint32(crc[:], 0)
+	buf.Write(crc[:])
+	buf.Write(payload)
+	return buf.Bytes()
+}
+
+// fakeDynIdx is a minimal DynamicIndexWriter stub.
+type fakeDynIdx struct{ count uint64 }
+
+func (f *fakeDynIdx) AddChunk(_ uint64, _ [32]byte) error { f.count++; return nil }
+func (f *fakeDynIdx) IndexLength() uint64                 { return f.count }
+func (f *fakeDynIdx) Close() ([32]byte, error)            { return [32]byte{}, nil }
+func (f *fakeDynIdx) UUID() [16]byte                      { return [16]byte{} }
+func (f *fakeDynIdx) Drop()                               {}
+
+func registerDynamicWriter(t *testing.T, ws *wstate.State) int {
+	t.Helper()
+	wid, err := ws.RegisterDynamicWriter("test.didx", &fakeDynIdx{})
+	if err != nil {
+		t.Fatalf("RegisterDynamicWriter: %v", err)
+	}
+	return wid
+}
+
+func TestHandler_MissingWid_Returns400(t *testing.T) {
+	dir := t.TempDir()
+	h := injectCtx(makeSessionCtx(dir))(NewHandler())
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/dynamic_chunk?digest="+hex.EncodeToString(make([]byte, 32))+"&size=1&encoded-size=13",
+		bytes.NewReader(makeUncompressedBlob([]byte{0})))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestHandler_WrongMethod_Returns405(t *testing.T) {
+	dir := t.TempDir()
+	h := injectCtx(makeSessionCtx(dir))(NewHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/dynamic_chunk", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestHandler_InvalidWid_Returns400(t *testing.T) {
+	dir := t.TempDir()
+	h := injectCtx(makeSessionCtx(dir))(NewHandler())
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/dynamic_chunk?wid=0&digest="+hex.EncodeToString(make([]byte, 32))+"&size=1&encoded-size=13",
+		nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestHandler_BodySizeMismatch_Returns400(t *testing.T) {
+	dir := t.TempDir()
+	ws := wstate.New()
+	wid := registerDynamicWriter(t, ws)
+	sc := &streamctx.SessionContext{
+		SessionID:     "s",
+		DatastoreRoot: dir,
+		BackupType:    "vm",
+		BackupID:      "100",
+		BackupTime:    time.Unix(1735000000, 0).UTC(),
+		WriterState:   ws,
+	}
+	h := injectCtx(sc)(NewHandler())
+
+	body := makeUncompressedBlob([]byte{0xAB})
+	url := "/dynamic_chunk?wid=" + strconv.Itoa(wid) +
+		"&digest=" + hex.EncodeToString(make([]byte, 32)) +
+		"&size=1&encoded-size=99" // 99 != len(body)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}

--- a/services/backupos-pbs/internal/dynamicclose/dynamicclose.go
+++ b/services/backupos-pbs/internal/dynamicclose/dynamicclose.go
@@ -38,14 +38,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wid, chunkCount, csum, err := parseQuery(r.URL.Query())
+	wid, chunkCount, size, csum, err := parseQuery(r.URL.Query())
 	if err != nil {
 		slog.Info("dynamic_close rejected: bad params", "reason", err.Error(), "session_id", sc.SessionID)
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	_, err = sc.WriterState.DynamicWriterClose(wid, chunkCount, csum)
+	_, err = sc.WriterState.DynamicWriterClose(wid, chunkCount, size, csum)
 	if err != nil {
 		slog.Info("dynamic_close failed",
 			"reason", err.Error(), "session_id", sc.SessionID, "wid", wid)
@@ -57,6 +57,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"session_id", sc.SessionID,
 		"wid", wid,
 		"chunk_count", chunkCount,
+		"size", size,
 	)
 
 	w.Header().Set("Content-Type", "application/json")
@@ -65,8 +66,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // parseQuery validates and extracts query parameters.
-// Note: no "size" parameter — dynamic archives have unknown total size.
-func parseQuery(q map[string][]string) (wid int, chunkCount uint64, csum [32]byte, err error) {
+func parseQuery(q map[string][]string) (wid int, chunkCount uint64, size uint64, csum [32]byte, err error) {
 	get := func(k string) string {
 		if v := q[k]; len(v) > 0 {
 			return v[0]
@@ -76,34 +76,43 @@ func parseQuery(q map[string][]string) (wid int, chunkCount uint64, csum [32]byt
 
 	widRaw := get("wid")
 	if widRaw == "" {
-		return 0, 0, [32]byte{}, fmt.Errorf("missing required parameter \"wid\"")
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("missing required parameter \"wid\"")
 	}
 	widI, e := strconv.Atoi(widRaw)
 	if e != nil || widI < 1 || widI > 256 {
-		return 0, 0, [32]byte{}, fmt.Errorf("invalid \"wid\": must be 1..256")
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("invalid \"wid\": must be 1..256")
 	}
 
 	ccRaw := get("chunk-count")
 	if ccRaw == "" {
-		return 0, 0, [32]byte{}, fmt.Errorf("missing required parameter \"chunk-count\"")
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("missing required parameter \"chunk-count\"")
 	}
 	ccI, e := strconv.ParseUint(ccRaw, 10, 64)
 	if e != nil {
-		return 0, 0, [32]byte{}, fmt.Errorf("invalid \"chunk-count\"")
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("invalid \"chunk-count\"")
+	}
+
+	sizeRaw := get("size")
+	if sizeRaw == "" {
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("missing required parameter \"size\"")
+	}
+	sizeI, e := strconv.ParseUint(sizeRaw, 10, 64)
+	if e != nil {
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("invalid \"size\"")
 	}
 
 	csumHex := get("csum")
 	if len(csumHex) != 64 {
-		return 0, 0, [32]byte{}, fmt.Errorf("invalid \"csum\": must be 64 hex chars")
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("invalid \"csum\": must be 64 hex chars")
 	}
 	csumBytes, e := hex.DecodeString(csumHex)
 	if e != nil {
-		return 0, 0, [32]byte{}, fmt.Errorf("invalid \"csum\": not valid hex")
+		return 0, 0, 0, [32]byte{}, fmt.Errorf("invalid \"csum\": not valid hex")
 	}
 	var c [32]byte
 	copy(c[:], csumBytes)
 
-	return widI, ccI, c, nil
+	return widI, ccI, sizeI, c, nil
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {

--- a/services/backupos-pbs/internal/dynamicclose/dynamicclose.go
+++ b/services/backupos-pbs/internal/dynamicclose/dynamicclose.go
@@ -1,0 +1,113 @@
+// Package dynamicclose implements the POST /dynamic_close H2 endpoint.
+//
+// The client calls POST /dynamic_close after all chunks have been uploaded and
+// associated via PUT /dynamic_index. Unlike POST /fixed_close, no "size"
+// parameter is expected — the total size of a dynamic archive is not known
+// upfront. The server validates chunk-count and index checksum only.
+package dynamicclose
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+// Handler implements POST /dynamic_close.
+type Handler struct{}
+
+// NewHandler constructs a dynamicclose handler.
+func NewHandler() *Handler { return &Handler{} }
+
+// ServeHTTP routes POST /dynamic_close → finalise; any other method → 405.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil {
+		slog.Error("dynamicclose handler invoked without streamctx")
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	wid, chunkCount, csum, err := parseQuery(r.URL.Query())
+	if err != nil {
+		slog.Info("dynamic_close rejected: bad params", "reason", err.Error(), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	_, err = sc.WriterState.DynamicWriterClose(wid, chunkCount, csum)
+	if err != nil {
+		slog.Info("dynamic_close failed",
+			"reason", err.Error(), "session_id", sc.SessionID, "wid", wid)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	slog.Info("dynamic_close finalised",
+		"session_id", sc.SessionID,
+		"wid", wid,
+		"chunk_count", chunkCount,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"data":null}`))
+}
+
+// parseQuery validates and extracts query parameters.
+// Note: no "size" parameter — dynamic archives have unknown total size.
+func parseQuery(q map[string][]string) (wid int, chunkCount uint64, csum [32]byte, err error) {
+	get := func(k string) string {
+		if v := q[k]; len(v) > 0 {
+			return v[0]
+		}
+		return ""
+	}
+
+	widRaw := get("wid")
+	if widRaw == "" {
+		return 0, 0, [32]byte{}, fmt.Errorf("missing required parameter \"wid\"")
+	}
+	widI, e := strconv.Atoi(widRaw)
+	if e != nil || widI < 1 || widI > 256 {
+		return 0, 0, [32]byte{}, fmt.Errorf("invalid \"wid\": must be 1..256")
+	}
+
+	ccRaw := get("chunk-count")
+	if ccRaw == "" {
+		return 0, 0, [32]byte{}, fmt.Errorf("missing required parameter \"chunk-count\"")
+	}
+	ccI, e := strconv.ParseUint(ccRaw, 10, 64)
+	if e != nil {
+		return 0, 0, [32]byte{}, fmt.Errorf("invalid \"chunk-count\"")
+	}
+
+	csumHex := get("csum")
+	if len(csumHex) != 64 {
+		return 0, 0, [32]byte{}, fmt.Errorf("invalid \"csum\": must be 64 hex chars")
+	}
+	csumBytes, e := hex.DecodeString(csumHex)
+	if e != nil {
+		return 0, 0, [32]byte{}, fmt.Errorf("invalid \"csum\": not valid hex")
+	}
+	var c [32]byte
+	copy(c[:], csumBytes)
+
+	return widI, ccI, c, nil
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/dynamicclose/dynamicclose_test.go
+++ b/services/backupos-pbs/internal/dynamicclose/dynamicclose_test.go
@@ -71,7 +71,7 @@ func TestHandler_MissingWid_Returns400(t *testing.T) {
 	ws, _, _ := makeState(t)
 	h := injectCtx(makeSessionCtx(ws))(NewHandler())
 
-	req := httptest.NewRequest(http.MethodPost, "/dynamic_close?chunk-count=0&csum="+strings.Repeat("00", 32), nil)
+	req := httptest.NewRequest(http.MethodPost, "/dynamic_close?chunk-count=0&size=0&csum="+strings.Repeat("00", 32), nil)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
@@ -80,15 +80,28 @@ func TestHandler_MissingWid_Returns400(t *testing.T) {
 	}
 }
 
+func TestHandler_MissingSize_Returns400(t *testing.T) {
+	ws, _, _ := makeState(t)
+	h := injectCtx(makeSessionCtx(ws))(NewHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/dynamic_close?wid=1&chunk-count=0&csum="+strings.Repeat("00", 32), nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing size, got %d", rr.Code)
+	}
+}
+
 func TestHandler_HappyPath_Returns200(t *testing.T) {
 	ws, wid, fi := makeState(t)
-	// Compute the expected csum (zero because fakeDynIdx.closeReturn is zero).
 	var expectedCsum [32]byte
 	fi.closeReturn = expectedCsum
 	h := injectCtx(makeSessionCtx(ws))(NewHandler())
 
 	csumHex := hex.EncodeToString(expectedCsum[:])
-	url := "/dynamic_close?wid=1&chunk-count=0&csum=" + csumHex
+	// No chunks appended → size=0, chunk-count=0, offset=0.
+	url := "/dynamic_close?wid=1&chunk-count=0&size=0&csum=" + csumHex
 	_ = wid
 	req := httptest.NewRequest(http.MethodPost, url, nil)
 	rr := httptest.NewRecorder()
@@ -101,14 +114,13 @@ func TestHandler_HappyPath_Returns200(t *testing.T) {
 
 func TestHandler_ChunkCountMismatch_Returns400(t *testing.T) {
 	ws, wid, _ := makeState(t)
-	// Append one chunk so server count = 1, but send chunk-count=0.
 	var d [32]byte
 	_ = ws.RegisterDynamicChunk(wid, d, 4096, false)
 	_ = ws.DynamicWriterAppendChunk(wid, 4096, d)
 	h := injectCtx(makeSessionCtx(ws))(NewHandler())
 
 	csumHex := strings.Repeat("00", 32)
-	url := "/dynamic_close?wid=1&chunk-count=0&csum=" + csumHex
+	url := "/dynamic_close?wid=1&chunk-count=0&size=4096&csum=" + csumHex
 	req := httptest.NewRequest(http.MethodPost, url, nil)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
@@ -120,11 +132,12 @@ func TestHandler_ChunkCountMismatch_Returns400(t *testing.T) {
 
 func TestHandler_CsumMismatch_Returns400(t *testing.T) {
 	ws, _, fi := makeState(t)
-	fi.closeReturn[0] = 0xAA // server returns non-zero csum
+	fi.closeReturn[0] = 0xAA
 	h := injectCtx(makeSessionCtx(ws))(NewHandler())
 
-	wrongCsum := strings.Repeat("00", 32) // client sends all-zeros
-	url := "/dynamic_close?wid=1&chunk-count=0&csum=" + wrongCsum
+	wrongCsum := strings.Repeat("00", 32)
+	// size=0 matches Offset=0 (no chunks appended)
+	url := "/dynamic_close?wid=1&chunk-count=0&size=0&csum=" + wrongCsum
 	req := httptest.NewRequest(http.MethodPost, url, nil)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)

--- a/services/backupos-pbs/internal/dynamicclose/dynamicclose_test.go
+++ b/services/backupos-pbs/internal/dynamicclose/dynamicclose_test.go
@@ -1,0 +1,135 @@
+package dynamicclose
+
+import (
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
+)
+
+// fakeDynIdx is a minimal DynamicIndexWriter stub.
+type fakeDynIdx struct {
+	count       uint64
+	closeReturn [32]byte
+	closeErr    error
+}
+
+func (f *fakeDynIdx) AddChunk(_ uint64, _ [32]byte) error { f.count++; return nil }
+func (f *fakeDynIdx) IndexLength() uint64                 { return f.count }
+func (f *fakeDynIdx) Close() ([32]byte, error)            { return f.closeReturn, f.closeErr }
+func (f *fakeDynIdx) UUID() [16]byte                      { return [16]byte{} }
+func (f *fakeDynIdx) Drop()                               {}
+
+func makeState(t *testing.T) (*wstate.State, int, *fakeDynIdx) {
+	t.Helper()
+	fi := &fakeDynIdx{}
+	ws := wstate.New()
+	wid, err := ws.RegisterDynamicWriter("test.didx", fi)
+	if err != nil {
+		t.Fatalf("RegisterDynamicWriter: %v", err)
+	}
+	return ws, wid, fi
+}
+
+func makeSessionCtx(ws *wstate.State) *streamctx.SessionContext {
+	return &streamctx.SessionContext{
+		SessionID:   "test-session",
+		BackupType:  "vm",
+		BackupID:    "100",
+		BackupTime:  time.Unix(1735000000, 0).UTC(),
+		WriterState: ws,
+	}
+}
+
+func injectCtx(sc *streamctx.SessionContext) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sc)))
+		})
+	}
+}
+
+func TestHandler_WrongMethod_Returns405(t *testing.T) {
+	ws, _, _ := makeState(t)
+	h := injectCtx(makeSessionCtx(ws))(NewHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/dynamic_close", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestHandler_MissingWid_Returns400(t *testing.T) {
+	ws, _, _ := makeState(t)
+	h := injectCtx(makeSessionCtx(ws))(NewHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/dynamic_close?chunk-count=0&csum="+strings.Repeat("00", 32), nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestHandler_HappyPath_Returns200(t *testing.T) {
+	ws, wid, fi := makeState(t)
+	// Compute the expected csum (zero because fakeDynIdx.closeReturn is zero).
+	var expectedCsum [32]byte
+	fi.closeReturn = expectedCsum
+	h := injectCtx(makeSessionCtx(ws))(NewHandler())
+
+	csumHex := hex.EncodeToString(expectedCsum[:])
+	url := "/dynamic_close?wid=1&chunk-count=0&csum=" + csumHex
+	_ = wid
+	req := httptest.NewRequest(http.MethodPost, url, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandler_ChunkCountMismatch_Returns400(t *testing.T) {
+	ws, wid, _ := makeState(t)
+	// Append one chunk so server count = 1, but send chunk-count=0.
+	var d [32]byte
+	_ = ws.RegisterDynamicChunk(wid, d, 4096, false)
+	_ = ws.DynamicWriterAppendChunk(wid, 4096, d)
+	h := injectCtx(makeSessionCtx(ws))(NewHandler())
+
+	csumHex := strings.Repeat("00", 32)
+	url := "/dynamic_close?wid=1&chunk-count=0&csum=" + csumHex
+	req := httptest.NewRequest(http.MethodPost, url, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for count mismatch, got %d", rr.Code)
+	}
+}
+
+func TestHandler_CsumMismatch_Returns400(t *testing.T) {
+	ws, _, fi := makeState(t)
+	fi.closeReturn[0] = 0xAA // server returns non-zero csum
+	h := injectCtx(makeSessionCtx(ws))(NewHandler())
+
+	wrongCsum := strings.Repeat("00", 32) // client sends all-zeros
+	url := "/dynamic_close?wid=1&chunk-count=0&csum=" + wrongCsum
+	req := httptest.NewRequest(http.MethodPost, url, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for csum mismatch, got %d", rr.Code)
+	}
+}

--- a/services/backupos-pbs/internal/dynamicindex/dynamicindex.go
+++ b/services/backupos-pbs/internal/dynamicindex/dynamicindex.go
@@ -1,0 +1,115 @@
+// Package dynamicindex implements the POST /dynamic_index H2 endpoint.
+//
+// The client calls POST /dynamic_index once per .didx file it wants to create.
+// Unlike POST /fixed_index, no "size" parameter is accepted — dynamic index
+// size is unknown upfront. The server creates the .didx writer, registers it
+// in the session WriterState, and returns the writer ID (wid).
+package dynamicindex
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"regexp"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/didx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snapshot"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+// archiveNameRegex matches valid .didx archive names.
+var archiveNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_.-]+\.didx$`)
+
+// Handler implements POST /dynamic_index.
+type Handler struct{}
+
+// NewHandler constructs a dynamicindex handler.
+func NewHandler() *Handler { return &Handler{} }
+
+// ServeHTTP routes POST /dynamic_index → create writer; any other method → 405.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil {
+		slog.Error("dynamicindex handler invoked without streamctx")
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	archiveName, err := parseQuery(r.URL.Query())
+	if err != nil {
+		slog.Info("dynamic_index rejected", "reason", err.Error(), "session_id", sc.SessionID)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	snapDir, err := snapshot.EnsureDir(sc.DatastoreRoot, sc.BackupType, sc.BackupID, sc.BackupTime)
+	if err != nil {
+		slog.Error("snapshot dir ensure failed",
+			"error", err, "session_id", sc.SessionID, "datastore_root", sc.DatastoreRoot)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	finalPath := snapDir + "/" + archiveName
+	dw, err := didx.Create(finalPath)
+	if err != nil {
+		slog.Error("didx create failed",
+			"error", err, "session_id", sc.SessionID, "archive_name", archiveName)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	wid, err := sc.WriterState.RegisterDynamicWriter(archiveName, dw)
+	if err != nil {
+		dw.Drop()
+		slog.Error("register dynamic writer failed",
+			"error", err, "session_id", sc.SessionID, "archive_name", archiveName)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	slog.Info("dynamic_index created",
+		"session_id", sc.SessionID,
+		"archive_name", archiveName,
+		"wid", wid,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]int{"data": wid})
+}
+
+// parseQuery validates and extracts the archive-name query parameter.
+func parseQuery(q map[string][]string) (archiveName string, err error) {
+	get := func(k string) string {
+		if v := q[k]; len(v) > 0 {
+			return v[0]
+		}
+		return ""
+	}
+
+	archiveName = get("archive-name")
+	if archiveName == "" {
+		return "", fmt.Errorf("missing required parameter \"archive-name\"")
+	}
+	if len(archiveName) > 64 {
+		return "", fmt.Errorf("\"archive-name\" too long (max 64 chars)")
+	}
+	if !archiveNameRegex.MatchString(archiveName) {
+		return "", fmt.Errorf("invalid \"archive-name\": must match [A-Za-z0-9_.-]+\\.didx")
+	}
+	return archiveName, nil
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/dynamicindex/dynamicindex_test.go
+++ b/services/backupos-pbs/internal/dynamicindex/dynamicindex_test.go
@@ -1,0 +1,108 @@
+package dynamicindex
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
+)
+
+func injectCtx(sc *streamctx.SessionContext) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sc)))
+		})
+	}
+}
+
+func makeSessionCtx(datastoreRoot string) *streamctx.SessionContext {
+	return &streamctx.SessionContext{
+		SessionID:     "test-session",
+		DatastoreID:   "ds-1",
+		DatastoreRoot: datastoreRoot,
+		BackupType:    "vm",
+		BackupID:      "100",
+		BackupTime:    time.Unix(1735000000, 0).UTC(),
+		WriterState:   wstate.New(),
+	}
+}
+
+func TestHandler_MissingArchiveName_Returns400(t *testing.T) {
+	dir := t.TempDir()
+	h := injectCtx(makeSessionCtx(dir))(NewHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/dynamic_index", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestHandler_BadExtension_Returns400(t *testing.T) {
+	dir := t.TempDir()
+	h := injectCtx(makeSessionCtx(dir))(NewHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/dynamic_index?archive-name=drive.fidx", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for .fidx name, got %d", rr.Code)
+	}
+}
+
+func TestHandler_WrongMethod_Returns405(t *testing.T) {
+	dir := t.TempDir()
+	h := injectCtx(makeSessionCtx(dir))(NewHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/dynamic_index?archive-name=pxar.didx", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestHandler_ValidRequest_Returns200WithWid(t *testing.T) {
+	dir := t.TempDir()
+	h := injectCtx(makeSessionCtx(dir))(NewHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/dynamic_index?archive-name=drive-scsi0.img.didx", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Data int `json:"data"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Data < 1 || resp.Data > 256 {
+		t.Errorf("wid out of range: %d", resp.Data)
+	}
+}
+
+func TestHandler_ArchiveNameTooLong_Returns400(t *testing.T) {
+	dir := t.TempDir()
+	h := injectCtx(makeSessionCtx(dir))(NewHandler())
+
+	// 65-char base + .didx = 70 chars total, over the 64-char limit
+	longName := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.didx"
+	req := httptest.NewRequest(http.MethodPost, "/dynamic_index?archive-name="+longName, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}

--- a/services/backupos-pbs/internal/upgrade/handler.go
+++ b/services/backupos-pbs/internal/upgrade/handler.go
@@ -37,22 +37,26 @@ const UpgradeToken = "proxmox-backup-protocol-v1"
 // is expected to wrap this with the requireAuth middleware, which also
 // attaches the Identity to the request context via auth.WithIdentity.
 type Handler struct {
-	datastores         *datastore.Lookup
-	sessions           *session.Store
-	blobHandler        http.Handler
-	finishHandler      http.Handler
-	fixedIndexHandler  http.Handler
-	fixedChunkHandler  http.Handler
-	fixedAppendHandler http.Handler
-	fixedCloseHandler  http.Handler
-	streamHandler      http.Handler // fallback 501-stub for unimplemented H2 paths
+	datastores          *datastore.Lookup
+	sessions            *session.Store
+	blobHandler         http.Handler
+	finishHandler       http.Handler
+	fixedIndexHandler   http.Handler
+	fixedChunkHandler   http.Handler
+	fixedAppendHandler  http.Handler
+	fixedCloseHandler   http.Handler
+	dynamicIndexHandler  http.Handler
+	dynamicChunkHandler  http.Handler
+	dynamicAppendHandler http.Handler
+	dynamicCloseHandler  http.Handler
+	streamHandler       http.Handler // fallback 501-stub for unimplemented H2 paths
 }
 
 // NewHandler constructs a new upgrade Handler.
 //
 // blobHandler handles POST /blob; finishHandler handles POST /finish.
-// fixedIndexHandler, fixedChunkHandler, fixedAppendHandler, fixedCloseHandler
-// handle the fixed-index lifecycle.
+// fixed* handlers handle the fixed-index lifecycle (/fixed_index, /fixed_chunk, /fixed_close).
+// dynamic* handlers handle the dynamic-index lifecycle (/dynamic_index, /dynamic_chunk, /dynamic_close).
 // streamHandler is the fallback invoked for all other H2 paths (501 stub).
 func NewHandler(
 	datastores *datastore.Lookup,
@@ -63,18 +67,26 @@ func NewHandler(
 	fixedChunkHandler http.Handler,
 	fixedAppendHandler http.Handler,
 	fixedCloseHandler http.Handler,
+	dynamicIndexHandler http.Handler,
+	dynamicChunkHandler http.Handler,
+	dynamicAppendHandler http.Handler,
+	dynamicCloseHandler http.Handler,
 	streamHandler http.Handler,
 ) *Handler {
 	return &Handler{
-		datastores:         datastores,
-		sessions:           sessions,
-		blobHandler:        blobHandler,
-		finishHandler:      finishHandler,
-		fixedIndexHandler:  fixedIndexHandler,
-		fixedChunkHandler:  fixedChunkHandler,
-		fixedAppendHandler: fixedAppendHandler,
-		fixedCloseHandler:  fixedCloseHandler,
-		streamHandler:      streamHandler,
+		datastores:           datastores,
+		sessions:             sessions,
+		blobHandler:          blobHandler,
+		finishHandler:        finishHandler,
+		fixedIndexHandler:    fixedIndexHandler,
+		fixedChunkHandler:    fixedChunkHandler,
+		fixedAppendHandler:   fixedAppendHandler,
+		fixedCloseHandler:    fixedCloseHandler,
+		dynamicIndexHandler:  dynamicIndexHandler,
+		dynamicChunkHandler:  dynamicChunkHandler,
+		dynamicAppendHandler: dynamicAppendHandler,
+		dynamicCloseHandler:  dynamicCloseHandler,
+		streamHandler:        streamHandler,
 	}
 }
 
@@ -205,6 +217,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.blobHandler, h.finishHandler,
 		h.fixedIndexHandler, h.fixedChunkHandler,
 		h.fixedAppendHandler, h.fixedCloseHandler,
+		h.dynamicIndexHandler, h.dynamicChunkHandler,
+		h.dynamicAppendHandler, h.dynamicCloseHandler,
 		h.streamHandler,
 	)
 	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -282,7 +296,19 @@ func identifyKind(path string) string {
 
 // buildSessionRouter routes H2 streams to the appropriate handler.
 // /fixed_index dispatches POST→fixedIndex and PUT→fixedAppend.
-func buildSessionRouter(blobHandler, finishHandler, fixedIndexHandler, fixedChunkHandler, fixedAppendHandler, fixedCloseHandler, fallback http.Handler) http.Handler {
+// /dynamic_index dispatches POST→dynamicIndex and PUT→dynamicAppend.
+func buildSessionRouter(
+	blobHandler, finishHandler,
+	fixedIndexHandler, fixedChunkHandler, fixedAppendHandler, fixedCloseHandler,
+	dynamicIndexHandler, dynamicChunkHandler, dynamicAppendHandler, dynamicCloseHandler,
+	fallback http.Handler,
+) http.Handler {
+	methodNotAllowed := func(w http.ResponseWriter, allow string) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Allow", allow)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "method not allowed"})
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/blob":
@@ -296,15 +322,25 @@ func buildSessionRouter(blobHandler, finishHandler, fixedIndexHandler, fixedChun
 			case http.MethodPut:
 				fixedAppendHandler.ServeHTTP(w, r)
 			default:
-				w.Header().Set("Content-Type", "application/json")
-				w.Header().Set("Allow", "POST, PUT")
-				w.WriteHeader(http.StatusMethodNotAllowed)
-				_ = json.NewEncoder(w).Encode(map[string]string{"error": "method not allowed"})
+				methodNotAllowed(w, "POST, PUT")
 			}
 		case "/fixed_chunk":
 			fixedChunkHandler.ServeHTTP(w, r)
 		case "/fixed_close":
 			fixedCloseHandler.ServeHTTP(w, r)
+		case "/dynamic_index":
+			switch r.Method {
+			case http.MethodPost:
+				dynamicIndexHandler.ServeHTTP(w, r)
+			case http.MethodPut:
+				dynamicAppendHandler.ServeHTTP(w, r)
+			default:
+				methodNotAllowed(w, "POST, PUT")
+			}
+		case "/dynamic_chunk":
+			dynamicChunkHandler.ServeHTTP(w, r)
+		case "/dynamic_close":
+			dynamicCloseHandler.ServeHTTP(w, r)
 		default:
 			fallback.ServeHTTP(w, r)
 		}

--- a/services/backupos-pbs/internal/upgrade/handler_test.go
+++ b/services/backupos-pbs/internal/upgrade/handler_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/blob"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/dynamicappend"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/dynamicchunk"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/dynamicclose"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/dynamicindex"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/finish"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedappend"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedchunk"
@@ -88,6 +92,10 @@ func newTestHandler(db *sql.DB) *Handler {
 		fixedchunk.NewHandler(),
 		fixedappend.NewHandler(),
 		fixedclose.NewHandler(),
+		dynamicindex.NewHandler(),
+		dynamicchunk.NewHandler(),
+		dynamicappend.NewHandler(),
+		dynamicclose.NewHandler(),
 		StubStreamHandler(),
 	)
 }

--- a/services/backupos-pbs/internal/wstate/wstate.go
+++ b/services/backupos-pbs/internal/wstate/wstate.go
@@ -40,8 +40,23 @@ type FixedWriter struct {
 	Closed          bool
 }
 
-// DynamicWriter is a placeholder for future dynamic-index support.
-type DynamicWriter struct{}
+// DynamicIndexWriter is the contract wstate needs from a didx writer.
+// Concrete implementation lives in internal/didx.
+type DynamicIndexWriter interface {
+	AddChunk(offset uint64, digest [32]byte) error
+	IndexLength() uint64
+	Close() ([32]byte, error)
+	UUID() [16]byte
+	Drop()
+}
+
+// DynamicWriter holds mutable state for one open .didx writer.
+type DynamicWriter struct {
+	Name       string
+	Index      DynamicIndexWriter
+	ChunkCount uint64
+	Closed     bool
+}
 
 // State is the per-session shared writer state.
 type State struct {
@@ -204,12 +219,112 @@ func (s *State) FixedWriterClose(wid int, chunkCount uint64, size uint64, csum [
 	return gotCsum, nil
 }
 
+// RegisterDynamicWriter inserts a new DynamicWriter and returns its wid.
+func (s *State) RegisterDynamicWriter(name string, index DynamicIndexWriter) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.EnsureUnfinished(); err != nil {
+		return 0, err
+	}
+	wid, err := s.nextWid()
+	if err != nil {
+		return 0, err
+	}
+	s.dynamicWriters[wid] = &DynamicWriter{
+		Name:  name,
+		Index: index,
+	}
+	return wid, nil
+}
+
+// RegisterDynamicChunk records a successfully uploaded chunk in known_chunks.
+// Unlike fixed chunks, there is no chunk-size constraint for dynamic writers.
+func (s *State) RegisterDynamicChunk(wid int, digest [32]byte, size uint32, isDuplicate bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.EnsureUnfinished(); err != nil {
+		return err
+	}
+	w, ok := s.dynamicWriters[wid]
+	if !ok {
+		return fmt.Errorf("dynamic writer %d not registered", wid)
+	}
+	if w.Closed {
+		return fmt.Errorf("dynamic writer %q already closed", w.Name)
+	}
+	s.knownChunks[digest] = size
+	_ = isDuplicate
+	return nil
+}
+
+// DynamicWriterAppendChunk associates an uploaded chunk with a position in the
+// .didx index. The digest must already be in known_chunks (checked by caller).
+// No size is passed — dynamic index entries carry only (offset, digest).
+func (s *State) DynamicWriterAppendChunk(wid int, offset uint64, digest [32]byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.EnsureUnfinished(); err != nil {
+		return err
+	}
+	w, ok := s.dynamicWriters[wid]
+	if !ok {
+		return fmt.Errorf("dynamic writer %d not registered", wid)
+	}
+	if w.Closed {
+		return fmt.Errorf("dynamic writer %q already closed", w.Name)
+	}
+	if err := w.Index.AddChunk(offset, digest); err != nil {
+		return fmt.Errorf("dynamic writer %q add_chunk failed: %w", w.Name, err)
+	}
+	w.ChunkCount++
+	return nil
+}
+
+// DynamicWriterClose finalises a writer, verifying chunk count and checksum.
+// No size validation — dynamic index size is not known upfront.
+func (s *State) DynamicWriterClose(wid int, chunkCount uint64, csum [32]byte) ([32]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.EnsureUnfinished(); err != nil {
+		return [32]byte{}, err
+	}
+	w, ok := s.dynamicWriters[wid]
+	if !ok {
+		return [32]byte{}, fmt.Errorf("dynamic writer %d not registered", wid)
+	}
+	if w.Closed {
+		return [32]byte{}, fmt.Errorf("dynamic writer %q already closed", w.Name)
+	}
+	if w.ChunkCount != chunkCount {
+		return [32]byte{}, fmt.Errorf("dynamic writer %q close: server saw %d chunks, client expected %d",
+			w.Name, w.ChunkCount, chunkCount)
+	}
+	if w.Index.IndexLength() != chunkCount {
+		return [32]byte{}, fmt.Errorf("dynamic writer %q close: index_length=%d, chunk_count=%d",
+			w.Name, w.Index.IndexLength(), chunkCount)
+	}
+	gotCsum, err := w.Index.Close()
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("dynamic writer %q close failed: %w", w.Name, err)
+	}
+	if gotCsum != csum {
+		return [32]byte{}, fmt.Errorf("dynamic writer %q close: server csum != client csum", w.Name)
+	}
+	w.Closed = true
+	return gotCsum, nil
+}
+
 // Cleanup drops any open writers (frees mmap/tmpfile) and marks the session
 // finished. Called from the upgrade handler after ServeConn returns.
 func (s *State) Cleanup() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, w := range s.fixedWriters {
+		if !w.Closed {
+			w.Index.Drop()
+		}
+	}
+	for _, w := range s.dynamicWriters {
 		if !w.Closed {
 			w.Index.Drop()
 		}

--- a/services/backupos-pbs/internal/wstate/wstate.go
+++ b/services/backupos-pbs/internal/wstate/wstate.go
@@ -55,6 +55,7 @@ type DynamicWriter struct {
 	Name       string
 	Index      DynamicIndexWriter
 	ChunkCount uint64
+	Offset     uint64 // cumulative end offset after last AppendChunk; equals total data size at close
 	Closed     bool
 }
 
@@ -277,12 +278,14 @@ func (s *State) DynamicWriterAppendChunk(wid int, offset uint64, digest [32]byte
 		return fmt.Errorf("dynamic writer %q add_chunk failed: %w", w.Name, err)
 	}
 	w.ChunkCount++
+	w.Offset = offset
 	return nil
 }
 
-// DynamicWriterClose finalises a writer, verifying chunk count and checksum.
-// No size validation — dynamic index size is not known upfront.
-func (s *State) DynamicWriterClose(wid int, chunkCount uint64, csum [32]byte) ([32]byte, error) {
+// DynamicWriterClose finalises a writer, verifying chunk count, total data size,
+// and index checksum. size must equal the cumulative end offset of the last chunk
+// (matches environment.rs: data.offset == size check in dynamic_writer_close).
+func (s *State) DynamicWriterClose(wid int, chunkCount uint64, size uint64, csum [32]byte) ([32]byte, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err := s.EnsureUnfinished(); err != nil {
@@ -302,6 +305,10 @@ func (s *State) DynamicWriterClose(wid int, chunkCount uint64, csum [32]byte) ([
 	if w.Index.IndexLength() != chunkCount {
 		return [32]byte{}, fmt.Errorf("dynamic writer %q close: index_length=%d, chunk_count=%d",
 			w.Name, w.Index.IndexLength(), chunkCount)
+	}
+	if w.Offset != size {
+		return [32]byte{}, fmt.Errorf("dynamic writer %q close: data offset %d != size %d",
+			w.Name, w.Offset, size)
 	}
 	gotCsum, err := w.Index.Close()
 	if err != nil {

--- a/services/backupos-pbs/internal/wstate/wstate_test.go
+++ b/services/backupos-pbs/internal/wstate/wstate_test.go
@@ -373,7 +373,7 @@ func TestDynamicWriterClose_HappyPath(t *testing.T) {
 	var d [32]byte
 	_ = ws.DynamicWriterAppendChunk(wid, 65536, d)
 
-	got, err := ws.DynamicWriterClose(wid, 1, expectedCsum)
+	got, err := ws.DynamicWriterClose(wid, 1, 65536, expectedCsum)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,9 +387,24 @@ func TestDynamicWriterClose_ChunkCountMismatch_ReturnsError(t *testing.T) {
 	fi := &fakeDynIdx{}
 	wid, _ := ws.RegisterDynamicWriter("a.didx", fi)
 	// No AppendChunk calls; server count=0, client claims 1.
-	_, err := ws.DynamicWriterClose(wid, 1, [32]byte{})
+	_, err := ws.DynamicWriterClose(wid, 1, 0, [32]byte{})
 	if err == nil {
 		t.Error("expected error for count mismatch, got nil")
+	}
+}
+
+func TestDynamicWriterClose_SizeMismatch_ReturnsError(t *testing.T) {
+	ws := New()
+	fi := &fakeDynIdx{}
+	wid, _ := ws.RegisterDynamicWriter("a.didx", fi)
+
+	var d [32]byte
+	_ = ws.DynamicWriterAppendChunk(wid, 65536, d) // Offset becomes 65536
+
+	// client claims size=99999, server tracked 65536
+	_, err := ws.DynamicWriterClose(wid, 1, 99999, [32]byte{})
+	if err == nil {
+		t.Error("expected error for size mismatch, got nil")
 	}
 }
 
@@ -402,7 +417,8 @@ func TestDynamicWriterClose_CsumMismatch_ReturnsError(t *testing.T) {
 
 	var wrongCsum [32]byte
 	wrongCsum[0] = 0xBB
-	_, err := ws.DynamicWriterClose(wid, 0, wrongCsum)
+	// size=0 matches Offset=0 (no chunks appended)
+	_, err := ws.DynamicWriterClose(wid, 0, 0, wrongCsum)
 	if err == nil {
 		t.Error("expected error for csum mismatch, got nil")
 	}
@@ -424,7 +440,7 @@ func TestCleanup_SkipsClosedDynamicWriters(t *testing.T) {
 	ws := New()
 	fi := &fakeDynIdx{}
 	wid, _ := ws.RegisterDynamicWriter("closed.didx", fi)
-	if _, err := ws.DynamicWriterClose(wid, 0, [32]byte{}); err != nil {
+	if _, err := ws.DynamicWriterClose(wid, 0, 0, [32]byte{}); err != nil {
 		t.Fatalf("close: %v", err)
 	}
 	ws.Cleanup()

--- a/services/backupos-pbs/internal/wstate/wstate_test.go
+++ b/services/backupos-pbs/internal/wstate/wstate_test.go
@@ -258,3 +258,177 @@ func TestCleanup_RejectsSubsequentRegistration(t *testing.T) {
 		t.Error("expected error registering after Cleanup, got nil")
 	}
 }
+
+// ---- Dynamic writer stubs ----
+
+type fakeDynIdx struct {
+	chunks      []dynChunkEntry
+	dropCalled  bool
+	closeReturn [32]byte
+	closeErr    error
+}
+
+type dynChunkEntry struct {
+	offset uint64
+	digest [32]byte
+}
+
+func (f *fakeDynIdx) AddChunk(offset uint64, digest [32]byte) error {
+	f.chunks = append(f.chunks, dynChunkEntry{offset, digest})
+	return nil
+}
+func (f *fakeDynIdx) IndexLength() uint64      { return uint64(len(f.chunks)) }
+func (f *fakeDynIdx) Close() ([32]byte, error) { return f.closeReturn, f.closeErr }
+func (f *fakeDynIdx) UUID() [16]byte           { return [16]byte{} }
+func (f *fakeDynIdx) Drop()                    { f.dropCalled = true }
+
+// ---- RegisterDynamicWriter ----
+
+func TestRegisterDynamicWriter_AssignsMonotonicWids(t *testing.T) {
+	ws := New()
+	wid1, err := ws.RegisterDynamicWriter("a.didx", &fakeDynIdx{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wid2, err := ws.RegisterDynamicWriter("b.didx", &fakeDynIdx{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wid1 != 1 {
+		t.Errorf("first wid: got %d, want 1", wid1)
+	}
+	if wid2 != 2 {
+		t.Errorf("second wid: got %d, want 2", wid2)
+	}
+}
+
+func TestRegisterDynamicWriter_SharedWidCounterWithFixed(t *testing.T) {
+	ws := New()
+	wid1, _ := ws.RegisterFixedWriter("a.fidx", &fakeFidx{}, ptrU64(4194304), 4194304, false)
+	wid2, _ := ws.RegisterDynamicWriter("b.didx", &fakeDynIdx{})
+	if wid1 != 1 {
+		t.Errorf("fixed wid: got %d, want 1", wid1)
+	}
+	if wid2 != 2 {
+		t.Errorf("dynamic wid: got %d, want 2", wid2)
+	}
+}
+
+// ---- RegisterDynamicChunk ----
+
+func TestRegisterDynamicChunk_AddsToKnownChunks(t *testing.T) {
+	ws := New()
+	wid, _ := ws.RegisterDynamicWriter("a.didx", &fakeDynIdx{})
+	var digest [32]byte
+	digest[0] = 0xCD
+	if err := ws.RegisterDynamicChunk(wid, digest, 8192, false); err != nil {
+		t.Fatal(err)
+	}
+	size, ok := ws.LookupChunk(digest)
+	if !ok {
+		t.Fatal("chunk not found in knownChunks")
+	}
+	if size != 8192 {
+		t.Errorf("size: got %d, want 8192", size)
+	}
+}
+
+func TestRegisterDynamicChunk_UnknownWid_ReturnsError(t *testing.T) {
+	ws := New()
+	var digest [32]byte
+	err := ws.RegisterDynamicChunk(99, digest, 4096, false)
+	if err == nil {
+		t.Error("expected error for unknown wid, got nil")
+	}
+}
+
+// ---- DynamicWriterAppendChunk ----
+
+func TestDynamicWriterAppendChunk_IncrementsChunkCount(t *testing.T) {
+	ws := New()
+	fi := &fakeDynIdx{}
+	wid, _ := ws.RegisterDynamicWriter("a.didx", fi)
+
+	var digest [32]byte
+	if err := ws.DynamicWriterAppendChunk(wid, 65536, digest); err != nil {
+		t.Fatal(err)
+	}
+	if len(fi.chunks) != 1 {
+		t.Errorf("expected 1 chunk in fakeDynIdx, got %d", len(fi.chunks))
+	}
+	if fi.chunks[0].offset != 65536 {
+		t.Errorf("offset: got %d, want 65536", fi.chunks[0].offset)
+	}
+}
+
+// ---- DynamicWriterClose ----
+
+func TestDynamicWriterClose_HappyPath(t *testing.T) {
+	ws := New()
+	var expectedCsum [32]byte
+	expectedCsum[0] = 0x42
+	fi := &fakeDynIdx{closeReturn: expectedCsum}
+	wid, _ := ws.RegisterDynamicWriter("a.didx", fi)
+
+	var d [32]byte
+	_ = ws.DynamicWriterAppendChunk(wid, 65536, d)
+
+	got, err := ws.DynamicWriterClose(wid, 1, expectedCsum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != expectedCsum {
+		t.Errorf("csum mismatch")
+	}
+}
+
+func TestDynamicWriterClose_ChunkCountMismatch_ReturnsError(t *testing.T) {
+	ws := New()
+	fi := &fakeDynIdx{}
+	wid, _ := ws.RegisterDynamicWriter("a.didx", fi)
+	// No AppendChunk calls; server count=0, client claims 1.
+	_, err := ws.DynamicWriterClose(wid, 1, [32]byte{})
+	if err == nil {
+		t.Error("expected error for count mismatch, got nil")
+	}
+}
+
+func TestDynamicWriterClose_CsumMismatch_ReturnsError(t *testing.T) {
+	ws := New()
+	var serverCsum [32]byte
+	serverCsum[0] = 0xAA
+	fi := &fakeDynIdx{closeReturn: serverCsum}
+	wid, _ := ws.RegisterDynamicWriter("a.didx", fi)
+
+	var wrongCsum [32]byte
+	wrongCsum[0] = 0xBB
+	_, err := ws.DynamicWriterClose(wid, 0, wrongCsum)
+	if err == nil {
+		t.Error("expected error for csum mismatch, got nil")
+	}
+}
+
+// ---- Cleanup with dynamic writers ----
+
+func TestCleanup_DropsOpenDynamicWriters(t *testing.T) {
+	ws := New()
+	fi := &fakeDynIdx{}
+	_, _ = ws.RegisterDynamicWriter("open.didx", fi)
+	ws.Cleanup()
+	if !fi.dropCalled {
+		t.Error("Drop not called on open dynamic writer during Cleanup")
+	}
+}
+
+func TestCleanup_SkipsClosedDynamicWriters(t *testing.T) {
+	ws := New()
+	fi := &fakeDynIdx{}
+	wid, _ := ws.RegisterDynamicWriter("closed.didx", fi)
+	if _, err := ws.DynamicWriterClose(wid, 0, [32]byte{}); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	ws.Cleanup()
+	if fi.dropCalled {
+		t.Error("Drop called on already-closed dynamic writer during Cleanup")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `.didx` writer (`internal/didx`) — BufWriter-based, 4096-byte header, 40-byte entries (end_offset || digest), index_csum = SHA256 over all entries
- Extends `wstate.State` with `DynamicIndexWriter` interface + `DynamicWriter` type and four new methods: `RegisterDynamicWriter`, `RegisterDynamicChunk`, `DynamicWriterAppendChunk`, `DynamicWriterClose`; `Cleanup()` now drops open dynamic writers
- Four new H2 stream handlers: `POST /dynamic_index`, `POST /dynamic_chunk`, `PUT /dynamic_index`, `POST /dynamic_close`
- `upgrade.NewHandler` expanded from 9 to 13 args; `buildSessionRouter` gains `/dynamic_index`, `/dynamic_chunk`, `/dynamic_close` routes
- 16 files changed, ~1774 insertions; all new packages have unit tests including byte-exact `.didx` layout verification

## Test plan

- [ ] `go test -count=1 ./...` passes on server
- [ ] `go build ./cmd/backupos-pbs` succeeds
- [ ] End-to-end: `proxmox-backup-client backup` with a `.pxar` archive reaches `POST /dynamic_close` without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)