### PR TITLE
feat(pbs): GC sweep phase + orchestration — milestone 6b

### DIFF
--- a/services/backupos-pbs/internal/chunkstore/atime_linux.go
+++ b/services/backupos-pbs/internal/chunkstore/atime_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package chunkstore
+
+import (
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func atimeFromFileInfo(path string, _ os.FileInfo) time.Time {
+	var st unix.Stat_t
+	if err := unix.Stat(path, &st); err != nil {
+		return time.Time{}
+	}
+	return time.Unix(st.Atim.Sec, st.Atim.Nsec)
+}
+
+// AtimeFromPath reads the access time of path from the filesystem.
+// Returns the zero time on error.
+func AtimeFromPath(path string) time.Time {
+	var st unix.Stat_t
+	if err := unix.Stat(path, &st); err != nil {
+		return time.Time{}
+	}
+	return time.Unix(st.Atim.Sec, st.Atim.Nsec)
+}

--- a/services/backupos-pbs/internal/chunkstore/atime_other.go
+++ b/services/backupos-pbs/internal/chunkstore/atime_other.go
@@ -1,0 +1,28 @@
+//go:build !linux
+
+package chunkstore
+
+import (
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func atimeFromFileInfo(path string, _ os.FileInfo) time.Time {
+	var st unix.Stat_t
+	if err := unix.Stat(path, &st); err != nil {
+		return time.Time{}
+	}
+	return time.Unix(st.Atimespec.Sec, st.Atimespec.Nsec)
+}
+
+// AtimeFromPath reads the access time of path from the filesystem.
+// Returns the zero time on error.
+func AtimeFromPath(path string) time.Time {
+	var st unix.Stat_t
+	if err := unix.Stat(path, &st); err != nil {
+		return time.Time{}
+	}
+	return time.Unix(st.Atimespec.Sec, st.Atimespec.Nsec)
+}

--- a/services/backupos-pbs/internal/chunkstore/chunkstore.go
+++ b/services/backupos-pbs/internal/chunkstore/chunkstore.go
@@ -10,6 +10,7 @@
 package chunkstore
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -135,4 +136,95 @@ func writeTempInDir(dir string, raw []byte) (string, error) {
 func touchAtime(path string) error {
 	now := time.Now()
 	return os.Chtimes(path, now, now)
+}
+
+// IterCallback is called by Iterate for each valid chunk file.
+// Returning a non-nil error stops the iteration and is returned by Iterate.
+type IterCallback func(digest [32]byte, path string, atime time.Time) error
+
+// Iterate walks the chunk store and calls cb for every chunk file whose
+// shard directory name is exactly 4 hex characters and whose filename is
+// exactly 64 hex characters. Other files (temp files, probes, etc.) are
+// silently skipped.
+func (s *Store) Iterate(ctx context.Context, cb IterCallback) error {
+	chunkDir := filepath.Join(s.root, ".chunks")
+	shards, err := os.ReadDir(chunkDir)
+	if err != nil {
+		return fmt.Errorf("read chunk dir: %w", err)
+	}
+
+	for _, shard := range shards {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if !shard.IsDir() {
+			continue
+		}
+		if !isHex(shard.Name(), 4) {
+			continue
+		}
+
+		shardPath := filepath.Join(chunkDir, shard.Name())
+		entries, err := os.ReadDir(shardPath)
+		if err != nil {
+			return fmt.Errorf("read shard %s: %w", shard.Name(), err)
+		}
+
+		for _, entry := range entries {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			if entry.IsDir() {
+				continue
+			}
+			if !isHex(entry.Name(), 64) {
+				continue
+			}
+
+			digestBytes, err := hex.DecodeString(entry.Name())
+			if err != nil {
+				continue
+			}
+			var digest [32]byte
+			copy(digest[:], digestBytes)
+
+			chunkPath := filepath.Join(shardPath, entry.Name())
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			atime := atimeFromFileInfo(chunkPath, info)
+
+			if err := cb(digest, chunkPath, atime); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// LockMutex acquires the store mutex and returns a function that releases it.
+// Used by the sweep phase to serialize chunk deletion with concurrent inserts.
+func (s *Store) LockMutex() func() {
+	s.mu.Lock()
+	return s.mu.Unlock
+}
+
+// isHex returns true if s is exactly n characters of lowercase hex.
+func isHex(s string, n int) bool {
+	if len(s) != n {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
 }

--- a/services/backupos-pbs/internal/chunkstore/chunkstore_test.go
+++ b/services/backupos-pbs/internal/chunkstore/chunkstore_test.go
@@ -1,11 +1,16 @@
 package chunkstore
 
 import (
+	"context"
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // setupStore creates a temp datastore root with a .chunks dir and a subset
@@ -157,5 +162,174 @@ func TestNew_MissingChunksDir_ReturnsError(t *testing.T) {
 	_, err := New(root)
 	if err == nil {
 		t.Error("expected error when .chunks dir missing, got nil")
+	}
+}
+
+func setChunkAtime(t *testing.T, path string, atime time.Time) {
+	t.Helper()
+	times := []unix.Timespec{
+		{Sec: atime.Unix(), Nsec: 0},
+		{Sec: 0, Nsec: unix.UTIME_OMIT},
+	}
+	if err := unix.UtimesNanoAt(unix.AT_FDCWD, path, times, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		t.Fatalf("setChunkAtime: %v", err)
+	}
+}
+
+func writeRawChunk(t *testing.T, root, name string) string {
+	t.Helper()
+	shard := name[:4]
+	if err := os.MkdirAll(filepath.Join(root, ".chunks", shard), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(root, ".chunks", shard, name)
+	if err := os.WriteFile(p, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+const iterChunk1 = "abcd" + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab"
+const iterChunk2 = "ef01" + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789ef"
+
+func TestIterate_VisitsValidChunks(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".chunks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s, err := New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p1 := writeRawChunk(t, root, iterChunk1)
+	p2 := writeRawChunk(t, root, iterChunk2)
+	now := time.Now()
+	setChunkAtime(t, p1, now.Add(-2*time.Hour))
+	setChunkAtime(t, p2, now.Add(-30*time.Minute))
+
+	seen := map[string]time.Time{}
+	err = s.Iterate(context.Background(), func(digest [32]byte, path string, atime time.Time) error {
+		seen[hex.EncodeToString(digest[:])] = atime
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Iterate: %v", err)
+	}
+	if len(seen) != 2 {
+		t.Errorf("got %d chunks, want 2", len(seen))
+	}
+	if _, ok := seen[iterChunk1]; !ok {
+		t.Errorf("iterChunk1 not visited")
+	}
+	if _, ok := seen[iterChunk2]; !ok {
+		t.Errorf("iterChunk2 not visited")
+	}
+}
+
+func TestIterate_SkipsNonHexFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".chunks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s, err := New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a valid chunk.
+	writeRawChunk(t, root, iterChunk1)
+
+	// Write a temp file that should be skipped.
+	shardDir := filepath.Join(root, ".chunks", "abcd")
+	if err := os.WriteFile(filepath.Join(shardDir, ".chunk.tmp.deadbeef"), []byte("tmp"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A shard dir with wrong length name.
+	if err := os.MkdirAll(filepath.Join(root, ".chunks", "xyz"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	count := 0
+	if err := s.Iterate(context.Background(), func(_ [32]byte, _ string, _ time.Time) error {
+		count++
+		return nil
+	}); err != nil {
+		t.Fatalf("Iterate: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("got %d chunks, want 1 (non-hex entries must be skipped)", count)
+	}
+}
+
+func TestIterate_CallbackError_Propagates(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".chunks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s, err := New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeRawChunk(t, root, iterChunk1)
+
+	sentinel := errors.New("stop")
+	err = s.Iterate(context.Background(), func(_ [32]byte, _ string, _ time.Time) error {
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got: %v", err)
+	}
+}
+
+func TestIterate_ContextCancelled_Stops(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".chunks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s, err := New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeRawChunk(t, root, iterChunk1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = s.Iterate(ctx, func(_ [32]byte, _ string, _ time.Time) error {
+		return nil
+	})
+	if err == nil {
+		t.Error("expected error from cancelled context")
+	}
+}
+
+func TestLockMutex_UnlockReleases(t *testing.T) {
+	root := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(root, ".chunks"), 0o755)
+	s, _ := New(root)
+
+	unlock := s.LockMutex()
+	// A second goroutine should block until unlock is called.
+	done := make(chan struct{})
+	go func() {
+		u2 := s.LockMutex()
+		u2()
+		close(done)
+	}()
+
+	// Give the goroutine a moment to try to acquire the lock.
+	time.Sleep(10 * time.Millisecond)
+	select {
+	case <-done:
+		t.Error("goroutine acquired lock before unlock was called")
+	default:
+	}
+
+	unlock()
+	select {
+	case <-done:
+		// correct: goroutine got the lock after unlock
+	case <-time.After(time.Second):
+		t.Error("goroutine did not acquire lock after unlock")
 	}
 }

--- a/services/backupos-pbs/internal/gcrun/gcrun.go
+++ b/services/backupos-pbs/internal/gcrun/gcrun.go
@@ -1,0 +1,81 @@
+// Package gcrun orchestrates a full garbage collection cycle.
+//
+// Execution order:
+//  1. VerifyAtimeUpdates — abort if the filesystem does not honor atime.
+//  2. AcquireExclusive  — acquire per-datastore flock; abort if already locked.
+//  3. Mark              — walk snapshots, touch atime on every referenced chunk.
+//  4. OldestActiveWriter— query the oldest active backup session start time.
+//  5. Sweep             — three-way decision per chunk; delete stale, keep in-use or pending.
+//
+// DefaultCutoff is the age at which an unreferenced chunk becomes eligible for
+// deletion. OldestWriterSafety (defined in gcsweep) is applied on top when an
+// active backup session started before the cutoff.
+package gcrun
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/chunkstore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/dslock"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcatime"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcmark"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcstatus"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcsweep"
+)
+
+// DefaultCutoff is the minimum age for a chunk to be eligible for deletion.
+// A chunk whose atime is older than (now - DefaultCutoff) has not been
+// referenced in over 24 hours and is safe to remove.
+const DefaultCutoff = 24*time.Hour + 5*time.Minute
+
+// OldestActiveWriterFunc returns the start time of the oldest active backup
+// session, or the zero time if there are none.
+type OldestActiveWriterFunc func(ctx context.Context) (time.Time, error)
+
+// Run executes a full GC cycle for the given datastore root.
+// It calls oldestWriterFn to query the oldest active backup session.
+// Returns the aggregated sweep status on success.
+func Run(ctx context.Context, datastoreRoot string, oldestWriterFn OldestActiveWriterFunc) (*gcstatus.Status, error) {
+	if err := gcatime.VerifyAtimeUpdates(datastoreRoot); err != nil {
+		return nil, fmt.Errorf("atime verification failed — aborting GC: %w", err)
+	}
+
+	lock, err := dslock.AcquireExclusive(datastoreRoot)
+	if err != nil {
+		return nil, fmt.Errorf("acquire GC lock: %w", err)
+	}
+	defer func() {
+		if err := lock.Release(); err != nil {
+			slog.Warn("gc: failed to release lock", "error", err)
+		}
+	}()
+
+	minAtime := time.Now().Add(-DefaultCutoff)
+
+	markStats, err := gcmark.Mark(ctx, datastoreRoot)
+	if err != nil {
+		return nil, fmt.Errorf("gc mark: %w", err)
+	}
+	slog.Info("gc run: mark complete", "stats", fmt.Sprintf("%+v", markStats))
+
+	oldestWriter, err := oldestWriterFn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("query oldest writer: %w", err)
+	}
+
+	store, err := chunkstore.New(datastoreRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open chunk store: %w", err)
+	}
+
+	status := &gcstatus.Status{}
+	if err := gcsweep.Sweep(ctx, store, oldestWriter, minAtime, status); err != nil {
+		return status, fmt.Errorf("gc sweep: %w", err)
+	}
+
+	slog.Info("gc run: sweep complete", "status", status.String())
+	return status, nil
+}

--- a/services/backupos-pbs/internal/gcrun/gcrun_test.go
+++ b/services/backupos-pbs/internal/gcrun/gcrun_test.go
@@ -1,0 +1,116 @@
+package gcrun
+
+import (
+	"context"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// buildDatastore creates a minimal datastore layout:
+//   - .chunks/<shard>/<digest>
+//   - <backup-type>/<backup-id>/<timestamp>/<archive>.fidx  (or empty dir)
+func buildDatastore(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	// Chunk store
+	chunkDir := filepath.Join(root, ".chunks")
+	if err := os.MkdirAll(chunkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func writeChunk(t *testing.T, root string, name string, atime time.Time) string {
+	t.Helper()
+	shard := name[:4]
+	p := filepath.Join(root, ".chunks", shard, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("chunkdata"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	times := []unix.Timespec{
+		{Sec: atime.Unix(), Nsec: 0},
+		{Sec: 0, Nsec: unix.UTIME_OMIT},
+	}
+	if err := unix.UtimesNanoAt(unix.AT_FDCWD, p, times, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		t.Fatalf("setAtime: %v", err)
+	}
+	return p
+}
+
+func noActiveWriter(_ context.Context) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func TestRun_NoChunks_Succeeds(t *testing.T) {
+	root := buildDatastore(t)
+
+	status, err := Run(context.Background(), root, noActiveWriter)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if status.DiskChunks != 0 {
+		t.Errorf("DiskChunks: got %d, want 0", status.DiskChunks)
+	}
+}
+
+func TestRun_OldUnreferencedChunk_Removed(t *testing.T) {
+	root := buildDatastore(t)
+
+	// A chunk whose atime is 48 hours old — well past DefaultCutoff.
+	name := hex.EncodeToString(make([]byte, 32))
+	chunkPath := writeChunk(t, root, name, time.Now().Add(-48*time.Hour))
+
+	status, err := Run(context.Background(), root, noActiveWriter)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := os.Stat(chunkPath); !os.IsNotExist(err) {
+		t.Error("expected old chunk to be removed")
+	}
+	if status.RemovedChunks != 1 {
+		t.Errorf("RemovedChunks: got %d, want 1", status.RemovedChunks)
+	}
+}
+
+func TestRun_RecentChunk_Kept(t *testing.T) {
+	root := buildDatastore(t)
+
+	// A chunk whose atime is only 1 hour old — within DefaultCutoff.
+	name := hex.EncodeToString(make([]byte, 32))
+	chunkPath := writeChunk(t, root, name, time.Now().Add(-1*time.Hour))
+
+	status, err := Run(context.Background(), root, noActiveWriter)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := os.Stat(chunkPath); err != nil {
+		t.Errorf("expected recent chunk to be kept: %v", err)
+	}
+	if status.RemovedChunks != 0 {
+		t.Errorf("RemovedChunks: got %d, want 0", status.RemovedChunks)
+	}
+}
+
+func TestRun_ContextCancelled_StopsMark(t *testing.T) {
+	root := buildDatastore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := Run(ctx, root, noActiveWriter)
+	// With no snapshot dirs the mark phase completes instantly even if cancelled,
+	// so we just confirm Run doesn't panic and that any non-nil error is context-related.
+	if err != nil && ctx.Err() == nil {
+		t.Errorf("unexpected non-context error: %v", err)
+	}
+}

--- a/services/backupos-pbs/internal/gcstatus/gcstatus.go
+++ b/services/backupos-pbs/internal/gcstatus/gcstatus.go
@@ -1,0 +1,47 @@
+// Package gcstatus defines the GC run statistics returned by the sweep phase.
+package gcstatus
+
+import "fmt"
+
+// Status collects chunk-level accounting for a single GC run.
+//
+// RemovedBad and StillBad are reserved for future integrity checking and
+// are always zero in the current implementation.
+type Status struct {
+	RemovedChunks int64
+	RemovedBytes  int64
+	PendingChunks int64
+	PendingBytes  int64
+	DiskChunks    int64
+	DiskBytes     int64
+	RemovedBad    int64
+	StillBad      int64
+}
+
+// Add merges other into s in place.
+func (s *Status) Add(other *Status) {
+	s.RemovedChunks += other.RemovedChunks
+	s.RemovedBytes += other.RemovedBytes
+	s.PendingChunks += other.PendingChunks
+	s.PendingBytes += other.PendingBytes
+	s.DiskChunks += other.DiskChunks
+	s.DiskBytes += other.DiskBytes
+	s.RemovedBad += other.RemovedBad
+	s.StillBad += other.StillBad
+}
+
+// Total returns a new Status that is the sum of s and other.
+func (s *Status) Total(other *Status) *Status {
+	out := *s
+	out.Add(other)
+	return &out
+}
+
+func (s *Status) String() string {
+	return fmt.Sprintf(
+		"removed=%d(%dB) pending=%d(%dB) disk=%d(%dB)",
+		s.RemovedChunks, s.RemovedBytes,
+		s.PendingChunks, s.PendingBytes,
+		s.DiskChunks, s.DiskBytes,
+	)
+}

--- a/services/backupos-pbs/internal/gcstatus/gcstatus_test.go
+++ b/services/backupos-pbs/internal/gcstatus/gcstatus_test.go
@@ -1,0 +1,46 @@
+package gcstatus
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAdd(t *testing.T) {
+	a := &Status{RemovedChunks: 1, RemovedBytes: 100, DiskChunks: 3, DiskBytes: 300}
+	b := &Status{RemovedChunks: 2, RemovedBytes: 200, PendingChunks: 1, PendingBytes: 50}
+	a.Add(b)
+	if a.RemovedChunks != 3 {
+		t.Errorf("RemovedChunks: got %d, want 3", a.RemovedChunks)
+	}
+	if a.RemovedBytes != 300 {
+		t.Errorf("RemovedBytes: got %d, want 300", a.RemovedBytes)
+	}
+	if a.PendingChunks != 1 {
+		t.Errorf("PendingChunks: got %d, want 1", a.PendingChunks)
+	}
+	if a.DiskChunks != 3 {
+		t.Errorf("DiskChunks: got %d, want 3", a.DiskChunks)
+	}
+}
+
+func TestTotal_DoesNotMutateReceiver(t *testing.T) {
+	a := &Status{RemovedChunks: 5}
+	b := &Status{RemovedChunks: 3}
+	c := a.Total(b)
+	if a.RemovedChunks != 5 {
+		t.Errorf("receiver mutated: got %d, want 5", a.RemovedChunks)
+	}
+	if c.RemovedChunks != 8 {
+		t.Errorf("Total: got %d, want 8", c.RemovedChunks)
+	}
+}
+
+func TestString_ContainsKeyFields(t *testing.T) {
+	s := &Status{RemovedChunks: 7, RemovedBytes: 700, PendingChunks: 2, PendingBytes: 200, DiskChunks: 10, DiskBytes: 1000}
+	str := s.String()
+	for _, want := range []string{"7", "700", "2", "200", "10", "1000"} {
+		if !strings.Contains(str, want) {
+			t.Errorf("String() missing %q: %s", want, str)
+		}
+	}
+}

--- a/services/backupos-pbs/internal/gcsweep/gcsweep.go
+++ b/services/backupos-pbs/internal/gcsweep/gcsweep.go
@@ -1,0 +1,82 @@
+// Package gcsweep implements the sweep phase of garbage collection.
+//
+// For each chunk in the chunk store it makes a three-way decision:
+//
+//	atime < minAtime              → delete (stale, no live reference)
+//	minAtime ≤ atime < oldestWriter → pending (may be referenced by an active backup)
+//	atime ≥ oldestWriter          → in-use (recently touched by mark or in-flight writer)
+//
+// If oldestWriter is earlier than minAtime, minAtime is extended backwards
+// by OldestWriterSafety to avoid deleting chunks written by an active session
+// that started before the GC cutoff was computed.
+//
+// Caller MUST hold the per-datastore exclusive lock before invoking Sweep.
+package gcsweep
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/chunkstore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcstatus"
+)
+
+// OldestWriterSafety is subtracted from oldestWriter when computing an
+// extended minAtime, to guard against chunks written by a session that
+// started just before the GC cutoff was captured.
+const OldestWriterSafety = 5 * time.Minute
+
+// Sweep iterates over every chunk in store, decides its fate, and updates
+// status accordingly. Chunk deletions are serialized with concurrent inserts
+// via store.LockMutex().
+func Sweep(ctx context.Context, store *chunkstore.Store, oldestWriter time.Time, minAtime time.Time, status *gcstatus.Status) error {
+	effectiveMin := minAtime
+	if !oldestWriter.IsZero() && oldestWriter.Before(minAtime) {
+		effectiveMin = oldestWriter.Add(-OldestWriterSafety)
+	}
+
+	return store.Iterate(ctx, func(_ [32]byte, path string, _ time.Time) error {
+		unlock := store.LockMutex()
+
+		// Re-stat under the store mutex to get size and a fresh atime,
+		// preventing a race where Insert() updated atime after Iterate read it.
+		info, err := os.Lstat(path)
+		if err != nil {
+			unlock()
+			if os.IsNotExist(err) {
+				return nil // concurrently deleted; skip
+			}
+			return fmt.Errorf("stat chunk %s: %w", path, err)
+		}
+		size := info.Size()
+		freshAtime := chunkstore.AtimeFromPath(path)
+
+		status.DiskChunks++
+		status.DiskBytes += size
+
+		switch {
+		case freshAtime.Before(effectiveMin):
+			err := os.Remove(path)
+			unlock()
+			if err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove chunk %s: %w", path, err)
+			}
+			status.RemovedChunks++
+			status.RemovedBytes += size
+			slog.Debug("gc sweep: removed chunk", "path", path)
+
+		case !oldestWriter.IsZero() && freshAtime.Before(oldestWriter):
+			unlock()
+			status.PendingChunks++
+			status.PendingBytes += size
+
+		default:
+			unlock()
+		}
+
+		return nil
+	})
+}

--- a/services/backupos-pbs/internal/gcsweep/gcsweep_test.go
+++ b/services/backupos-pbs/internal/gcsweep/gcsweep_test.go
@@ -1,0 +1,209 @@
+package gcsweep
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/chunkstore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcstatus"
+	"golang.org/x/sys/unix"
+)
+
+// makeStore creates a temp datastore with .chunks/<shard>/ layout.
+func makeStore(t *testing.T) (store *chunkstore.Store, root string) {
+	t.Helper()
+	root = t.TempDir()
+	chunkDir := filepath.Join(root, ".chunks")
+	if err := os.MkdirAll(chunkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s, err := chunkstore.New(root)
+	if err != nil {
+		t.Fatalf("chunkstore.New: %v", err)
+	}
+	return s, root
+}
+
+// writeChunk writes a fake chunk file and sets its atime to the given time.
+func writeChunk(t *testing.T, root string, name string, atime time.Time) string {
+	t.Helper()
+	shard := name[:4]
+	shardDir := filepath.Join(root, ".chunks", shard)
+	if err := os.MkdirAll(shardDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(shardDir, name)
+	if err := os.WriteFile(p, []byte("chunkdata"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	setAtime(t, p, atime)
+	return p
+}
+
+func setAtime(t *testing.T, path string, atime time.Time) {
+	t.Helper()
+	times := []unix.Timespec{
+		{Sec: atime.Unix(), Nsec: 0},
+		{Sec: 0, Nsec: unix.UTIME_OMIT},
+	}
+	if err := unix.UtimesNanoAt(unix.AT_FDCWD, path, times, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		t.Fatalf("setAtime: %v", err)
+	}
+}
+
+const hexChunk = "abcd" + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab"
+const hexChunk2 = "ef01" + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789ef"
+
+func TestSweep_OldChunk_Removed(t *testing.T) {
+	store, root := makeStore(t)
+	now := time.Now()
+	minAtime := now.Add(-1 * time.Hour)
+	oldAtime := now.Add(-2 * time.Hour)
+
+	path := writeChunk(t, root, hexChunk, oldAtime)
+	status := &gcstatus.Status{}
+
+	if err := Sweep(context.Background(), store, time.Time{}, minAtime, status); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("expected old chunk to be removed")
+	}
+	if status.RemovedChunks != 1 {
+		t.Errorf("RemovedChunks: got %d, want 1", status.RemovedChunks)
+	}
+	if status.DiskChunks != 1 {
+		t.Errorf("DiskChunks: got %d, want 1", status.DiskChunks)
+	}
+}
+
+func TestSweep_RecentChunk_Kept(t *testing.T) {
+	store, root := makeStore(t)
+	now := time.Now()
+	minAtime := now.Add(-1 * time.Hour)
+	recentAtime := now.Add(-30 * time.Minute)
+
+	path := writeChunk(t, root, hexChunk, recentAtime)
+	status := &gcstatus.Status{}
+
+	if err := Sweep(context.Background(), store, time.Time{}, minAtime, status); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected recent chunk to be kept, got: %v", err)
+	}
+	if status.RemovedChunks != 0 {
+		t.Errorf("RemovedChunks: got %d, want 0", status.RemovedChunks)
+	}
+}
+
+func TestSweep_PendingChunk_WithActiveWriter(t *testing.T) {
+	store, root := makeStore(t)
+	now := time.Now()
+	minAtime := now.Add(-1 * time.Hour)
+	oldestWriter := now.Add(-30 * time.Minute)
+	// Chunk atime is between minAtime and oldestWriter → pending
+	chunkAtime := now.Add(-45 * time.Minute)
+
+	path := writeChunk(t, root, hexChunk, chunkAtime)
+	status := &gcstatus.Status{}
+
+	if err := Sweep(context.Background(), store, oldestWriter, minAtime, status); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected pending chunk to be kept, got: %v", err)
+	}
+	if status.PendingChunks != 1 {
+		t.Errorf("PendingChunks: got %d, want 1", status.PendingChunks)
+	}
+	if status.RemovedChunks != 0 {
+		t.Errorf("RemovedChunks: got %d, want 0", status.RemovedChunks)
+	}
+}
+
+func TestSweep_OldestWriterExtendsMinAtime(t *testing.T) {
+	store, root := makeStore(t)
+	now := time.Now()
+	minAtime := now.Add(-1 * time.Hour)
+	// oldestWriter is before minAtime, so effectiveMin = oldestWriter - 5min
+	oldestWriter := now.Add(-90 * time.Minute)
+	effectiveMin := oldestWriter.Add(-OldestWriterSafety)
+
+	// Chunk atime is between effectiveMin and minAtime → should be kept (pending)
+	chunkAtime := effectiveMin.Add(1 * time.Minute)
+
+	path := writeChunk(t, root, hexChunk, chunkAtime)
+	status := &gcstatus.Status{}
+
+	if err := Sweep(context.Background(), store, oldestWriter, minAtime, status); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected chunk to be kept (effectiveMin extended): %v", err)
+	}
+	if status.RemovedChunks != 0 {
+		t.Errorf("RemovedChunks: got %d, want 0", status.RemovedChunks)
+	}
+}
+
+func TestSweep_MultipleChunks_MixedDecisions(t *testing.T) {
+	store, root := makeStore(t)
+	now := time.Now()
+	minAtime := now.Add(-1 * time.Hour)
+
+	oldPath := writeChunk(t, root, hexChunk, now.Add(-2*time.Hour))
+	recentPath := writeChunk(t, root, hexChunk2, now.Add(-30*time.Minute))
+	status := &gcstatus.Status{}
+
+	if err := Sweep(context.Background(), store, time.Time{}, minAtime, status); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Error("old chunk should be removed")
+	}
+	if _, err := os.Stat(recentPath); err != nil {
+		t.Errorf("recent chunk should be kept: %v", err)
+	}
+	if status.RemovedChunks != 1 {
+		t.Errorf("RemovedChunks: got %d, want 1", status.RemovedChunks)
+	}
+	if status.DiskChunks != 2 {
+		t.Errorf("DiskChunks: got %d, want 2", status.DiskChunks)
+	}
+}
+
+func TestSweep_ContextCancelled_StopsIteration(t *testing.T) {
+	store, root := makeStore(t)
+	now := time.Now()
+	minAtime := now.Add(-1 * time.Hour)
+	writeChunk(t, root, hexChunk, now.Add(-2*time.Hour))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	status := &gcstatus.Status{}
+	err := Sweep(ctx, store, time.Time{}, minAtime, status)
+	if err == nil {
+		t.Error("expected error from cancelled context")
+	}
+}
+
+func TestSweep_NoChunks_ReturnsNil(t *testing.T) {
+	store, _ := makeStore(t)
+	status := &gcstatus.Status{}
+	if err := Sweep(context.Background(), store, time.Time{}, time.Now().Add(-time.Hour), status); err != nil {
+		t.Errorf("Sweep on empty store: %v", err)
+	}
+	if status.DiskChunks != 0 {
+		t.Errorf("DiskChunks: got %d, want 0", status.DiskChunks)
+	}
+}

--- a/services/backupos-pbs/internal/session/session.go
+++ b/services/backupos-pbs/internal/session/session.go
@@ -15,6 +15,7 @@
 package session
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -127,6 +128,23 @@ func (s *Store) Finish(sessionID string) (bool, error) {
 		return false, fmt.Errorf("rows affected: %w", err)
 	}
 	return rows > 0, nil
+}
+
+// OldestActiveStartedAt returns the start time of the oldest active backup
+// session (state='backup'). Returns the zero time and nil if no active backup
+// sessions exist — the caller interprets a zero time as "no writer to protect".
+func (s *Store) OldestActiveStartedAt(ctx context.Context) (time.Time, error) {
+	const query = `
+		SELECT MIN(started_at) FROM pbs_active_sessions WHERE state = 'backup'
+	`
+	var ms sql.NullInt64
+	if err := s.db.QueryRowContext(ctx, query).Scan(&ms); err != nil {
+		return time.Time{}, fmt.Errorf("oldest active started_at: %w", err)
+	}
+	if !ms.Valid {
+		return time.Time{}, nil
+	}
+	return time.UnixMilli(ms.Int64), nil
 }
 
 // ErrNotFound is returned when no session matches the id.

--- a/services/backupos-pbs/internal/session/session_test.go
+++ b/services/backupos-pbs/internal/session/session_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -270,6 +271,81 @@ func TestFinish_AfterAbortedIsNoop(t *testing.T) {
 	_ = db.QueryRow(`SELECT state FROM pbs_active_sessions WHERE id = ?`, id).Scan(&gotState)
 	if gotState != "aborted" {
 		t.Errorf("state should remain aborted, got %q", gotState)
+	}
+}
+
+func TestOldestActiveStartedAt_NoSessions_ReturnsZero(t *testing.T) {
+	db := setupTestDB(t)
+	s := NewStore(db)
+
+	got, err := s.OldestActiveStartedAt(context.Background())
+	if err != nil {
+		t.Fatalf("OldestActiveStartedAt: %v", err)
+	}
+	if !got.IsZero() {
+		t.Errorf("expected zero time for empty table, got %v", got)
+	}
+}
+
+func TestOldestActiveStartedAt_ReturnsOldestBackup(t *testing.T) {
+	db := setupTestDB(t)
+	db.SetMaxOpenConns(1)
+	s := NewStore(db)
+
+	// Insert two backup sessions with known started_at values.
+	older := time.Now().Add(-2 * time.Hour).Truncate(time.Millisecond)
+	newer := time.Now().Add(-1 * time.Hour).Truncate(time.Millisecond)
+
+	_, err := db.Exec(`
+		INSERT INTO pbs_active_sessions (id, token_id, datastore_id, backup_type, backup_id, backup_time, started_at, state)
+		VALUES ('s1', '', '', 'vm', '100', 0, ?, 'backup')
+	`, older.UnixMilli())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`
+		INSERT INTO pbs_active_sessions (id, token_id, datastore_id, backup_type, backup_id, backup_time, started_at, state)
+		VALUES ('s2', '', '', 'vm', '101', 0, ?, 'backup')
+	`, newer.UnixMilli())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.OldestActiveStartedAt(context.Background())
+	if err != nil {
+		t.Fatalf("OldestActiveStartedAt: %v", err)
+	}
+	if got.UnixMilli() != older.UnixMilli() {
+		t.Errorf("got %v, want %v", got, older)
+	}
+}
+
+func TestOldestActiveStartedAt_IgnoresNonBackupSessions(t *testing.T) {
+	db := setupTestDB(t)
+	db.SetMaxOpenConns(1)
+	s := NewStore(db)
+
+	// Reader and finished sessions should not count.
+	for _, row := range []struct{ id, state string }{
+		{"r1", "reader"},
+		{"f1", "finished"},
+		{"a1", "aborted"},
+	} {
+		_, err := db.Exec(`
+			INSERT INTO pbs_active_sessions (id, token_id, datastore_id, backup_type, backup_id, backup_time, started_at, state)
+			VALUES (?, '', '', 'vm', '100', 0, ?, ?)
+		`, row.id, time.Now().Add(-time.Hour).UnixMilli(), row.state)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := s.OldestActiveStartedAt(context.Background())
+	if err != nil {
+		t.Fatalf("OldestActiveStartedAt: %v", err)
+	}
+	if !got.IsZero() {
+		t.Errorf("expected zero time (no backup sessions), got %v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **`internal/gcstatus`**: `Status` struct with 8 fields (removed/pending/disk chunks+bytes, RemovedBad/StillBad=0) + `Add`, `Total`, `String` methods
- **`internal/gcsweep`**: Three-way chunk decision under `store.LockMutex()` — delete if `atime < effectiveMin`, pending if `atime < oldestWriter`, in-use otherwise. Extends `minAtime` backwards by `OldestWriterSafety` (5 min) when an active writer started before the cutoff
- **`internal/gcrun`**: Full GC orchestration: `VerifyAtimeUpdates → AcquireExclusive → Mark → OldestActiveWriterFn → Sweep`. `DefaultCutoff = 24h5m`
- **`internal/chunkstore`**: `Iterate` (hex-validated 4-char shard / 64-char chunk walk with atime via platform-specific `AtimeFromPath`) + `LockMutex` (serialises sweep deletes against concurrent inserts). Build-tagged `atime_linux.go` / `atime_other.go`
- **`internal/session`**: `OldestActiveStartedAt` — `MIN(started_at) FROM pbs_active_sessions WHERE state='backup'`; returns zero time when no active writers

## Test plan

- [ ] `go test ./internal/gcstatus/...` — Add/Total/String
- [ ] `go test ./internal/chunkstore/...` — Iterate (valid chunks visited, non-hex skipped, callback error propagates, context cancel), LockMutex serialisation
- [ ] `go test ./internal/session/...` — OldestActiveStartedAt (empty, oldest of two, ignores non-backup states)
- [ ] `go test ./internal/gcsweep/...` — old chunk removed, recent kept, pending with active writer, minAtime extension, mixed decisions, context cancel, empty store
- [ ] `go test ./internal/gcrun/...` — no chunks, old chunk removed, recent kept, context cancel

🤖 Generated with [Claude Code](https://claude.com/claude-code)