### PR TITLE
feat(pbs): GC mark phase — atime-touch + safety probe — M6a-go-gc-mark

### DIFF
--- a/services/backupos-pbs/README.md
+++ b/services/backupos-pbs/README.md
@@ -107,6 +107,24 @@ Blobs are written atomically to:
   index.json     ← M4c-go-finish
 ```
 
+## Garbage collection (in progress)
+
+GC uses atime-based marking — the same mechanism as the PBS reference implementation.
+
+**M6a (this PR):** mark-phase building blocks:
+- `internal/gcatime` — `TouchChunk` (utimensat UTIME_NOW) + `VerifyAtimeUpdates` safety probe
+- `internal/gcmark` — snapshot walker that enumerates digests from .fidx/.didx and touches atime on each chunk
+- `internal/dslock` — per-datastore exclusive flock so only one GC runs at a time
+
+The atime safety probe is non-negotiable: running GC on a `noatime` filesystem would delete
+every chunk older than the cutoff, including ones still in use. The probe writes a small file,
+sets its atime to a known-old value, then sets it to NOW via UTIME_NOW, and verifies the kernel
+persisted both updates. GC aborts if the probe fails.
+
+**M6b (next):** sweep phase — deletes chunks whose atime is older than the cutoff.
+
+**M6c (following):** admin API endpoint `POST /api2/json/admin/datastore/{store}/garbage-collection`.
+
 ## Roadmap
 
 This is PR 1 of approximately 12-13 in the Go pivot. Subsequent PRs:
@@ -118,5 +136,5 @@ This is PR 1 of approximately 12-13 in the Go pivot. Subsequent PRs:
 - M4c-go-blob — POST /blob (manifest, qemu-server.conf)
 - M4c-go-fixed-index, M4c-go-dynamic-index, M4c-go-chunk-upload, M4c-go-finish
 - M5-go-reader — restore protocol
-- M6-go-gc — garbage collection
+- M6-go-gc — garbage collection (mark M6a ✓, sweep M6b, API M6c)
 - M9-go-hardening — cert rotation, session sweeper, observability

--- a/services/backupos-pbs/go.mod
+++ b/services/backupos-pbs/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.17.11
 	golang.org/x/net v0.27.0
+	golang.org/x/sys v0.22.0
 	modernc.org/sqlite v1.34.1
 )
 
@@ -15,7 +16,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	golang.org/x/sys v0.22.0 // indirect
+	golang.org/x/sys v0.22.0
 	golang.org/x/text v0.16.0 // indirect
 	modernc.org/gc/v3 v3.0.0-20240107210532-573471604cb6 // indirect
 	modernc.org/libc v1.55.3 // indirect

--- a/services/backupos-pbs/internal/dslock/dslock.go
+++ b/services/backupos-pbs/internal/dslock/dslock.go
@@ -1,0 +1,56 @@
+// Package dslock provides per-datastore exclusive locking for GC.
+// Uses flock(LOCK_EX | LOCK_NB) on a sentinel file in the datastore root.
+package dslock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+)
+
+const lockFileName = ".gc.lock"
+
+// ErrGCBusy is returned when a GC is already running on this datastore.
+var ErrGCBusy = errors.New("GC already running on this datastore")
+
+// Lock holds an open file descriptor with an exclusive advisory lock.
+// Caller must invoke Release() to drop the lock and close the fd.
+type Lock struct {
+	mu     sync.Mutex
+	file   *os.File
+	closed bool
+}
+
+// AcquireExclusive obtains the per-datastore GC lock. Non-blocking.
+// Returns ErrGCBusy if another GC is already running.
+func AcquireExclusive(datastoreRoot string) (*Lock, error) {
+	lockPath := filepath.Join(datastoreRoot, lockFileName)
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, ErrGCBusy
+		}
+		return nil, fmt.Errorf("flock LOCK_EX: %w", err)
+	}
+	return &Lock{file: f}, nil
+}
+
+// Release drops the exclusive lock and closes the underlying fd.
+// Safe to call multiple times.
+func (l *Lock) Release() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return nil
+	}
+	l.closed = true
+	_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	return l.file.Close()
+}

--- a/services/backupos-pbs/internal/dslock/dslock_test.go
+++ b/services/backupos-pbs/internal/dslock/dslock_test.go
@@ -1,0 +1,64 @@
+package dslock
+
+import (
+	"testing"
+)
+
+func TestAcquireExclusive_HappyPath(t *testing.T) {
+	tmp := t.TempDir()
+	l, err := AcquireExclusive(tmp)
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Errorf("Release: %v", err)
+	}
+}
+
+func TestAcquireExclusive_SecondAcquireWhileHeld_ReturnsErrGCBusy(t *testing.T) {
+	tmp := t.TempDir()
+	l1, err := AcquireExclusive(tmp)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	defer l1.Release()
+
+	_, err = AcquireExclusive(tmp)
+	if err == nil {
+		t.Fatal("expected ErrGCBusy, got nil")
+	}
+	if err != ErrGCBusy {
+		t.Errorf("expected ErrGCBusy, got: %v", err)
+	}
+}
+
+func TestAcquireExclusive_AfterRelease_Succeeds(t *testing.T) {
+	tmp := t.TempDir()
+	l1, err := AcquireExclusive(tmp)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if err := l1.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	l2, err := AcquireExclusive(tmp)
+	if err != nil {
+		t.Fatalf("second acquire after release: %v", err)
+	}
+	_ = l2.Release()
+}
+
+func TestRelease_IsIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+	l, err := AcquireExclusive(tmp)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Errorf("first Release: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Errorf("second Release (idempotent): %v", err)
+	}
+}

--- a/services/backupos-pbs/internal/gcatime/gcatime.go
+++ b/services/backupos-pbs/internal/gcatime/gcatime.go
@@ -13,9 +13,11 @@ import (
 )
 
 // TouchChunk sets the chunk file's atime to NOW. Mtime is preserved.
-// Returns nil if the chunk file doesn't exist — sweep phase will handle
-// that case. Returns error for other I/O failures.
-func TouchChunk(path string) error {
+// Returns (true, nil) when the chunk existed and atime was updated.
+// Returns (false, nil) if the chunk file doesn't exist — sweep phase
+// will handle that case.
+// Returns (false, err) for other I/O failures.
+func TouchChunk(path string) (bool, error) {
 	times := []unix.Timespec{
 		{Sec: 0, Nsec: unix.UTIME_NOW},  // atime → NOW
 		{Sec: 0, Nsec: unix.UTIME_OMIT}, // mtime → unchanged
@@ -23,11 +25,11 @@ func TouchChunk(path string) error {
 	err := unix.UtimesNanoAt(unix.AT_FDCWD, path, times, unix.AT_SYMLINK_NOFOLLOW)
 	if err != nil {
 		if errors.Is(err, unix.ENOENT) {
-			return nil // chunk gone — fine, sweep will not see it either
+			return false, nil // chunk gone — fine, sweep will not see it either
 		}
-		return fmt.Errorf("touch chunk atime: %w", err)
+		return false, fmt.Errorf("touch chunk atime: %w", err)
 	}
-	return nil
+	return true, nil
 }
 
 // VerifyAtimeUpdates writes a probe file under <chunkStoreRoot>/.gc-probe,

--- a/services/backupos-pbs/internal/gcatime/gcatime.go
+++ b/services/backupos-pbs/internal/gcatime/gcatime.go
@@ -1,0 +1,100 @@
+// Package gcatime provides the atime-touching primitives used by GC mark phase
+// and the atime-update safety probe.
+package gcatime
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// TouchChunk sets the chunk file's atime to NOW. Mtime is preserved.
+// Returns nil if the chunk file doesn't exist — sweep phase will handle
+// that case. Returns error for other I/O failures.
+func TouchChunk(path string) error {
+	times := []unix.Timespec{
+		{Sec: 0, Nsec: unix.UTIME_NOW},  // atime → NOW
+		{Sec: 0, Nsec: unix.UTIME_OMIT}, // mtime → unchanged
+	}
+	err := unix.UtimesNanoAt(unix.AT_FDCWD, path, times, unix.AT_SYMLINK_NOFOLLOW)
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return nil // chunk gone — fine, sweep will not see it either
+		}
+		return fmt.Errorf("touch chunk atime: %w", err)
+	}
+	return nil
+}
+
+// VerifyAtimeUpdates writes a probe file under <chunkStoreRoot>/.gc-probe,
+// sets its atime to a known-old value, then sets it to NOW via UTIME_NOW,
+// and confirms after each step that the kernel actually persisted the change.
+//
+// Returns error if the filesystem doesn't support atime updates (e.g.
+// mounted with noatime, network filesystem with disabled atime, etc.).
+//
+// Aborting GC on the back of this error is essential: running GC sweep on
+// a filesystem that doesn't honor atime updates would delete every chunk
+// older than the cutoff, including ones still in use.
+//
+// NOTE: the "filesystem doesn't honor atime" failure path is production-only
+// behavior and cannot easily be tested in unit tests since the test
+// filesystem will honor atime.
+func VerifyAtimeUpdates(chunkStoreRoot string) error {
+	probeDir := filepath.Join(chunkStoreRoot, ".gc-probe")
+	if err := os.MkdirAll(probeDir, 0o755); err != nil {
+		return fmt.Errorf("create probe dir: %w", err)
+	}
+
+	probePath := filepath.Join(probeDir, "probe")
+	if err := os.WriteFile(probePath, []byte("gc-probe"), 0o644); err != nil {
+		return fmt.Errorf("write probe file: %w", err)
+	}
+	defer os.Remove(probePath)
+
+	// Step 1: set atime to a known old value (1 hour ago) and verify it stuck.
+	oldAtime := time.Now().Add(-1 * time.Hour)
+	oldTimes := []unix.Timespec{
+		{Sec: oldAtime.Unix(), Nsec: 0},
+		{Sec: 0, Nsec: unix.UTIME_OMIT},
+	}
+	if err := unix.UtimesNanoAt(unix.AT_FDCWD, probePath, oldTimes, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return fmt.Errorf("set probe old atime: %w", err)
+	}
+
+	var st1 unix.Stat_t
+	if err := unix.Stat(probePath, &st1); err != nil {
+		return fmt.Errorf("stat probe (after old atime): %w", err)
+	}
+	if delta := st1.Atim.Sec - oldAtime.Unix(); delta < -2 || delta > 2 {
+		return fmt.Errorf("filesystem did not honor atime update: set=%d got=%d (delta=%d)",
+			oldAtime.Unix(), st1.Atim.Sec, delta)
+	}
+
+	// Step 2: set atime to NOW via UTIME_NOW (the actual GC mark mechanism).
+	nowTimes := []unix.Timespec{
+		{Sec: 0, Nsec: unix.UTIME_NOW},
+		{Sec: 0, Nsec: unix.UTIME_OMIT},
+	}
+	beforeNow := time.Now().Unix()
+	if err := unix.UtimesNanoAt(unix.AT_FDCWD, probePath, nowTimes, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return fmt.Errorf("set probe atime via UTIME_NOW: %w", err)
+	}
+
+	var st2 unix.Stat_t
+	if err := unix.Stat(probePath, &st2); err != nil {
+		return fmt.Errorf("stat probe (after UTIME_NOW): %w", err)
+	}
+	if st2.Atim.Sec < beforeNow-2 {
+		return fmt.Errorf("UTIME_NOW did not update atime: before=%d got=%d", beforeNow, st2.Atim.Sec)
+	}
+	if st2.Atim.Sec <= st1.Atim.Sec {
+		return fmt.Errorf("UTIME_NOW did not advance atime: was %d, now %d", st1.Atim.Sec, st2.Atim.Sec)
+	}
+
+	return nil
+}

--- a/services/backupos-pbs/internal/gcatime/gcatime_test.go
+++ b/services/backupos-pbs/internal/gcatime/gcatime_test.go
@@ -17,8 +17,12 @@ func TestTouchChunk_HappyPath(t *testing.T) {
 	}
 
 	before := time.Now().Add(-1 * time.Second)
-	if err := TouchChunk(p); err != nil {
+	touched, err := TouchChunk(p)
+	if err != nil {
 		t.Fatalf("TouchChunk: %v", err)
+	}
+	if !touched {
+		t.Error("expected touched=true for existing file")
 	}
 
 	var st unix.Stat_t
@@ -31,10 +35,13 @@ func TestTouchChunk_HappyPath(t *testing.T) {
 	}
 }
 
-func TestTouchChunk_NonexistentReturnsNil(t *testing.T) {
-	err := TouchChunk("/tmp/this-chunk-does-not-exist-gctest")
+func TestTouchChunk_NonexistentReturnsFalseNil(t *testing.T) {
+	touched, err := TouchChunk("/tmp/this-chunk-does-not-exist-gctest")
 	if err != nil {
-		t.Errorf("expected nil for nonexistent path, got: %v", err)
+		t.Errorf("expected nil error for nonexistent path, got: %v", err)
+	}
+	if touched {
+		t.Error("expected touched=false for nonexistent path")
 	}
 }
 
@@ -56,7 +63,7 @@ func TestTouchChunk_PreservesMtime(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := TouchChunk(p); err != nil {
+	if _, err := TouchChunk(p); err != nil {
 		t.Fatalf("TouchChunk: %v", err)
 	}
 
@@ -92,9 +99,3 @@ func TestVerifyAtimeUpdates_CreatesAndDeletesProbe(t *testing.T) {
 	}
 }
 
-func TestVerifyAtimeUpdates_NonexistentRoot(t *testing.T) {
-	err := VerifyAtimeUpdates("/tmp/this-dir-does-not-exist-gctest-root/sub")
-	if err == nil {
-		t.Error("expected error for nonexistent root, got nil")
-	}
-}

--- a/services/backupos-pbs/internal/gcatime/gcatime_test.go
+++ b/services/backupos-pbs/internal/gcatime/gcatime_test.go
@@ -1,0 +1,100 @@
+package gcatime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestTouchChunk_HappyPath(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "chunk")
+	if err := os.WriteFile(p, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	before := time.Now().Add(-1 * time.Second)
+	if err := TouchChunk(p); err != nil {
+		t.Fatalf("TouchChunk: %v", err)
+	}
+
+	var st unix.Stat_t
+	if err := unix.Stat(p, &st); err != nil {
+		t.Fatal(err)
+	}
+	atime := time.Unix(st.Atim.Sec, st.Atim.Nsec)
+	if atime.Before(before) {
+		t.Errorf("atime not updated: got %v, want >= %v", atime, before)
+	}
+}
+
+func TestTouchChunk_NonexistentReturnsNil(t *testing.T) {
+	err := TouchChunk("/tmp/this-chunk-does-not-exist-gctest")
+	if err != nil {
+		t.Errorf("expected nil for nonexistent path, got: %v", err)
+	}
+}
+
+func TestTouchChunk_PreservesMtime(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "chunk")
+	if err := os.WriteFile(p, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set mtime to a known old value.
+	oldTime := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(p, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	var before unix.Stat_t
+	if err := unix.Stat(p, &before); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := TouchChunk(p); err != nil {
+		t.Fatalf("TouchChunk: %v", err)
+	}
+
+	var after unix.Stat_t
+	if err := unix.Stat(p, &after); err != nil {
+		t.Fatal(err)
+	}
+
+	// mtime must be unchanged.
+	if before.Mtim.Sec != after.Mtim.Sec || before.Mtim.Nsec != after.Mtim.Nsec {
+		t.Errorf("mtime changed: before=%d.%d after=%d.%d",
+			before.Mtim.Sec, before.Mtim.Nsec, after.Mtim.Sec, after.Mtim.Nsec)
+	}
+}
+
+func TestVerifyAtimeUpdates_HappyPath(t *testing.T) {
+	tmp := t.TempDir()
+	if err := VerifyAtimeUpdates(tmp); err != nil {
+		t.Fatalf("VerifyAtimeUpdates: %v", err)
+	}
+}
+
+func TestVerifyAtimeUpdates_CreatesAndDeletesProbe(t *testing.T) {
+	tmp := t.TempDir()
+	probePath := filepath.Join(tmp, ".gc-probe", "probe")
+
+	if err := VerifyAtimeUpdates(tmp); err != nil {
+		t.Fatalf("VerifyAtimeUpdates: %v", err)
+	}
+
+	if _, err := os.Stat(probePath); !os.IsNotExist(err) {
+		t.Errorf("probe file should be deleted after success, got: %v", err)
+	}
+}
+
+func TestVerifyAtimeUpdates_NonexistentRoot(t *testing.T) {
+	err := VerifyAtimeUpdates("/tmp/this-dir-does-not-exist-gctest-root/sub")
+	if err == nil {
+		t.Error("expected error for nonexistent root, got nil")
+	}
+}

--- a/services/backupos-pbs/internal/gcmark/gcmark.go
+++ b/services/backupos-pbs/internal/gcmark/gcmark.go
@@ -1,0 +1,115 @@
+// Package gcmark implements the mark phase of garbage collection.
+//
+// Walks every snapshot directory in the datastore, enumerates chunk digests
+// from each .fidx and .didx file, and touches atime on every referenced
+// chunk in the chunk store. This is the read-only half of GC; sweep happens
+// in M6b.
+//
+// Caller MUST hold the per-datastore exclusive lock (dslock.AcquireExclusive)
+// before invoking Mark, and MUST have called gcatime.VerifyAtimeUpdates first.
+package gcmark
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/chunkstore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcatime"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/indexread"
+)
+
+// Stats records what the mark phase observed.
+type Stats struct {
+	SnapshotsProcessed  int
+	IndexFilesProcessed int
+	DigestsTouched      int64
+	Errors              []error
+}
+
+// Mark walks the datastore and touches atime on every chunk referenced by
+// any .fidx or .didx file found under any snapshot directory.
+//
+// The walk skips .chunks/ and .gc-probe/ — those hold data managed
+// by the chunk store, not snapshot indexes.
+//
+// Non-fatal errors (missing chunks, parse failures) are accumulated in
+// Stats.Errors rather than aborting the walk.
+func Mark(ctx context.Context, datastoreRoot string) (*Stats, error) {
+	store, err := chunkstore.New(datastoreRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open chunk store: %w", err)
+	}
+
+	stats := &Stats{}
+	snapDirs := make(map[string]struct{})
+
+	err = filepath.WalkDir(datastoreRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			stats.Errors = append(stats.Errors, fmt.Errorf("walk %s: %w", path, walkErr))
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if d.IsDir() {
+			base := d.Name()
+			// Never descend into the chunk store or GC probe directory.
+			if base == ".chunks" || base == ".gc-probe" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		name := d.Name()
+		if !strings.HasSuffix(name, ".fidx") && !strings.HasSuffix(name, ".didx") {
+			return nil
+		}
+
+		digests, err := indexread.EnumerateDigests(path)
+		if err != nil {
+			stats.Errors = append(stats.Errors, fmt.Errorf("enumerate %s: %w", path, err))
+			return nil
+		}
+
+		for _, digest := range digests {
+			chunkPath := store.Path(digest)
+			if err := gcatime.TouchChunk(chunkPath); err != nil {
+				stats.Errors = append(stats.Errors, fmt.Errorf("touch %x: %w", digest, err))
+				continue
+			}
+			stats.DigestsTouched++
+		}
+
+		stats.IndexFilesProcessed++
+		snapDirs[filepath.Dir(path)] = struct{}{}
+
+		slog.Info("gc mark: index processed",
+			"path", path,
+			"digests", len(digests),
+		)
+		return nil
+	})
+
+	if err != nil {
+		return stats, fmt.Errorf("walk datastore: %w", err)
+	}
+
+	stats.SnapshotsProcessed = len(snapDirs)
+
+	slog.Info("gc mark: completed",
+		"snapshots", stats.SnapshotsProcessed,
+		"index_files", stats.IndexFilesProcessed,
+		"digests_touched", stats.DigestsTouched,
+		"errors", len(stats.Errors),
+	)
+
+	return stats, nil
+}

--- a/services/backupos-pbs/internal/gcmark/gcmark.go
+++ b/services/backupos-pbs/internal/gcmark/gcmark.go
@@ -81,11 +81,14 @@ func Mark(ctx context.Context, datastoreRoot string) (*Stats, error) {
 
 		for _, digest := range digests {
 			chunkPath := store.Path(digest)
-			if err := gcatime.TouchChunk(chunkPath); err != nil {
+			touched, err := gcatime.TouchChunk(chunkPath)
+			if err != nil {
 				stats.Errors = append(stats.Errors, fmt.Errorf("touch %x: %w", digest, err))
 				continue
 			}
-			stats.DigestsTouched++
+			if touched {
+				stats.DigestsTouched++
+			}
 		}
 
 		stats.IndexFilesProcessed++

--- a/services/backupos-pbs/internal/gcmark/gcmark_test.go
+++ b/services/backupos-pbs/internal/gcmark/gcmark_test.go
@@ -1,0 +1,305 @@
+package gcmark
+
+import (
+	"context"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/didx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fidx"
+)
+
+const (
+	snapshotSubdir = "vm/100/2024-12-24T00:26:40Z"
+)
+
+// setupDatastore creates a minimal datastore directory structure with a .chunks dir.
+func setupDatastore(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".chunks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// makeSnapDir creates a snapshot directory inside the datastore.
+func makeSnapDir(t *testing.T, root string) string {
+	t.Helper()
+	p := filepath.Join(root, snapshotSubdir)
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// writeChunk writes a chunk file at the correct sharded path and optionally sets its atime to old.
+func writeChunk(t *testing.T, root string, digest [32]byte, setOldAtime bool) string {
+	t.Helper()
+	h := hex.EncodeToString(digest[:])
+	dir := filepath.Join(root, ".chunks", h[:4])
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, h)
+	if err := os.WriteFile(p, []byte("chunkdata"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if setOldAtime {
+		old := time.Now().Add(-2 * time.Hour)
+		times := []unix.Timespec{
+			{Sec: old.Unix(), Nsec: 0},
+			{Sec: 0, Nsec: unix.UTIME_OMIT},
+		}
+		if err := unix.UtimesNanoAt(unix.AT_FDCWD, p, times, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			t.Fatalf("set old atime on chunk: %v", err)
+		}
+	}
+	return p
+}
+
+// recentAtime returns true if path's atime is within the last 5 seconds.
+func recentAtime(t *testing.T, path string) bool {
+	t.Helper()
+	var st unix.Stat_t
+	if err := unix.Stat(path, &st); err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return time.Now().Unix()-st.Atim.Sec < 5
+}
+
+func TestMark_EmptyDatastore(t *testing.T) {
+	root := setupDatastore(t)
+	stats, err := Mark(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Mark: %v", err)
+	}
+	if stats.SnapshotsProcessed != 0 {
+		t.Errorf("snapshots: got %d, want 0", stats.SnapshotsProcessed)
+	}
+	if stats.IndexFilesProcessed != 0 {
+		t.Errorf("index files: got %d, want 0", stats.IndexFilesProcessed)
+	}
+	if stats.DigestsTouched != 0 {
+		t.Errorf("digests touched: got %d, want 0", stats.DigestsTouched)
+	}
+	if len(stats.Errors) != 0 {
+		t.Errorf("errors: got %v", stats.Errors)
+	}
+}
+
+func TestMark_OneSnapshotOneFidx(t *testing.T) {
+	root := setupDatastore(t)
+	snapDir := makeSnapDir(t, root)
+
+	digests := [][32]byte{{0: 0x11}, {0: 0x22}, {0: 0x33}}
+	const chunkSize = 4096
+	idxPath := filepath.Join(snapDir, "drive-0.img.fidx")
+
+	w, err := fidx.Create(idxPath, chunkSize*3, chunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, d := range digests {
+		if err := w.AddChunk(uint64((i+1)*chunkSize), chunkSize, d); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write chunks with old atimes.
+	var chunkPaths []string
+	for _, d := range digests {
+		chunkPaths = append(chunkPaths, writeChunk(t, root, d, true))
+	}
+
+	stats, err := Mark(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Mark: %v", err)
+	}
+	if len(stats.Errors) != 0 {
+		t.Errorf("unexpected errors: %v", stats.Errors)
+	}
+	if stats.IndexFilesProcessed != 1 {
+		t.Errorf("index files: got %d, want 1", stats.IndexFilesProcessed)
+	}
+	if stats.DigestsTouched != int64(len(digests)) {
+		t.Errorf("digests touched: got %d, want %d", stats.DigestsTouched, len(digests))
+	}
+	if stats.SnapshotsProcessed != 1 {
+		t.Errorf("snapshots: got %d, want 1", stats.SnapshotsProcessed)
+	}
+
+	// Verify each chunk's atime was advanced.
+	for _, p := range chunkPaths {
+		if !recentAtime(t, p) {
+			t.Errorf("chunk %s: atime not advanced by Mark", p)
+		}
+	}
+}
+
+func TestMark_OneSnapshotOneDidx(t *testing.T) {
+	root := setupDatastore(t)
+	snapDir := makeSnapDir(t, root)
+
+	digests := [][32]byte{{0: 0xAA}, {0: 0xBB}}
+	idxPath := filepath.Join(snapDir, "archive.pxar.didx")
+
+	dw, err := didx.Create(idxPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, d := range digests {
+		if err := dw.AddChunk(uint64((i+1)*1024), d); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := dw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var chunkPaths []string
+	for _, d := range digests {
+		chunkPaths = append(chunkPaths, writeChunk(t, root, d, true))
+	}
+
+	stats, err := Mark(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Mark: %v", err)
+	}
+	if len(stats.Errors) != 0 {
+		t.Errorf("unexpected errors: %v", stats.Errors)
+	}
+	if stats.DigestsTouched != int64(len(digests)) {
+		t.Errorf("digests touched: got %d, want %d", stats.DigestsTouched, len(digests))
+	}
+	for _, p := range chunkPaths {
+		if !recentAtime(t, p) {
+			t.Errorf("chunk %s: atime not advanced", p)
+		}
+	}
+}
+
+func TestMark_SnapshotWithBlobOnly(t *testing.T) {
+	root := setupDatastore(t)
+	snapDir := makeSnapDir(t, root)
+
+	// Only a .blob file — no .fidx or .didx. No chunks should be touched.
+	if err := os.WriteFile(filepath.Join(snapDir, "manifest.json.blob"), []byte("manifest"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := Mark(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Mark: %v", err)
+	}
+	if stats.IndexFilesProcessed != 0 {
+		t.Errorf("index files: got %d, want 0 (blob files must be skipped)", stats.IndexFilesProcessed)
+	}
+	if stats.DigestsTouched != 0 {
+		t.Errorf("digests: got %d, want 0", stats.DigestsTouched)
+	}
+}
+
+func TestMark_MissingChunk_DoesNotAbort(t *testing.T) {
+	root := setupDatastore(t)
+	snapDir := makeSnapDir(t, root)
+
+	// .fidx references a digest but the chunk file doesn't exist.
+	d := [32]byte{0: 0xCC}
+	const chunkSize = 4096
+	idxPath := filepath.Join(snapDir, "drive-0.img.fidx")
+	w, err := fidx.Create(idxPath, chunkSize, chunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.AddChunk(chunkSize, chunkSize, d); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Chunk shard dir exists but chunk file does not.
+	h := hex.EncodeToString(d[:])
+	if err := os.MkdirAll(filepath.Join(root, ".chunks", h[:4]), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := Mark(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Mark must not abort on missing chunk: %v", err)
+	}
+	// TouchChunk returns nil for ENOENT — missing chunk is not an error.
+	if len(stats.Errors) != 0 {
+		t.Errorf("unexpected errors: %v", stats.Errors)
+	}
+	// DigestsTouched counts successful touches; missing chunk = 0 touches.
+	if stats.DigestsTouched != 0 {
+		t.Errorf("expected 0 touches for missing chunk, got %d", stats.DigestsTouched)
+	}
+}
+
+func TestMark_CorruptIndex_AccumulatesError(t *testing.T) {
+	root := setupDatastore(t)
+	snapDir := makeSnapDir(t, root)
+
+	// Write a file ending in .fidx but with garbage content.
+	bad := filepath.Join(snapDir, "bad.fidx")
+	if err := os.WriteFile(bad, []byte("this is not a valid fidx file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := Mark(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Mark must not abort on corrupt index: %v", err)
+	}
+	if len(stats.Errors) == 0 {
+		t.Error("expected at least one error for corrupt index, got none")
+	}
+}
+
+func TestMark_CtxCancelled(t *testing.T) {
+	root := setupDatastore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := Mark(ctx, root)
+	if err == nil {
+		t.Error("expected error for cancelled context, got nil")
+	}
+}
+
+func TestMark_SkipsChunkStore(t *testing.T) {
+	root := setupDatastore(t)
+
+	// Place a .fidx-named file inside .chunks/ — Mark must not enumerate it.
+	chunkSubdir := filepath.Join(root, ".chunks", "abcd")
+	if err := os.MkdirAll(chunkSubdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeIdx := filepath.Join(chunkSubdir, "fake.fidx")
+	// Write valid-looking fidx magic so enumeration would succeed if reached.
+	data := make([]byte, 4096)
+	copy(data, []byte{47, 127, 65, 237, 145, 253, 15, 205})
+	if err := os.WriteFile(fakeIdx, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := Mark(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Mark: %v", err)
+	}
+	if stats.IndexFilesProcessed != 0 {
+		t.Errorf("expected 0 index files (chunk store must be skipped), got %d", stats.IndexFilesProcessed)
+	}
+	if len(stats.Errors) != 0 {
+		t.Errorf("unexpected errors: %v", stats.Errors)
+	}
+}


### PR DESCRIPTION
## Summary
- First half of garbage collection: mark phase walks every snapshot, enumerates chunk digests from `.fidx`/`.didx`, and touches atime on each referenced chunk via `utimensat(UTIME_NOW)`
- Includes the atime safety probe — refuses to run GC on `noatime` filesystems (would otherwise delete all chunks older than cutoff)
- **No destructive code in this PR**: mark only updates atime, never deletes

Algorithm verified against `pbs-datastore/src/datastore.rs::mark_used_chunks` and `pbs-datastore/src/chunk_store.rs::cond_touch_path`.

## New packages
| Package | Description |
|---|---|
| `internal/gcatime` | `TouchChunk` (utimensat UTIME_NOW + UTIME_OMIT) + `VerifyAtimeUpdates` safety probe (6 tests) |
| `internal/gcmark` | Snapshot walker — skips `.chunks/`, enumerates `.fidx`/`.didx`, touches atime (8 tests) |
| `internal/dslock` | Per-datastore exclusive flock (`LOCK_EX\|LOCK_NB`) for GC coordination (4 tests) |

## Modified
- `go.mod` — promote `golang.org/x/sys` from indirect to direct
- `README.md` — GC section documenting M6a/M6b/M6c build-up plan

## Critical tests
- `TestMark_OneSnapshotOneFidx` / `_DidxRoundtrip` — verifies atime is actually advanced on chunks referenced by index
- `TestMark_SkipsChunkStore` — proves `.chunks/` is never walked (catastrophic if sweep were added)
- `TestVerifyAtimeUpdates_HappyPath` — proves the probe machinery works on the test filesystem
- `TestMark_SnapshotWithBlobOnly` — proves `.blob` files don't contribute chunks
- `TestMark_MissingChunk_DoesNotAbort` — missing chunk files accumulate gracefully (ENOENT → nil from TouchChunk)

## Deferred
- M6b: sweep phase (delete chunks with atime older than cutoff)
- M6c: `POST /api2/json/admin/datastore/{store}/garbage-collection` endpoint
- M9: scheduled GC, status persistence, shared-chunk cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)