### PR TITLE
feat(pbs): reader-protocol GET /download + GET /chunk — M5b-go-reader-endpoints

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -43,7 +43,9 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedchunk"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedclose"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedindex"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/download"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/handlers"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/readchunk"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/readerupgrade"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/upgrade"
@@ -119,7 +121,12 @@ func main() {
 		RepoID:  repoIDString,
 	})
 
-	readerHandler := readerupgrade.NewHandler(validator, datastoreLookup, readerupgrade.Stub501Handler())
+	readerHandler := readerupgrade.NewHandler(
+		validator,
+		datastoreLookup,
+		download.NewHandler(),
+		readchunk.NewHandler(),
+	)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api2/json/version", versionHandler.ServeHTTP)

--- a/services/backupos-pbs/internal/download/download.go
+++ b/services/backupos-pbs/internal/download/download.go
@@ -1,0 +1,164 @@
+// Package download implements GET /download for the reader protocol.
+//
+// Wire format (matches PBS reference src/api2/reader/mod.rs:download_file):
+//
+//	GET /download?file-name=<archive-name>
+//	→
+//	Content-Type: application/octet-stream
+//	Content-Length: <file size>
+//	<raw file contents>
+//
+// For .fidx and .didx files, the handler ALSO parses the index body and
+// registers every chunk digest in the session's allowed_chunks set,
+// gating subsequent GET /chunk requests.
+package download
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/indexread"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+const maxFileNameLen = 64
+
+// Handler serves GET /download requests.
+type Handler struct{}
+
+// NewHandler constructs a download Handler.
+func NewHandler() *Handler { return &Handler{} }
+
+// ServeHTTP handles GET /download?file-name=<name>.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil || sc.ReaderState == nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	fileName := r.URL.Query().Get("file-name")
+	if fileName == "" {
+		writeJSONError(w, http.StatusBadRequest, `missing required parameter "file-name"`)
+		return
+	}
+	if !validFileName(fileName) {
+		writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("invalid file-name: %q", fileName))
+		return
+	}
+
+	snapDir := filepath.Join(
+		sc.DatastoreRoot,
+		sc.BackupType,
+		sc.BackupID,
+		sc.BackupTime.UTC().Format("2006-01-02T15:04:05Z"),
+	)
+	filePath := filepath.Join(snapDir, fileName)
+
+	// Defense-in-depth: reject any path that escapes the snapshot directory,
+	// even if validFileName somehow passed a crafted name.
+	if !strings.HasPrefix(filepath.Clean(filePath), filepath.Clean(snapDir)+string(filepath.Separator)) {
+		writeJSONError(w, http.StatusBadRequest, "file-name escapes snapshot directory")
+		return
+	}
+
+	st, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeJSONError(w, http.StatusNotFound, fmt.Sprintf("file not found: %s", fileName))
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, "stat failed")
+		return
+	}
+	if !st.Mode().IsRegular() {
+		writeJSONError(w, http.StatusBadRequest, "not a regular file")
+		return
+	}
+
+	// For index files: register all chunk digests BEFORE streaming.
+	registered := 0
+	if strings.HasSuffix(fileName, ".fidx") || strings.HasSuffix(fileName, ".didx") {
+		digests, err := indexread.EnumerateDigests(filePath)
+		if err != nil {
+			slog.Warn("download: index parse failed",
+				"session_id", sc.SessionID,
+				"file_name", fileName,
+				"error", err,
+			)
+			writeJSONError(w, http.StatusInternalServerError, "index parse failed")
+			return
+		}
+		for _, d := range digests {
+			sc.ReaderState.RegisterChunk(d)
+		}
+		registered = len(digests)
+	}
+
+	// Open separately from the parse step so we don't hold two fds at once.
+	f, err := os.Open(filePath)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "open failed")
+		return
+	}
+	defer f.Close()
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", st.Size()))
+	w.WriteHeader(http.StatusOK)
+
+	n, err := io.Copy(w, f)
+	if err != nil {
+		slog.Warn("download: stream failed",
+			"session_id", sc.SessionID,
+			"file_name", fileName,
+			"bytes_sent", n,
+			"error", err,
+		)
+		return
+	}
+
+	slog.Info("download served",
+		"session_id", sc.SessionID,
+		"file_name", fileName,
+		"size", st.Size(),
+		"chunks_registered", registered,
+	)
+}
+
+// validFileName accepts only safe characters — no slashes, no dots sequences,
+// no control chars. File-name must be non-empty and ≤ maxFileNameLen.
+func validFileName(name string) bool {
+	if len(name) == 0 || len(name) > maxFileNameLen {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '.' || r == '-' || r == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/download/download_test.go
+++ b/services/backupos-pbs/internal/download/download_test.go
@@ -88,7 +88,7 @@ func TestHandler_InvalidFileName_Returns400(t *testing.T) {
 	srv := httptest.NewServer(withSession(NewHandler(), sc))
 	defer srv.Close()
 
-	cases := []string{"../escape", "with/slash", "with space", "a\x00b"}
+	cases := []string{"../escape", "with/slash", "with space", "has@symbol"}
 	for _, name := range cases {
 		t.Run(name, func(t *testing.T) {
 			resp, err := http.Get(srv.URL + "/download?file-name=" + name)

--- a/services/backupos-pbs/internal/download/download_test.go
+++ b/services/backupos-pbs/internal/download/download_test.go
@@ -1,0 +1,334 @@
+package download
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/didx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fidx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/rstate"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+var testBackupTime = time.Unix(1735000000, 0).UTC()
+
+func makeSessionCtx(t *testing.T, datastoreRoot string) *streamctx.SessionContext {
+	t.Helper()
+	return &streamctx.SessionContext{
+		SessionID:     "test-session",
+		DatastoreID:   "ds-1",
+		DatastoreRoot: datastoreRoot,
+		BackupType:    "vm",
+		BackupID:      "100",
+		BackupTime:    testBackupTime,
+		ReaderState:   rstate.New(),
+	}
+}
+
+func makeSnapDir(t *testing.T, root string) string {
+	t.Helper()
+	ts := testBackupTime.UTC().Format("2006-01-02T15:04:05Z")
+	p := filepath.Join(root, "vm", "100", ts)
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func withSession(h http.Handler, sc *streamctx.SessionContext) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sc)))
+	})
+}
+
+func TestHandler_WrongMethod_Returns405(t *testing.T) {
+	tmp := t.TempDir()
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST", srv.URL+"/download?file-name=backup.blob", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_MissingFileName_Returns400(t *testing.T) {
+	tmp := t.TempDir()
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/download")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_InvalidFileName_Returns400(t *testing.T) {
+	tmp := t.TempDir()
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	cases := []string{"../escape", "with/slash", "with space", "a\x00b"}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			resp, err := http.Get(srv.URL + "/download?file-name=" + name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("expected 400 for %q, got %d", name, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestHandler_PathEscape_Returns400(t *testing.T) {
+	// Even if a name passes validFileName, the prefix check should catch escapes.
+	// We test this by constructing a request manually with a raw query.
+	tmp := t.TempDir()
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	// "..%2F..%2Fetc%2Fpasswd" URL-decodes to "../../etc/passwd"
+	resp, err := http.Get(srv.URL + "/download?file-name=..%2F..%2Fetc%2Fpasswd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for path-escape file-name, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_NonexistentFile_Returns404(t *testing.T) {
+	tmp := t.TempDir()
+	makeSnapDir(t, tmp)
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/download?file-name=nosuchfile.blob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_BlobFile_StreamsRawBytes(t *testing.T) {
+	tmp := t.TempDir()
+	snapDir := makeSnapDir(t, tmp)
+	want := []byte("hello blob content")
+	blobPath := filepath.Join(snapDir, "backup.blob")
+	if err := os.WriteFile(blobPath, want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/download?file-name=backup.blob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/octet-stream" {
+		t.Errorf("expected Content-Type application/octet-stream, got %q", ct)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("body mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestHandler_FidxFile_RegistersChunks_AndStreamsRawBytes(t *testing.T) {
+	tmp := t.TempDir()
+	snapDir := makeSnapDir(t, tmp)
+	idxPath := filepath.Join(snapDir, "drive-0.img.fidx")
+	const chunkSize = 4096
+
+	digests := [][32]byte{
+		{0: 0x11},
+		{0: 0x22},
+		{0: 0x33},
+	}
+	w, err := fidx.Create(idxPath, chunkSize*3, chunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, d := range digests {
+		offset := uint64((i + 1) * chunkSize)
+		if err := w.AddChunk(offset, chunkSize, d); err != nil {
+			t.Fatalf("AddChunk: %v", err)
+		}
+	}
+	if _, err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rawFile, err := os.ReadFile(idxPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/download?file-name=drive-0.img.fidx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, rawFile) {
+		t.Error("response body does not match raw .fidx file bytes")
+	}
+
+	// Verify all digests were registered in the session.
+	for _, d := range digests {
+		if !sc.ReaderState.CheckChunkAccess(d) {
+			t.Errorf("digest %x not registered after /download", d)
+		}
+	}
+}
+
+func TestHandler_DidxFile_RegistersChunks_AndStreamsRawBytes(t *testing.T) {
+	tmp := t.TempDir()
+	snapDir := makeSnapDir(t, tmp)
+	idxPath := filepath.Join(snapDir, "archive.pxar.didx")
+
+	digests := [][32]byte{
+		{0: 0xAA},
+		{0: 0xBB},
+	}
+	dw, err := didx.Create(idxPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	offsets := []uint64{1024, 2048}
+	for i, d := range digests {
+		if err := dw.AddChunk(offsets[i], d); err != nil {
+			t.Fatalf("AddChunk: %v", err)
+		}
+	}
+	if _, err := dw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rawFile, err := os.ReadFile(idxPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/download?file-name=archive.pxar.didx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, rawFile) {
+		t.Error("response body does not match raw .didx file bytes")
+	}
+
+	for _, d := range digests {
+		if !sc.ReaderState.CheckChunkAccess(d) {
+			t.Errorf("digest %x not registered after /download", d)
+		}
+	}
+}
+
+func TestHandler_NoStreamCtx_Returns500(t *testing.T) {
+	// Handler called without session context injected.
+	srv := httptest.NewServer(NewHandler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/download?file-name=backup.blob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_NotARegularFile_Returns400(t *testing.T) {
+	tmp := t.TempDir()
+	snapDir := makeSnapDir(t, tmp)
+
+	// Create a directory where a file is expected.
+	dirPath := filepath.Join(snapDir, "notafile.blob")
+	if err := os.Mkdir(dirPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/download?file-name=notafile.blob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}

--- a/services/backupos-pbs/internal/indexread/indexread.go
+++ b/services/backupos-pbs/internal/indexread/indexread.go
@@ -1,0 +1,127 @@
+// Package indexread provides minimal readers for PBS .fidx and .didx files.
+//
+// Unlike the writers in internal/fidx and internal/didx, these readers
+// only need to enumerate chunk digests for chunk-access registration.
+// They do NOT decode the full index semantics (chunk offsets, ranges,
+// file sizes, etc.) — that's the client's job during restore.
+//
+// Header layout is identical to what the writers produce; see
+// internal/fidx/fidx.go and internal/didx/didx.go for the full format.
+package indexread
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	headerSize    = 4096
+	fidxEntrySize = 32
+	didxEntrySize = 40
+)
+
+// MagicFidx is the fixed-index magic from PBS file_formats.rs.
+var MagicFidx = [8]byte{47, 127, 65, 237, 145, 253, 15, 205}
+
+// MagicDidx is the dynamic-index magic from PBS file_formats.rs.
+var MagicDidx = [8]byte{28, 145, 78, 165, 25, 186, 179, 205}
+
+// IndexType identifies which kind of index a file is.
+type IndexType int
+
+const (
+	IndexUnknown IndexType = iota
+	IndexFixed
+	IndexDynamic
+)
+
+// DetectType opens the file, reads the magic bytes, and returns the type.
+// Returns IndexUnknown (nil error) for any unrecognized magic.
+func DetectType(path string) (IndexType, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return IndexUnknown, err
+	}
+	defer f.Close()
+
+	var magic [8]byte
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
+		return IndexUnknown, fmt.Errorf("read magic: %w", err)
+	}
+	switch magic {
+	case MagicFidx:
+		return IndexFixed, nil
+	case MagicDidx:
+		return IndexDynamic, nil
+	}
+	return IndexUnknown, nil
+}
+
+// EnumerateDigests reads every chunk digest from the index file. The file
+// is opened, parsed, and closed inside this function — it does NOT consume
+// an open file handle the caller may need to stream back.
+func EnumerateDigests(path string) ([][32]byte, error) {
+	t, err := DetectType(path)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	st, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	fileSize := st.Size()
+	if fileSize < headerSize {
+		return nil, fmt.Errorf("index file too short: %d bytes", fileSize)
+	}
+
+	bodyLen := fileSize - headerSize
+
+	switch t {
+	case IndexFixed:
+		if bodyLen%fidxEntrySize != 0 {
+			return nil, fmt.Errorf("fidx body not aligned: %d bytes", bodyLen)
+		}
+		count := bodyLen / fidxEntrySize
+		if _, err := f.Seek(headerSize, io.SeekStart); err != nil {
+			return nil, err
+		}
+		digests := make([][32]byte, count)
+		for i := int64(0); i < count; i++ {
+			if _, err := io.ReadFull(f, digests[i][:]); err != nil {
+				return nil, fmt.Errorf("read fidx digest %d: %w", i, err)
+			}
+		}
+		return digests, nil
+
+	case IndexDynamic:
+		if bodyLen%didxEntrySize != 0 {
+			return nil, fmt.Errorf("didx body not aligned: %d bytes", bodyLen)
+		}
+		count := bodyLen / didxEntrySize
+		if _, err := f.Seek(headerSize, io.SeekStart); err != nil {
+			return nil, err
+		}
+		digests := make([][32]byte, count)
+		var entry [didxEntrySize]byte
+		for i := int64(0); i < count; i++ {
+			if _, err := io.ReadFull(f, entry[:]); err != nil {
+				return nil, fmt.Errorf("read didx entry %d: %w", i, err)
+			}
+			// entry layout: end_le[0:8] || digest[8:40]
+			copy(digests[i][:], entry[8:40])
+		}
+		return digests, nil
+
+	default:
+		return nil, errors.New("not an index file")
+	}
+}

--- a/services/backupos-pbs/internal/indexread/indexread_test.go
+++ b/services/backupos-pbs/internal/indexread/indexread_test.go
@@ -1,0 +1,189 @@
+package indexread
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/didx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fidx"
+)
+
+func writeMagic(t *testing.T, dir string, magic [8]byte) string {
+	t.Helper()
+	p := filepath.Join(dir, "test.idx")
+	if err := os.WriteFile(p, magic[:], 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestDetectType_Fidx(t *testing.T) {
+	tmp := t.TempDir()
+	p := writeMagic(t, tmp, MagicFidx)
+	got, err := DetectType(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != IndexFixed {
+		t.Errorf("expected IndexFixed, got %v", got)
+	}
+}
+
+func TestDetectType_Didx(t *testing.T) {
+	tmp := t.TempDir()
+	p := writeMagic(t, tmp, MagicDidx)
+	got, err := DetectType(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != IndexDynamic {
+		t.Errorf("expected IndexDynamic, got %v", got)
+	}
+}
+
+func TestDetectType_Unknown(t *testing.T) {
+	tmp := t.TempDir()
+	p := writeMagic(t, tmp, [8]byte{0xDE, 0xAD, 0xBE, 0xEF, 0, 0, 0, 0})
+	got, err := DetectType(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != IndexUnknown {
+		t.Errorf("expected IndexUnknown, got %v", got)
+	}
+}
+
+func TestDetectType_FileTooShort(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "short.idx")
+	if err := os.WriteFile(p, []byte{0x01, 0x02}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := DetectType(p)
+	if err == nil {
+		t.Error("expected error for file too short to read magic, got nil")
+	}
+}
+
+func TestEnumerateDigests_FidxRoundtrip(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "test.fidx")
+	const chunkSize = 4096
+	const numChunks = 3
+
+	w, err := fidx.Create(path, chunkSize*numChunks, chunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := [][32]byte{
+		{0: 0x11, 1: 0x22},
+		{0: 0x33, 1: 0x44},
+		{0: 0x55, 1: 0x66},
+	}
+	for i, d := range want {
+		offset := uint64((i + 1) * chunkSize)
+		if err := w.AddChunk(offset, chunkSize, d); err != nil {
+			t.Fatalf("AddChunk %d: %v", i, err)
+		}
+	}
+	if _, err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := EnumerateDigests(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d digests, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("digest[%d]: got %x, want %x", i, got[i], want[i])
+		}
+	}
+}
+
+func TestEnumerateDigests_DidxRoundtrip(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "test.didx")
+
+	w, err := didx.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := [][32]byte{
+		{0: 0xAA, 1: 0xBB},
+		{0: 0xCC, 1: 0xDD},
+	}
+	offsets := []uint64{1024, 2048}
+	for i, d := range want {
+		if err := w.AddChunk(offsets[i], d); err != nil {
+			t.Fatalf("AddChunk %d: %v", i, err)
+		}
+	}
+	if _, err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := EnumerateDigests(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d digests, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("digest[%d]: got %x, want %x", i, got[i], want[i])
+		}
+	}
+}
+
+func TestEnumerateDigests_BadAlignment_Fidx(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "bad.fidx")
+	// header (4096) + 31 bytes — not divisible by 32
+	data := make([]byte, headerSize+31)
+	copy(data, MagicFidx[:])
+	if err := os.WriteFile(p, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := EnumerateDigests(p)
+	if err == nil {
+		t.Error("expected error for bad fidx body alignment, got nil")
+	}
+}
+
+func TestEnumerateDigests_BadAlignment_Didx(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "bad.didx")
+	// header (4096) + 39 bytes — not divisible by 40
+	data := make([]byte, headerSize+39)
+	copy(data, MagicDidx[:])
+	if err := os.WriteFile(p, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := EnumerateDigests(p)
+	if err == nil {
+		t.Error("expected error for bad didx body alignment, got nil")
+	}
+}
+
+func TestEnumerateDigests_NotAnIndex(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "blob.blob")
+	data := make([]byte, headerSize+32)
+	data[0] = 0xDE
+	data[1] = 0xAD
+	if err := os.WriteFile(p, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := EnumerateDigests(p)
+	if err == nil {
+		t.Error("expected error for non-index file, got nil")
+	}
+}

--- a/services/backupos-pbs/internal/readchunk/readchunk.go
+++ b/services/backupos-pbs/internal/readchunk/readchunk.go
@@ -1,0 +1,119 @@
+// Package readchunk implements GET /chunk for the reader protocol.
+//
+// Wire format (matches PBS reference src/api2/reader/mod.rs:download_chunk):
+//
+//	GET /chunk?digest=<64 hex chars>
+//	→
+//	200 application/octet-stream <chunk DataBlob bytes>   if digest is allowed
+//	401 if digest not in session's allowed_chunks set
+//	404 if chunk file is missing on disk
+package readchunk
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+// Handler serves GET /chunk requests.
+type Handler struct{}
+
+// NewHandler constructs a readchunk Handler.
+func NewHandler() *Handler { return &Handler{} }
+
+// ServeHTTP handles GET /chunk?digest=<hex>.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil || sc.ReaderState == nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	digestHex := r.URL.Query().Get("digest")
+	if len(digestHex) != 64 {
+		writeJSONError(w, http.StatusBadRequest, `"digest" must be 64 hex characters`)
+		return
+	}
+	digestBytes, err := hex.DecodeString(digestHex)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "digest is not valid hex")
+		return
+	}
+	var digest [32]byte
+	copy(digest[:], digestBytes)
+
+	// Auth check first — matches PBS reference check_chunk_access ordering.
+	if !sc.ReaderState.CheckChunkAccess(digest) {
+		slog.Info("chunk download denied",
+			"session_id", sc.SessionID,
+			"digest", digestHex,
+		)
+		writeJSONError(w, http.StatusUnauthorized,
+			fmt.Sprintf("download chunk %s not allowed", digestHex))
+		return
+	}
+
+	// Chunk path: <datastore_root>/.chunks/<first4hex>/<fullhex>
+	chunkPath := filepath.Join(sc.DatastoreRoot, ".chunks", digestHex[:4], digestHex)
+
+	st, err := os.Stat(chunkPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeJSONError(w, http.StatusNotFound, "chunk not found on disk")
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, "stat failed")
+		return
+	}
+	if !st.Mode().IsRegular() {
+		writeJSONError(w, http.StatusInternalServerError, "chunk path is not a regular file")
+		return
+	}
+
+	f, err := os.Open(chunkPath)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "open failed")
+		return
+	}
+	defer f.Close()
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", st.Size()))
+	w.WriteHeader(http.StatusOK)
+
+	n, err := io.Copy(w, f)
+	if err != nil {
+		slog.Warn("chunk stream failed",
+			"session_id", sc.SessionID,
+			"digest", digestHex,
+			"bytes_sent", n,
+			"error", err,
+		)
+		return
+	}
+
+	slog.Info("chunk served",
+		"session_id", sc.SessionID,
+		"digest", digestHex,
+		"size", st.Size(),
+	)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/readchunk/readchunk_test.go
+++ b/services/backupos-pbs/internal/readchunk/readchunk_test.go
@@ -1,0 +1,219 @@
+package readchunk
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/rstate"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+var testBackupTime = time.Unix(1735000000, 0).UTC()
+
+func makeSessionCtx(t *testing.T, datastoreRoot string) *streamctx.SessionContext {
+	t.Helper()
+	return &streamctx.SessionContext{
+		SessionID:     "test-session",
+		DatastoreID:   "ds-1",
+		DatastoreRoot: datastoreRoot,
+		BackupType:    "vm",
+		BackupID:      "100",
+		BackupTime:    testBackupTime,
+		ReaderState:   rstate.New(),
+	}
+}
+
+func withSession(h http.Handler, sc *streamctx.SessionContext) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sc)))
+	})
+}
+
+// writeChunk creates the chunk file at <root>/.chunks/<first4>/<hex> with the given content.
+func writeChunk(t *testing.T, root string, digest [32]byte, content []byte) {
+	t.Helper()
+	digestHex := hex.EncodeToString(digest[:])
+	dir := filepath.Join(root, ".chunks", digestHex[:4])
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, digestHex), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHandler_WrongMethod_Returns405(t *testing.T) {
+	tmp := t.TempDir()
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST", srv.URL+"/chunk?digest="+strings.Repeat("a", 64), nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_MissingDigest_Returns400(t *testing.T) {
+	tmp := t.TempDir()
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/chunk")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_BadHex_Returns400(t *testing.T) {
+	tmp := t.TempDir()
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	// 64 chars but not valid hex
+	resp, err := http.Get(srv.URL + "/chunk?digest=" + strings.Repeat("z", 64))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_WrongDigestLength_Returns400(t *testing.T) {
+	tmp := t.TempDir()
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	for _, length := range []int{63, 65} {
+		resp, err := http.Get(srv.URL + "/chunk?digest=" + strings.Repeat("a", length))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected 400 for digest length %d, got %d", length, resp.StatusCode)
+		}
+	}
+}
+
+func TestHandler_DigestNotAllowed_Returns401(t *testing.T) {
+	tmp := t.TempDir()
+	sc := makeSessionCtx(t, tmp)
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	digestHex := strings.Repeat("ab", 32) // valid 64-char hex, not registered
+	resp, err := http.Get(srv.URL + "/chunk?digest=" + digestHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "not allowed") {
+		t.Errorf("expected 'not allowed' in body, got: %s", body)
+	}
+}
+
+func TestHandler_AllowedDigest_StreamsBytes(t *testing.T) {
+	tmp := t.TempDir()
+	sc := makeSessionCtx(t, tmp)
+
+	var digest [32]byte
+	digest[0] = 0xDE
+	digest[1] = 0xAD
+	want := []byte("chunk data blob bytes")
+	writeChunk(t, tmp, digest, want)
+	sc.ReaderState.RegisterChunk(digest)
+
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	digestHex := hex.EncodeToString(digest[:])
+	resp, err := http.Get(srv.URL + "/chunk?digest=" + digestHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/octet-stream" {
+		t.Errorf("expected Content-Type application/octet-stream, got %q", ct)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("body mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestHandler_AllowedButMissingOnDisk_Returns404(t *testing.T) {
+	tmp := t.TempDir()
+	sc := makeSessionCtx(t, tmp)
+
+	var digest [32]byte
+	digest[0] = 0xFF
+	// Register but don't write the chunk file.
+	sc.ReaderState.RegisterChunk(digest)
+
+	srv := httptest.NewServer(withSession(NewHandler(), sc))
+	defer srv.Close()
+
+	digestHex := hex.EncodeToString(digest[:])
+	resp, err := http.Get(srv.URL + "/chunk?digest=" + digestHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_NoStreamCtx_Returns500(t *testing.T) {
+	srv := httptest.NewServer(NewHandler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/chunk?digest=" + strings.Repeat("a", 64))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}

--- a/services/backupos-pbs/internal/readerupgrade/handler.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler.go
@@ -6,7 +6,6 @@
 //   - Snapshot must already exist (snapshot.ResolveDir, not EnsureDir)
 //   - Acquires shared lock (LOCK_SH) — multiple concurrent readers coexist
 //   - Reader sessions are NOT persisted to pbs_active_sessions
-//   - H2 stream routes stubbed at 501 in M5a; real handlers land in M5b
 //
 // Auth is performed inline (not via requireAuth middleware), so this handler
 // must be registered on the mux directly, not wrapped.
@@ -44,32 +43,27 @@ const (
 
 // Handler handles a PBS reader-protocol upgrade request.
 type Handler struct {
-	validator  *auth.Validator
-	datastores *datastore.Lookup
-	streamH2   http.Handler // 501-stub in M5a; real router in M5b
+	validator       *auth.Validator
+	datastores      *datastore.Lookup
+	downloadHandler http.Handler
+	chunkHandler    http.Handler
 }
 
 // NewHandler constructs a reader upgrade Handler.
 // validator is used for inline auth (no requireAuth middleware needed).
-// streamH2 is the H2 handler after the upgrade (use Stub501Handler() for M5a).
-func NewHandler(validator *auth.Validator, datastores *datastore.Lookup, streamH2 http.Handler) *Handler {
+// downloadHandler serves GET /download; chunkHandler serves GET /chunk.
+func NewHandler(
+	validator *auth.Validator,
+	datastores *datastore.Lookup,
+	downloadHandler http.Handler,
+	chunkHandler http.Handler,
+) *Handler {
 	return &Handler{
-		validator:  validator,
-		datastores: datastores,
-		streamH2:   streamH2,
+		validator:       validator,
+		datastores:      datastores,
+		downloadHandler: downloadHandler,
+		chunkHandler:    chunkHandler,
 	}
-}
-
-// Stub501Handler returns a handler that responds 501 to every H2 stream.
-// Used as the streamH2 handler in M5a; replaced by a real router in M5b.
-func Stub501Handler() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotImplemented)
-		_ = json.NewEncoder(w).Encode(map[string]string{
-			"error": "reader download endpoints not yet implemented (M5b)",
-		})
-	})
 }
 
 // ServeHTTP handles the reader upgrade request.
@@ -230,15 +224,30 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ReaderState:   rs,
 	}
 
-	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		h.streamH2.ServeHTTP(w, r.WithContext(streamctx.WithSession(r.Context(), sc)))
+	router := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := streamctx.WithSession(r.Context(), sc)
+		r = r.WithContext(ctx)
+		switch r.URL.Path {
+		case "/download":
+			h.downloadHandler.ServeHTTP(w, r)
+		case "/chunk":
+			h.chunkHandler.ServeHTTP(w, r)
+		case "/speedtest":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "speedtest not implemented in V1"})
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+		}
 	})
 
 	h2srv := &http2.Server{
 		MaxReadFrameSize: h2MaxFrameSize,
 	}
 	h2srv.ServeConn(conn, &http2.ServeConnOpts{
-		Handler: wrapped,
+		Handler: router,
 	})
 
 	// Connection closed. Release the shared lock.

--- a/services/backupos-pbs/internal/readerupgrade/handler_test.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler_test.go
@@ -96,10 +96,14 @@ func makeSnapDir(t *testing.T, root string) string {
 }
 
 func newTestHandler(db *sql.DB) *Handler {
+	stub := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+	})
 	return NewHandler(
 		auth.NewValidator(db),
 		datastore.NewLookup(db),
-		Stub501Handler(),
+		stub,
+		stub,
 	)
 }
 

--- a/services/backupos-pbs/internal/readerupgrade/handler_test.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler_test.go
@@ -343,8 +343,8 @@ func TestHandler_ExclusivelyLockedSnapshot_Returns409(t *testing.T) {
 //  1. Send GET with Upgrade headers + auth over TLS
 //  2. Receive 101 Switching Protocols with Upgrade: proxmox-backup-reader-protocol-v1
 //  3. Drive HTTP/2 over the same connection
-//  4. Issue an H2 GET request
-//  5. Receive 501 from Stub501Handler
+//  4. Issue an H2 GET to an unknown path
+//  5. Receive 404 from the router (no matching route)
 //  6. No pbs_active_sessions row is written (readers are not persisted)
 func TestHandler_FullUpgradeDance(t *testing.T) {
 	tmp := t.TempDir()
@@ -425,9 +425,9 @@ func TestHandler_FullUpgradeDance(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	// Step 5: expect 501 from Stub501Handler.
-	if resp.StatusCode != http.StatusNotImplemented {
-		t.Errorf("expected 501 from stub handler, got %d", resp.StatusCode)
+	// Step 5: expect 404 — unknown route, real router has no match.
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 from router (unknown route), got %d", resp.StatusCode)
 	}
 
 	// Step 6: reader sessions are NOT persisted — no pbs_active_sessions table


### PR DESCRIPTION
## Summary
- Replaces M5a `Stub501Handler` with real implementations of `GET /download` and `GET /chunk`
- After this PR, a PVE client can perform a complete restore: handshake → download index → register chunks → download chunks → reassemble
- Wire format verified against `src/api2/reader/mod.rs` from git.proxmox.com

## New packages
| Package | Description |
|---|---|
| `internal/indexread` | Minimal `.fidx` / `.didx` digest enumerators (8 tests, roundtrip for both formats) |
| `internal/download` | `GET /download` — streams raw file bytes; registers chunk digests for `.fidx`/`.didx` before streaming (10 tests) |
| `internal/readchunk` | `GET /chunk` — 401 if digest not in `allowed_chunks`, 404 if missing on disk (8 tests) |

## Modified
- `internal/readerupgrade/handler.go`: replace `Stub501Handler` with real H2 router (`/download` → downloadHandler, `/chunk` → chunkHandler, `/speedtest` → 501); `NewHandler` grows by 2 args; `Stub501Handler` symbol removed
- `cmd/backupos-pbs/main.go`: wire `download.NewHandler()` + `readchunk.NewHandler()`
- `internal/readerupgrade/handler_test.go`: update `newTestHandler` for new 4-arg signature

## Key design decisions
- `GET /download` registers ALL chunk digests BEFORE streaming the index body (matches PBS reference ordering)
- `GET /chunk` returns **401** (not 403/404) for unregistered digests — matches PBS `UNAUTHORIZED` response
- `io.Copy` for streaming — no full-file buffering; chunks can be 4+ MiB
- File-name validation + path-escape prefix check in download handler

## Test plan
- [ ] CI passes: `go test -count=1 ./...` green
- [ ] `TestEnumerateDigests_FidxRoundtrip` and `_DidxRoundtrip` pass (byte-exact digest matching)
- [ ] `TestHandler_FidxFile_RegistersChunks_AndStreamsRawBytes` — body matches raw file, all digests registered
- [ ] `TestHandler_DigestNotAllowed_Returns401` — message contains "not allowed"
- [ ] Existing readerupgrade tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)