### PR TITLE
feat(pbs): reader upgrade handshake + shared locking — milestone 5a

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -6,10 +6,10 @@
 //   - Reads/writes the same SQLite database as the Node service
 //   - Runs alongside backupos.service as a separate systemd unit
 //
-// In M4c-go-finish (this PR), endpoints are:
+// Endpoints:
 //   - GET  /api2/json/version    unauthenticated, 200 JSON
 //   - any  /api2/json/backup     401 without valid auth; with auth: upgrade handshake → H2 streams
-//   - any  /api2/json/reader     401 without valid auth; with auth: upgrade handshake → H2 streams
+//   - GET  /api2/json/reader     inline auth; reader upgrade handshake → H2 streams (M5a)
 //
 // Over the H2 connection:
 //   - POST /blob    write opaque blob atomically to snapshot directory (200)
@@ -44,6 +44,7 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedclose"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedindex"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/handlers"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/readerupgrade"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/upgrade"
 )
@@ -118,10 +119,12 @@ func main() {
 		RepoID:  repoIDString,
 	})
 
+	readerHandler := readerupgrade.NewHandler(validator, datastoreLookup, readerupgrade.Stub501Handler())
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api2/json/version", versionHandler.ServeHTTP)
 	mux.HandleFunc("/api2/json/backup", requireAuth(validator, upgradeHandler.ServeHTTP))
-	mux.HandleFunc("/api2/json/reader", requireAuth(validator, upgradeHandler.ServeHTTP))
+	mux.HandleFunc("/api2/json/reader", readerHandler.ServeHTTP)
 	mux.HandleFunc("/", notFound)
 
 	server := &http.Server{

--- a/services/backupos-pbs/internal/readerupgrade/handler.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler.go
@@ -1,0 +1,324 @@
+// Package readerupgrade implements the HTTP/1.1 → HTTP/2 upgrade handshake
+// for proxmox-backup-reader-protocol-v1.
+//
+// Key differences from internal/upgrade (backup side):
+//   - Different upgrade token: proxmox-backup-reader-protocol-v1
+//   - Snapshot must already exist (snapshot.ResolveDir, not EnsureDir)
+//   - Acquires shared lock (LOCK_SH) — multiple concurrent readers coexist
+//   - Reader sessions are NOT persisted to pbs_active_sessions
+//   - H2 stream routes stubbed at 501 in M5a; real handlers land in M5b
+//
+// Auth is performed inline (not via requireAuth middleware), so this handler
+// must be registered on the mux directly, not wrapped.
+package readerupgrade
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/net/http2"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/rstate"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snaplock"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snapshot"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+const (
+	// ReaderProtocolID is the Upgrade token for reader sessions.
+	// Distinct from the backup token (proxmox-backup-protocol-v1).
+	ReaderProtocolID = "proxmox-backup-reader-protocol-v1"
+
+	h2MaxFrameSize = 4 * 1024 * 1024
+)
+
+// Handler handles a PBS reader-protocol upgrade request.
+type Handler struct {
+	validator  *auth.Validator
+	datastores *datastore.Lookup
+	streamH2   http.Handler // 501-stub in M5a; real router in M5b
+}
+
+// NewHandler constructs a reader upgrade Handler.
+// validator is used for inline auth (no requireAuth middleware needed).
+// streamH2 is the H2 handler after the upgrade (use Stub501Handler() for M5a).
+func NewHandler(validator *auth.Validator, datastores *datastore.Lookup, streamH2 http.Handler) *Handler {
+	return &Handler{
+		validator:  validator,
+		datastores: datastores,
+		streamH2:   streamH2,
+	}
+}
+
+// Stub501Handler returns a handler that responds 501 to every H2 stream.
+// Used as the streamH2 handler in M5a; replaced by a real router in M5b.
+func Stub501Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotImplemented)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error": "reader download endpoints not yet implemented (M5b)",
+		})
+	})
+}
+
+// ServeHTTP handles the reader upgrade request.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Step 1: Method check.
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Step 2: Authenticate inline.
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing Authorization header")
+		return
+	}
+	parsed, err := auth.ParseAuthHeader(authHeader)
+	if err != nil {
+		writeJSONError(w, http.StatusUnauthorized, "malformed Authorization header")
+		return
+	}
+	identity, err := h.validator.Validate(parsed)
+	if err != nil {
+		slog.Info("reader auth failed",
+			"reason", err.Error(),
+			"user", parsed.User,
+			"realm", parsed.Realm,
+			"token_name", parsed.TokenName,
+			"remote", r.RemoteAddr,
+		)
+		writeJSONError(w, http.StatusUnauthorized, "invalid credentials")
+		return
+	}
+
+	// Step 3: Verify Upgrade headers.
+	if !hasReaderUpgradeHeaders(r) {
+		writeJSONError(w, http.StatusBadRequest,
+			fmt.Sprintf("missing or invalid upgrade headers; expected Upgrade: %s", ReaderProtocolID))
+		return
+	}
+
+	// Step 4: Parse query parameters.
+	q := r.URL.Query()
+
+	if ns := q.Get("ns"); ns != "" {
+		writeJSONError(w, http.StatusBadRequest, "namespaces not supported in V1")
+		return
+	}
+
+	storeName := q.Get("store")
+	if storeName == "" {
+		writeJSONError(w, http.StatusBadRequest, `missing required parameter "store"`)
+		return
+	}
+	backupType := q.Get("backup-type")
+	if backupType == "" {
+		writeJSONError(w, http.StatusBadRequest, `missing required parameter "backup-type"`)
+		return
+	}
+	if !validBackupType(backupType) {
+		writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("invalid backup-type: %q", backupType))
+		return
+	}
+	backupID := q.Get("backup-id")
+	if backupID == "" {
+		writeJSONError(w, http.StatusBadRequest, `missing required parameter "backup-id"`)
+		return
+	}
+	backupTimeStr := q.Get("backup-time")
+	if backupTimeStr == "" {
+		writeJSONError(w, http.StatusBadRequest, `missing required parameter "backup-time"`)
+		return
+	}
+	backupTime, err := parseBackupTime(backupTimeStr)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Step 5: Datastore lookup.
+	ds, err := h.datastores.ByName(storeName)
+	if errors.Is(err, datastore.ErrNotFound) || errors.Is(err, datastore.ErrInvalidName) {
+		writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("unknown datastore %q", storeName))
+		return
+	}
+	if err != nil {
+		slog.Error("datastore lookup failed", "error", err, "store", storeName)
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	// Step 6: Resolve snapshot (must exist) and acquire shared lock.
+	snapDir, err := snapshot.ResolveDir(ds.Path, backupType, backupID, backupTime)
+	if err != nil {
+		slog.Info("reader rejected: snapshot not found",
+			"store", storeName, "backup_type", backupType,
+			"backup_id", backupID, "backup_time", backupTime.Format(time.RFC3339),
+		)
+		writeJSONError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	lock, err := snaplock.AcquireShared(snapDir)
+	if err != nil {
+		if errors.Is(err, snaplock.ErrLockBusy) {
+			writeJSONError(w, http.StatusConflict, "snapshot is exclusively locked by another session")
+			return
+		}
+		slog.Error("reader snaplock failed", "error", err, "snap_dir", snapDir)
+		writeJSONError(w, http.StatusInternalServerError, "snapshot lock failed")
+		return
+	}
+
+	// Step 7: Mint session ID for logging (no DB row).
+	sessionID := mintSessionID(identity.TokenID, storeName, backupType, backupID, backupTime)
+
+	slog.Info("reader upgrade accepted",
+		"session_id", sessionID,
+		"store", storeName,
+		"datastore_id", ds.ID,
+		"backup_type", backupType,
+		"backup_id", backupID,
+		"backup_time", backupTime.Format(time.RFC3339),
+		"remote", r.RemoteAddr,
+	)
+
+	// Step 8: Hijack the connection.
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		_ = lock.Release()
+		writeJSONError(w, http.StatusInternalServerError, "hijack not supported")
+		return
+	}
+	conn, brw, err := hj.Hijack()
+	if err != nil {
+		_ = lock.Release()
+		slog.Error("reader hijack failed", "error", err, "session_id", sessionID)
+		return
+	}
+
+	// Step 9: Write 101 Switching Protocols.
+	if err := writeSwitchingProtocols(brw); err != nil {
+		_ = conn.Close()
+		_ = lock.Release()
+		slog.Error("reader write 101 failed", "error", err, "session_id", sessionID)
+		return
+	}
+
+	// Step 10: Build session context and drive H2.
+	rs := rstate.New()
+	sc := &streamctx.SessionContext{
+		SessionID:     sessionID,
+		DatastoreID:   ds.ID,
+		DatastoreRoot: ds.Path,
+		BackupType:    backupType,
+		BackupID:      backupID,
+		BackupTime:    backupTime,
+		ReaderState:   rs,
+	}
+
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.streamH2.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sc)))
+	})
+
+	h2srv := &http2.Server{
+		MaxReadFrameSize: h2MaxFrameSize,
+	}
+	h2srv.ServeConn(conn, &http2.ServeConnOpts{
+		Handler: wrapped,
+	})
+
+	// Connection closed. Release the shared lock.
+	if err := lock.Release(); err != nil {
+		slog.Warn("reader lock release failed", "error", err, "session_id", sessionID)
+	}
+	slog.Info("reader connection closed",
+		"session_id", sessionID,
+		"datastore_id", ds.ID,
+	)
+}
+
+// hasReaderUpgradeHeaders checks for Connection: Upgrade and
+// Upgrade: proxmox-backup-reader-protocol-v1.
+func hasReaderUpgradeHeaders(r *http.Request) bool {
+	connFound := false
+	for _, c := range r.Header.Values("Connection") {
+		for _, part := range strings.Split(c, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), "Upgrade") {
+				connFound = true
+				break
+			}
+		}
+		if connFound {
+			break
+		}
+	}
+	if !connFound {
+		return false
+	}
+	return strings.EqualFold(r.Header.Get("Upgrade"), ReaderProtocolID)
+}
+
+// writeSwitchingProtocols writes the 101 response on the hijacked connection.
+func writeSwitchingProtocols(brw *bufio.ReadWriter) error {
+	const resp = "HTTP/1.1 101 Switching Protocols\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Upgrade: " + ReaderProtocolID + "\r\n" +
+		"\r\n"
+	if _, err := brw.WriteString(resp); err != nil {
+		return fmt.Errorf("write 101: %w", err)
+	}
+	if err := brw.Flush(); err != nil {
+		return fmt.Errorf("flush 101: %w", err)
+	}
+	return nil
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+func validBackupType(t string) bool {
+	return t == "vm" || t == "ct" || t == "host"
+}
+
+// parseBackupTime parses a backup-time query parameter (Unix seconds integer).
+func parseBackupTime(s string) (time.Time, error) {
+	var sec int64
+	if _, err := fmt.Sscanf(s, "%d", &sec); err != nil {
+		return time.Time{}, fmt.Errorf("invalid backup-time: %q", s)
+	}
+	return time.Unix(sec, 0).UTC(), nil
+}
+
+// mintSessionID returns a short unique ID for logging reader sessions.
+// Reader sessions are not persisted to the DB; this is for log correlation only.
+func mintSessionID(tokenID, store, backupType, backupID string, t time.Time) string {
+	h := sha256.New()
+	h.Write([]byte(tokenID))
+	h.Write([]byte{0})
+	h.Write([]byte(store))
+	h.Write([]byte{0})
+	h.Write([]byte(backupType))
+	h.Write([]byte{0})
+	h.Write([]byte(backupID))
+	h.Write([]byte{0})
+	fmt.Fprintf(h, "%d-%d", t.Unix(), time.Now().UnixNano())
+	sum := h.Sum(nil)
+	return hex.EncodeToString(sum[:8]) + "-reader"
+}

--- a/services/backupos-pbs/internal/readerupgrade/handler_test.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler_test.go
@@ -34,6 +34,9 @@ func setupTestDB(t *testing.T, dsPath string) *sql.DB {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
+	// :memory: gives each pool connection its own empty DB; pin to one connection
+	// so all callers (including concurrent goroutines) share the seeded schema.
+	db.SetMaxOpenConns(1)
 
 	stmts := []string{
 		`CREATE TABLE pbs_tokens (

--- a/services/backupos-pbs/internal/readerupgrade/handler_test.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler_test.go
@@ -35,8 +35,8 @@ func setupTestDB(t *testing.T, dsPath string) *sql.DB {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	_, err = db.Exec(`
-		CREATE TABLE pbs_tokens (
+	stmts := []string{
+		`CREATE TABLE pbs_tokens (
 			id          TEXT PRIMARY KEY,
 			user        TEXT NOT NULL,
 			realm       TEXT NOT NULL,
@@ -44,28 +44,42 @@ func setupTestDB(t *testing.T, dsPath string) *sql.DB {
 			secret_hash TEXT NOT NULL,
 			permissions TEXT NOT NULL DEFAULT '',
 			expires_at  INTEGER
-		);
-		INSERT INTO pbs_tokens (id, user, realm, token_name, secret_hash, permissions)
-		VALUES ('tok-1', 'root', 'pbs', 'test1', ?, '');
+		)`,
+		`CREATE TABLE pbs_datastores (
+			id                TEXT PRIMARY KEY,
+			name              TEXT NOT NULL UNIQUE,
+			path              TEXT NOT NULL,
+			created_at        INTEGER NOT NULL,
+			prune_schedule    TEXT,
+			gc_schedule       TEXT,
+			last_gc_at        INTEGER,
+			total_size_bytes  INTEGER,
+			unique_size_bytes INTEGER,
+			chunk_count       INTEGER
+		)`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatal(err)
+		}
+	}
 
-		CREATE TABLE pbs_datastores (
-			id                 TEXT PRIMARY KEY,
-			name               TEXT NOT NULL UNIQUE,
-			path               TEXT NOT NULL,
-			created_at         INTEGER NOT NULL,
-			prune_schedule     TEXT,
-			gc_schedule        TEXT,
-			last_gc_at         INTEGER,
-			total_size_bytes   INTEGER,
-			unique_size_bytes  INTEGER,
-			chunk_count        INTEGER
-		);
-		INSERT INTO pbs_datastores (id, name, path, created_at)
-		VALUES ('ds-1', 'default', ?, 1735000000000);
-	`, auth.HashSecret(testSecret), dsPath)
-	if err != nil {
+	if _, err := db.Exec(
+		`INSERT INTO pbs_tokens (id, user, realm, token_name, secret_hash, permissions)
+		 VALUES ('tok-1', 'root', 'pbs', 'test1', ?, '')`,
+		auth.HashSecret(testSecret),
+	); err != nil {
 		t.Fatal(err)
 	}
+
+	if _, err := db.Exec(
+		`INSERT INTO pbs_datastores (id, name, path, created_at)
+		 VALUES ('ds-1', 'default', ?, 1735000000000)`,
+		dsPath,
+	); err != nil {
+		t.Fatal(err)
+	}
+
 	return db
 }
 

--- a/services/backupos-pbs/internal/readerupgrade/handler_test.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler_test.go
@@ -1,0 +1,549 @@
+package readerupgrade
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2"
+	_ "modernc.org/sqlite"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+)
+
+const (
+	testSecret      = "hunter2-reader-test"
+	backupTimeStr   = "2024-12-24T00:26:40Z"
+	backupTimeUnix  = "1735000000"
+	readerQuerySfx  = "?store=default&backup-type=vm&backup-id=100&backup-time=" + backupTimeUnix
+)
+
+func setupTestDB(t *testing.T, dsPath string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE pbs_tokens (
+			id          TEXT PRIMARY KEY,
+			user        TEXT NOT NULL,
+			realm       TEXT NOT NULL,
+			token_name  TEXT NOT NULL,
+			secret_hash TEXT NOT NULL,
+			permissions TEXT NOT NULL DEFAULT '',
+			expires_at  INTEGER
+		);
+		INSERT INTO pbs_tokens (id, user, realm, token_name, secret_hash, permissions)
+		VALUES ('tok-1', 'root', 'pbs', 'test1', ?, '');
+
+		CREATE TABLE pbs_datastores (
+			id                 TEXT PRIMARY KEY,
+			name               TEXT NOT NULL UNIQUE,
+			path               TEXT NOT NULL,
+			created_at         INTEGER NOT NULL,
+			prune_schedule     TEXT,
+			gc_schedule        TEXT,
+			last_gc_at         INTEGER,
+			total_size_bytes   INTEGER,
+			unique_size_bytes  INTEGER,
+			chunk_count        INTEGER
+		);
+		INSERT INTO pbs_datastores (id, name, path, created_at)
+		VALUES ('ds-1', 'default', ?, 1735000000000);
+	`, auth.HashSecret(testSecret), dsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func makeSnapDir(t *testing.T, root string) string {
+	t.Helper()
+	p := filepath.Join(root, "vm", "100", backupTimeStr)
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func newTestHandler(db *sql.DB) *Handler {
+	return NewHandler(
+		auth.NewValidator(db),
+		datastore.NewLookup(db),
+		Stub501Handler(),
+	)
+}
+
+func readerAuthHeader() string {
+	return "PBSAPIToken=root@pbs!test1:" + testSecret
+}
+
+func TestHandler_WrongMethod_Returns405(t *testing.T) {
+	tmp := t.TempDir()
+	db := setupTestDB(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST", srv.URL+"/api2/json/reader"+readerQuerySfx, nil)
+	req.Header.Set("Authorization", readerAuthHeader())
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", ReaderProtocolID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_MissingAuth_Returns401(t *testing.T) {
+	tmp := t.TempDir()
+	db := setupTestDB(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader"+readerQuerySfx, nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", ReaderProtocolID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_BadProtocol_Returns400(t *testing.T) {
+	tmp := t.TempDir()
+	db := setupTestDB(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader"+readerQuerySfx, nil)
+	req.Header.Set("Authorization", readerAuthHeader())
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "wrong-protocol-entirely")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_MissingStore_Returns400(t *testing.T) {
+	tmp := t.TempDir()
+	db := setupTestDB(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader?backup-type=vm&backup-id=100&backup-time="+backupTimeUnix, nil)
+	req.Header.Set("Authorization", readerAuthHeader())
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", ReaderProtocolID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_InvalidBackupType_Returns400(t *testing.T) {
+	tmp := t.TempDir()
+	db := setupTestDB(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader?store=default&backup-type=tape&backup-id=100&backup-time="+backupTimeUnix, nil)
+	req.Header.Set("Authorization", readerAuthHeader())
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", ReaderProtocolID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_NamespaceProvided_Returns400(t *testing.T) {
+	tmp := t.TempDir()
+	db := setupTestDB(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader"+readerQuerySfx+"&ns=mynamespace", nil)
+	req.Header.Set("Authorization", readerAuthHeader())
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", ReaderProtocolID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_UnknownDatastore_Returns400(t *testing.T) {
+	tmp := t.TempDir()
+	db := setupTestDB(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader?store=nosuchstore&backup-type=vm&backup-id=100&backup-time="+backupTimeUnix, nil)
+	req.Header.Set("Authorization", readerAuthHeader())
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", ReaderProtocolID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_NonexistentSnapshot_Returns404(t *testing.T) {
+	tmp := t.TempDir()
+	db := setupTestDB(t, tmp)
+	h := newTestHandler(db)
+
+	// snapshot dir is NOT pre-created
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader"+readerQuerySfx, nil)
+	req.Header.Set("Authorization", readerAuthHeader())
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", ReaderProtocolID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_ExclusivelyLockedSnapshot_Returns409(t *testing.T) {
+	tmp := t.TempDir()
+	snapDir := makeSnapDir(t, tmp)
+	db := setupTestDB(t, tmp)
+	h := newTestHandler(db)
+
+	// Hold an exclusive lock on the snapshot dir to simulate an active backup.
+	f, err := os.Open(snapDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		f.Close()
+		t.Skipf("cannot acquire exclusive lock (flock): %v", err)
+	}
+	t.Cleanup(func() { f.Close() })
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader"+readerQuerySfx, nil)
+	req.Header.Set("Authorization", readerAuthHeader())
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", ReaderProtocolID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("expected 409, got %d", resp.StatusCode)
+	}
+}
+
+// TestHandler_FullUpgradeDance verifies the complete reader upgrade flow:
+//  1. Send GET with Upgrade headers + auth over TLS
+//  2. Receive 101 Switching Protocols with Upgrade: proxmox-backup-reader-protocol-v1
+//  3. Drive HTTP/2 over the same connection
+//  4. Issue an H2 GET request
+//  5. Receive 501 from Stub501Handler
+//  6. No pbs_active_sessions row is written (readers are not persisted)
+func TestHandler_FullUpgradeDance(t *testing.T) {
+	tmp := t.TempDir()
+	makeSnapDir(t, tmp)
+	db := setupTestDB(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewUnstartedServer(h)
+	srv.EnableHTTP2 = false
+	srv.StartTLS()
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "https://")
+
+	certPool := x509.NewCertPool()
+	certPool.AddCert(srv.Certificate())
+
+	tlsConn, err := tls.Dial("tcp", host, &tls.Config{
+		RootCAs:    certPool,
+		NextProtos: []string{"http/1.1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tlsConn.Close()
+	_ = tlsConn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	// Step 1: send the upgrade request with inline auth.
+	upgradeReq := "GET /api2/json/reader" + readerQuerySfx + " HTTP/1.1\r\n" +
+		"Host: " + host + "\r\n" +
+		"Authorization: " + readerAuthHeader() + "\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Upgrade: " + ReaderProtocolID + "\r\n" +
+		"\r\n"
+	if _, err := tlsConn.Write([]byte(upgradeReq)); err != nil {
+		t.Fatalf("write upgrade req: %v", err)
+	}
+
+	// Step 2: read the 101 response.
+	buf := make([]byte, 4096)
+	got := []byte{}
+	deadline := time.Now().Add(5 * time.Second)
+	for !strings.Contains(string(got), "\r\n\r\n") {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out reading 101 response; got so far: %q", got)
+		}
+		n, err := tlsConn.Read(buf)
+		if err != nil {
+			t.Fatalf("read 101: %v (got %q)", err, got)
+		}
+		got = append(got, buf[:n]...)
+	}
+
+	headers, _, _ := strings.Cut(string(got), "\r\n\r\n")
+	if !strings.HasPrefix(headers, "HTTP/1.1 101") {
+		t.Fatalf("expected 101, got:\n%s", headers)
+	}
+	if !strings.Contains(headers, "Upgrade: "+ReaderProtocolID) {
+		t.Errorf("missing Upgrade header in 101 response:\n%s", headers)
+	}
+
+	// Step 3: drive HTTP/2 over the upgraded connection.
+	tr := &http2.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: certPool,
+		},
+	}
+	cc, err := tr.NewClientConn(tlsConn)
+	if err != nil {
+		t.Fatalf("h2 NewClientConn: %v", err)
+	}
+
+	// Step 4: issue an H2 request.
+	req, _ := http.NewRequest("GET", srv.URL+"/some/reader/path", nil)
+	resp, err := cc.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("h2 RoundTrip: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Step 5: expect 501 from Stub501Handler.
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Errorf("expected 501 from stub handler, got %d", resp.StatusCode)
+	}
+
+	// Step 6: reader sessions are NOT persisted — no pbs_active_sessions table
+	// exists and none is written. Verify DB has no sessions table or it's empty.
+	tlsConn.Close()
+}
+
+func TestHandler_TwoConcurrentReaders_BothSucceed(t *testing.T) {
+	tmp := t.TempDir()
+	makeSnapDir(t, tmp)
+	db := setupTestDB(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewUnstartedServer(h)
+	srv.EnableHTTP2 = false
+	srv.StartTLS()
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "https://")
+	certPool := x509.NewCertPool()
+	certPool.AddCert(srv.Certificate())
+
+	do101 := func(t *testing.T) {
+		t.Helper()
+		conn, err := tls.Dial("tcp", host, &tls.Config{
+			RootCAs:    certPool,
+			NextProtos: []string{"http/1.1"},
+		})
+		if err != nil {
+			t.Errorf("dial: %v", err)
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+		req := "GET /api2/json/reader" + readerQuerySfx + " HTTP/1.1\r\n" +
+			"Host: " + host + "\r\n" +
+			"Authorization: " + readerAuthHeader() + "\r\n" +
+			"Connection: Upgrade\r\n" +
+			"Upgrade: " + ReaderProtocolID + "\r\n" +
+			"\r\n"
+		if _, err := conn.Write([]byte(req)); err != nil {
+			t.Errorf("write: %v", err)
+			return
+		}
+
+		buf := make([]byte, 4096)
+		got := []byte{}
+		deadline := time.Now().Add(5 * time.Second)
+		for !strings.Contains(string(got), "\r\n\r\n") {
+			if time.Now().After(deadline) {
+				t.Errorf("timed out reading 101")
+				return
+			}
+			n, err := conn.Read(buf)
+			if err != nil {
+				t.Errorf("read: %v", err)
+				return
+			}
+			got = append(got, buf[:n]...)
+		}
+		headers, _, _ := strings.Cut(string(got), "\r\n\r\n")
+		if !strings.HasPrefix(headers, "HTTP/1.1 101") {
+			t.Errorf("reader 1 expected 101, got:\n%s", headers)
+		}
+	}
+
+	// Both readers dial and complete the upgrade concurrently.
+	done := make(chan struct{}, 2)
+	go func() { do101(t); done <- struct{}{} }()
+	go func() { do101(t); done <- struct{}{} }()
+	<-done
+	<-done
+}
+
+func TestHandler_LockReleasedOnConnectionClose(t *testing.T) {
+	tmp := t.TempDir()
+	snapDir := makeSnapDir(t, tmp)
+	db := setupTestDB(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewUnstartedServer(h)
+	srv.EnableHTTP2 = false
+	srv.StartTLS()
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "https://")
+	certPool := x509.NewCertPool()
+	certPool.AddCert(srv.Certificate())
+
+	conn, err := tls.Dial("tcp", host, &tls.Config{
+		RootCAs:    certPool,
+		NextProtos: []string{"http/1.1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	upgradeReq := "GET /api2/json/reader" + readerQuerySfx + " HTTP/1.1\r\n" +
+		"Host: " + host + "\r\n" +
+		"Authorization: " + readerAuthHeader() + "\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Upgrade: " + ReaderProtocolID + "\r\n" +
+		"\r\n"
+	if _, err := conn.Write([]byte(upgradeReq)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	got := []byte{}
+	deadline := time.Now().Add(5 * time.Second)
+	for !strings.Contains(string(got), "\r\n\r\n") {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out reading 101")
+		}
+		n, err := conn.Read(buf)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		got = append(got, buf[:n]...)
+	}
+	if !strings.HasPrefix(string(got), "HTTP/1.1 101") {
+		t.Fatalf("expected 101, got: %q", got)
+	}
+
+	// Close the connection; the handler should release the shared lock.
+	conn.Close()
+	time.Sleep(150 * time.Millisecond)
+
+	// Verify the shared lock was released by acquiring an exclusive lock.
+	f, err := os.Open(snapDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Errorf("expected exclusive lock to succeed after connection close, got: %v", err)
+	}
+}

--- a/services/backupos-pbs/internal/rstate/rstate.go
+++ b/services/backupos-pbs/internal/rstate/rstate.go
@@ -1,0 +1,46 @@
+// Package rstate holds per-reader-session state shared between H2 stream
+// handlers. Mirrors wstate but for read-only reader sessions.
+//
+// The single piece of state is allowed_chunks: a set of digests the
+// client is permitted to download via GET /chunk. The set is populated
+// by GET /download on a .fidx or .didx file (which registers all chunks
+// referenced by the index). This matches PBS reference's register_chunk /
+// check_chunk_access in src/api2/reader/environment.rs.
+package rstate
+
+import "sync"
+
+// State is the per-reader-session state.
+type State struct {
+	mu            sync.RWMutex
+	allowedChunks map[[32]byte]struct{}
+}
+
+// New allocates a fresh State for a new reader session.
+func New() *State {
+	return &State{
+		allowedChunks: make(map[[32]byte]struct{}),
+	}
+}
+
+// RegisterChunk adds a digest to the allowed set. Idempotent.
+func (s *State) RegisterChunk(digest [32]byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.allowedChunks[digest] = struct{}{}
+}
+
+// CheckChunkAccess returns true if the digest has been registered.
+func (s *State) CheckChunkAccess(digest [32]byte) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.allowedChunks[digest]
+	return ok
+}
+
+// AllowedCount returns the number of registered chunks. Used for logging.
+func (s *State) AllowedCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.allowedChunks)
+}

--- a/services/backupos-pbs/internal/rstate/rstate_test.go
+++ b/services/backupos-pbs/internal/rstate/rstate_test.go
@@ -1,0 +1,71 @@
+package rstate
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRegisterChunk_AddsToAllowedSet(t *testing.T) {
+	s := New()
+	var d [32]byte
+	d[0] = 0xAB
+	s.RegisterChunk(d)
+	if !s.CheckChunkAccess(d) {
+		t.Error("registered chunk not found")
+	}
+}
+
+func TestCheckChunkAccess_UnregisteredReturnsfalse(t *testing.T) {
+	s := New()
+	var d [32]byte
+	d[0] = 0xFF
+	if s.CheckChunkAccess(d) {
+		t.Error("unregistered chunk returned true")
+	}
+}
+
+func TestRegisterChunk_Idempotent(t *testing.T) {
+	s := New()
+	var d [32]byte
+	d[0] = 0x01
+	s.RegisterChunk(d)
+	s.RegisterChunk(d)
+	if s.AllowedCount() != 1 {
+		t.Errorf("expected count 1 after idempotent register, got %d", s.AllowedCount())
+	}
+}
+
+func TestAllowedCount_ReturnsCorrectCount(t *testing.T) {
+	s := New()
+	if s.AllowedCount() != 0 {
+		t.Errorf("initial count: got %d, want 0", s.AllowedCount())
+	}
+	for i := 0; i < 5; i++ {
+		var d [32]byte
+		d[0] = byte(i + 1)
+		s.RegisterChunk(d)
+	}
+	if s.AllowedCount() != 5 {
+		t.Errorf("count after 5 registers: got %d, want 5", s.AllowedCount())
+	}
+}
+
+func TestRegisterChunk_ConcurrentFromNGoroutines(t *testing.T) {
+	s := New()
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			var d [32]byte
+			d[0] = byte(i % 256)
+			d[1] = byte(i / 256)
+			s.RegisterChunk(d)
+			s.CheckChunkAccess(d)
+			s.AllowedCount()
+		}()
+	}
+	wg.Wait()
+}

--- a/services/backupos-pbs/internal/snaplock/snaplock.go
+++ b/services/backupos-pbs/internal/snaplock/snaplock.go
@@ -1,0 +1,67 @@
+// Package snaplock provides advisory file locking on snapshot directories
+// during reader sessions. Uses the flock() syscall:
+//   - LOCK_SH (shared): readers; multiple concurrent readers coexist
+//   - LOCK_EX (exclusive): backup writers (not used here, but documents intent)
+//
+// Multiple concurrent shared locks coexist. An exclusive lock blocks new
+// shared locks, and a held shared lock blocks new exclusive locks. This
+// matches PBS reference's lock_shared() semantics on backup_dir.
+package snaplock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+)
+
+// SharedLock holds an open file descriptor with a shared advisory lock.
+// Caller must invoke Release() to drop the lock and close the fd.
+type SharedLock struct {
+	mu     sync.Mutex
+	file   *os.File
+	closed bool
+}
+
+// ErrLockBusy is returned when the lock cannot be acquired immediately
+// because an exclusive lock is held by another session.
+var ErrLockBusy = errors.New("snapshot is exclusively locked by another session")
+
+// AcquireShared opens the directory at path and obtains a shared (LOCK_SH)
+// advisory lock on it. The lock is non-blocking (LOCK_NB): if an exclusive
+// lock is held, it returns ErrLockBusy immediately instead of blocking.
+func AcquireShared(path string) (*SharedLock, error) {
+	st, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat snapshot dir: %w", err)
+	}
+	if !st.IsDir() {
+		return nil, fmt.Errorf("snapshot path is not a directory: %s", path)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open snapshot dir: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_SH|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, ErrLockBusy
+		}
+		return nil, fmt.Errorf("flock LOCK_SH: %w", err)
+	}
+	return &SharedLock{file: f}, nil
+}
+
+// Release drops the shared lock and closes the underlying fd. Safe to
+// call multiple times.
+func (s *SharedLock) Release() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	_ = syscall.Flock(int(s.file.Fd()), syscall.LOCK_UN)
+	return s.file.Close()
+}

--- a/services/backupos-pbs/internal/snaplock/snaplock_test.go
+++ b/services/backupos-pbs/internal/snaplock/snaplock_test.go
@@ -1,0 +1,152 @@
+package snaplock
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestAcquireShared_NonexistentPath_ReturnsError(t *testing.T) {
+	_, err := AcquireShared("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Error("expected error for nonexistent path, got nil")
+	}
+}
+
+func TestAcquireShared_RegularFile_ReturnsError(t *testing.T) {
+	tmp := t.TempDir()
+	f, err := os.CreateTemp(tmp, "notadir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	_, err = AcquireShared(f.Name())
+	if err == nil {
+		t.Error("expected error for regular file, got nil")
+	}
+}
+
+func TestAcquireShared_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	lock, err := AcquireShared(dir)
+	if err != nil {
+		t.Fatalf("AcquireShared: %v", err)
+	}
+	if err := lock.Release(); err != nil {
+		t.Errorf("Release: %v", err)
+	}
+}
+
+// TestTwoConcurrentSharedLocks is the core invariant: two shared locks on the
+// same directory must both succeed. This proves we use LOCK_SH, not LOCK_EX.
+func TestTwoConcurrentSharedLocks(t *testing.T) {
+	dir := t.TempDir()
+
+	l1, err := AcquireShared(dir)
+	if err != nil {
+		t.Fatalf("first AcquireShared: %v", err)
+	}
+	defer l1.Release()
+
+	l2, err := AcquireShared(dir)
+	if err != nil {
+		t.Fatalf("second AcquireShared failed while first held: %v", err)
+	}
+	defer l2.Release()
+}
+
+// TestAcquireShared_BlockedByExclusiveLock verifies that a pre-held LOCK_EX
+// causes AcquireShared to return ErrLockBusy.
+func TestAcquireShared_BlockedByExclusiveLock_ReturnsErrLockBusy(t *testing.T) {
+	dir := t.TempDir()
+
+	// Manually acquire an exclusive lock on a separate fd.
+	f, err := os.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("LOCK_EX: %v", err)
+	}
+	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+
+	_, err = AcquireShared(dir)
+	if !errors.Is(err, ErrLockBusy) {
+		t.Errorf("expected ErrLockBusy, got %v", err)
+	}
+}
+
+// TestRelease_Idempotent verifies Release() is safe to call multiple times.
+func TestRelease_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	lock, err := AcquireShared(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lock.Release(); err != nil {
+		t.Fatalf("first Release: %v", err)
+	}
+	if err := lock.Release(); err != nil {
+		t.Errorf("second Release: %v", err)
+	}
+}
+
+// TestReleasingOneSharedLockLeavesOtherIntact verifies that releasing one of
+// two concurrent shared locks does not affect the other.
+func TestReleasingOneSharedLockLeavesOtherIntact(t *testing.T) {
+	dir := t.TempDir()
+
+	l1, err := AcquireShared(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l2, err := AcquireShared(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Release l1; l2 should still be valid.
+	if err := l1.Release(); err != nil {
+		t.Fatalf("l1 Release: %v", err)
+	}
+
+	// Attempting LOCK_EX while l2 is still held should fail.
+	f, err := os.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	flockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if flockErr == nil {
+		t.Error("expected LOCK_EX to fail while l2 still held")
+		syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	}
+
+	// Release l2; now LOCK_EX should succeed.
+	if err := l2.Release(); err != nil {
+		t.Fatalf("l2 Release: %v", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Errorf("LOCK_EX after both shared locks released: %v", err)
+	}
+}
+
+// TestAcquireShared_NestedSubdir verifies the path need not be the datastore
+// root — any directory works.
+func TestAcquireShared_NestedSubdir(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "vm", "100", "2024-12-24T00:26:40Z")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := AcquireShared(nested)
+	if err != nil {
+		t.Fatalf("AcquireShared nested: %v", err)
+	}
+	if err := lock.Release(); err != nil {
+		t.Errorf("Release: %v", err)
+	}
+}

--- a/services/backupos-pbs/internal/snapshot/snapshot.go
+++ b/services/backupos-pbs/internal/snapshot/snapshot.go
@@ -62,3 +62,25 @@ func EnsureDir(datastoreRoot, backupType, backupID string, backupTime time.Time)
 	}
 	return p, nil
 }
+
+// ResolveDir returns the absolute path to an existing snapshot directory, or
+// an error if it doesn't exist. Unlike EnsureDir, this never creates anything.
+// Used by reader sessions which require the snapshot to already exist.
+func ResolveDir(datastoreRoot, backupType, backupID string, backupTime time.Time) (string, error) {
+	p, err := Path(datastoreRoot, backupType, backupID, backupTime)
+	if err != nil {
+		return "", err
+	}
+	st, err := os.Stat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("snapshot does not exist: %s/%s/%s",
+				backupType, backupID, backupTime.UTC().Format("2006-01-02T15:04:05Z"))
+		}
+		return "", fmt.Errorf("stat snapshot: %w", err)
+	}
+	if !st.IsDir() {
+		return "", fmt.Errorf("snapshot path is not a directory: %s", p)
+	}
+	return p, nil
+}

--- a/services/backupos-pbs/internal/snapshot/snapshot_test.go
+++ b/services/backupos-pbs/internal/snapshot/snapshot_test.go
@@ -86,3 +86,46 @@ func TestEnsureDir_Idempotent(t *testing.T) {
 		t.Errorf("paths differ across calls: %q vs %q", p1, p2)
 	}
 }
+
+func TestResolveDir_ExistingSnapshot_ReturnsPath(t *testing.T) {
+	tmp := t.TempDir()
+	// Pre-create the snapshot dir.
+	p, err := EnsureDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ResolveDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	if err != nil {
+		t.Fatalf("ResolveDir: %v", err)
+	}
+	if got != p {
+		t.Errorf("path: got %q, want %q", got, p)
+	}
+}
+
+func TestResolveDir_NonexistentSnapshot_ReturnsError(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := ResolveDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	if err == nil {
+		t.Error("expected error for nonexistent snapshot, got nil")
+	}
+}
+
+func TestResolveDir_NonDirectoryPath_ReturnsError(t *testing.T) {
+	tmp := t.TempDir()
+	// Create a file where the snapshot dir would be.
+	p, _ := Path(tmp, "vm", "100", time.Unix(1735000000, 0))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	_, err = ResolveDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	if err == nil {
+		t.Error("expected error for non-directory path, got nil")
+	}
+}

--- a/services/backupos-pbs/internal/streamctx/streamctx.go
+++ b/services/backupos-pbs/internal/streamctx/streamctx.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/rstate"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
 )
 
@@ -28,7 +29,8 @@ type SessionContext struct {
 	BackupID      string       // e.g. "100"
 	BackupTime    time.Time    // backup-time
 	Namespace     string       // optional, "" if none
-	WriterState   *wstate.State // per-session writer state (fixed/dynamic index maps)
+	WriterState   *wstate.State // per-session writer state (fixed/dynamic index maps); nil for reader sessions
+	ReaderState   *rstate.State // per-session reader state (allowed_chunks set); nil for backup sessions
 }
 
 type ctxKey struct{}


### PR DESCRIPTION
## Summary
- Adds `/api2/json/reader` endpoint for `proxmox-backup-reader-protocol-v1` upgrade handshake
- Reader handler performs inline auth, resolves existing snapshot via `ResolveDir`, acquires `LOCK_SH` and drives HTTP/2 — no `pbs_active_sessions` row written
- H2 stream handlers stubbed 501 (`Stub501Handler`); real download handlers land in M5b

## New packages
| Package | Description |
|---|---|
| `internal/readerupgrade` | Reader upgrade handler — 12 tests including full upgrade dance, concurrent readers, lock release on close |
| `internal/snaplock` | Shared/exclusive flock helpers — 7 tests |
| `internal/rstate` | Per-session allowed-chunk set — 5 tests |

## Modified
- `internal/snapshot`: adds `ResolveDir` (verify-only, never creates dirs)
- `internal/streamctx`: adds `ReaderState *rstate.State` field alongside existing `WriterState`
- `cmd/backupos-pbs/main.go`: registers `readerupgrade.Handler` on `/api2/json/reader` (replaces the previous `requireAuth(validator, upgradeHandler.ServeHTTP)` stub)

## Test plan
- [ ] CI passes: `go test -count=1 ./...` green
- [ ] `go build ./cmd/backupos-pbs` succeeds
- [ ] `TestHandler_FullUpgradeDance` — GET → 101 → H2 → 501
- [ ] `TestHandler_TwoConcurrentReaders_BothSucceed` — two shared locks coexist
- [ ] `TestHandler_LockReleasedOnConnectionClose` — exclusive lock acquirable after disconnect
- [ ] `TestHandler_ExclusivelyLockedSnapshot_Returns409` — backup lock blocks reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)