### PR TITLE
feat(pbs): GC admin API — POST/GET /admin/datastore/{store}/gc — milestone 6c

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -44,6 +45,9 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedclose"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedindex"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/download"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcadmin"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcrun"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gctask"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/handlers"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/readchunk"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/readerupgrade"
@@ -128,10 +132,25 @@ func main() {
 		readchunk.NewHandler(),
 	)
 
+	gcTracker := gctask.NewTracker()
+	oldestActiveWriter := gcrun.OldestActiveWriterFunc(func(ctx context.Context) (time.Time, error) {
+		return sessionStore.OldestActiveStartedAt(ctx)
+	})
+	gcAdminHandler := gcadmin.NewHandler(datastoreLookup, gcTracker, oldestActiveWriter)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api2/json/version", versionHandler.ServeHTTP)
 	mux.HandleFunc("/api2/json/backup", requireAuth(validator, upgradeHandler.ServeHTTP))
 	mux.HandleFunc("/api2/json/reader", readerHandler.ServeHTTP)
+	mux.HandleFunc("/api2/json/admin/datastore/", requireAuth(validator,
+		func(w http.ResponseWriter, r *http.Request) {
+			if !strings.HasSuffix(r.URL.Path, "/gc") {
+				http.NotFound(w, r)
+				return
+			}
+			gcAdminHandler.ServeHTTP(w, r)
+		},
+	))
 	mux.HandleFunc("/", notFound)
 
 	server := &http.Server{

--- a/services/backupos-pbs/internal/gcadmin/gcadmin.go
+++ b/services/backupos-pbs/internal/gcadmin/gcadmin.go
@@ -1,0 +1,160 @@
+// Package gcadmin implements the HTTP handler for the GC admin API.
+//
+// Routes:
+//
+//	POST /api2/json/admin/datastore/{store}/gc  → start GC, returns 202 with task_id
+//	GET  /api2/json/admin/datastore/{store}/gc  → most recent GC status for datastore
+//
+// GC runs asynchronously in a goroutine. The handler returns 202 immediately.
+// Client disconnect does NOT cancel the GC (context.Background is used).
+// A second POST while GC is running returns 409.
+package gcadmin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/dslock"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcrun"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcstatus"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gctask"
+)
+
+// Handler serves the GC admin endpoints.
+type Handler struct {
+	datastores         *datastore.Lookup
+	tracker            *gctask.Tracker
+	oldestActiveWriter gcrun.OldestActiveWriterFunc
+	// runFn is the GC execution function. Defaults to gcrun.Run; overridable in tests.
+	runFn func(ctx context.Context, root string, fn gcrun.OldestActiveWriterFunc) (*gcstatus.Status, error)
+}
+
+// NewHandler constructs a Handler.
+func NewHandler(
+	datastores *datastore.Lookup,
+	tracker *gctask.Tracker,
+	oldestActiveWriter gcrun.OldestActiveWriterFunc,
+) *Handler {
+	return &Handler{
+		datastores:         datastores,
+		tracker:            tracker,
+		oldestActiveWriter: oldestActiveWriter,
+		runFn:              gcrun.Run,
+	}
+}
+
+// ServeHTTP dispatches POST (start GC) and GET (status).
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	storeName, ok := extractStore(r.URL.Path)
+	if !ok {
+		writeJSONError(w, http.StatusBadRequest, "could not extract datastore name from path")
+		return
+	}
+
+	ds, err := h.datastores.ByName(storeName)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) || errors.Is(err, datastore.ErrInvalidName) {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("unknown datastore %q", storeName))
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		h.startGC(w, ds)
+	case http.MethodGet:
+		h.getStatus(w, ds)
+	default:
+		w.Header().Set("Allow", "POST, GET")
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) startGC(w http.ResponseWriter, ds *datastore.Datastore) {
+	task, err := h.tracker.Begin(ds.ID, ds.Name)
+	if err != nil {
+		if errors.Is(err, gctask.ErrGCAlreadyRunning) {
+			writeJSONError(w, http.StatusConflict, "garbage collection already running")
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	go func(taskID, dsID, dsName, dsRoot string) {
+		ctx := context.Background()
+		slog.Info("gc started", "task_id", taskID, "datastore", dsName, "datastore_id", dsID)
+
+		status, runErr := h.runFn(ctx, dsRoot, h.oldestActiveWriter)
+		if runErr != nil {
+			if errors.Is(runErr, dslock.ErrGCBusy) {
+				slog.Warn("gc raced with external dslock holder", "task_id", taskID, "datastore_id", dsID)
+			}
+			h.tracker.Fail(taskID, runErr)
+			slog.Info("gc failed", "task_id", taskID, "datastore_id", dsID, "error", runErr.Error())
+			return
+		}
+
+		h.tracker.Succeed(taskID, status, nil)
+		slog.Info("gc succeeded",
+			"task_id", taskID,
+			"datastore_id", dsID,
+			"removed_chunks", status.RemovedChunks,
+			"removed_bytes", status.RemovedBytes,
+			"disk_chunks", status.DiskChunks,
+			"disk_bytes", status.DiskBytes,
+		)
+	}(task.ID, ds.ID, ds.Name, ds.Path)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"data": map[string]any{
+			"task_id":    task.ID,
+			"datastore":  ds.Name,
+			"state":      task.State,
+			"started_at": task.StartedAt.Format(time.RFC3339),
+		},
+	})
+}
+
+func (h *Handler) getStatus(w http.ResponseWriter, ds *datastore.Datastore) {
+	latest := h.tracker.Latest(ds.ID)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if latest == nil {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": nil})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"data": latest})
+}
+
+// extractStore parses /api2/json/admin/datastore/{store}/gc and returns store name.
+func extractStore(path string) (string, bool) {
+	const prefix = "/api2/json/admin/datastore/"
+	const suffix = "/gc"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return "", false
+	}
+	middle := strings.TrimPrefix(path, prefix)
+	middle = strings.TrimSuffix(middle, suffix)
+	if middle == "" || strings.Contains(middle, "/") {
+		return "", false
+	}
+	return middle, true
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/gcadmin/gcadmin_test.go
+++ b/services/backupos-pbs/internal/gcadmin/gcadmin_test.go
@@ -1,0 +1,337 @@
+package gcadmin
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcrun"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcstatus"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gctask"
+)
+
+// ---- test infrastructure ----
+
+func setupDB(t *testing.T, dsName, dsPath string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE pbs_datastores (
+			id         TEXT PRIMARY KEY,
+			name       TEXT NOT NULL UNIQUE,
+			path       TEXT NOT NULL,
+			created_at INTEGER NOT NULL
+		)
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(
+		`INSERT INTO pbs_datastores (id, name, path, created_at) VALUES (?, ?, ?, ?)`,
+		"ds-test-id", dsName, dsPath, time.Now().UnixMilli(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func makeDSRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".chunks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func noWriter(_ context.Context) (time.Time, error) { return time.Time{}, nil }
+
+func newHandler(t *testing.T, db *sql.DB, runFn func(context.Context, string, gcrun.OldestActiveWriterFunc) (*gcstatus.Status, error)) *Handler {
+	t.Helper()
+	h := NewHandler(datastore.NewLookup(db), gctask.NewTracker(), noWriter)
+	if runFn != nil {
+		h.runFn = runFn
+	}
+	return h
+}
+
+func doRequest(t *testing.T, h *Handler, method, path string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w.Result()
+}
+
+func readBody(t *testing.T, resp *http.Response) map[string]any {
+	t.Helper()
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("parse body: %v\nbody: %s", err, b)
+	}
+	return out
+}
+
+// ---- tests ----
+
+func TestPOST_Returns202WithTaskID(t *testing.T) {
+	root := makeDSRoot(t)
+	db := setupDB(t, "mystore", root)
+
+	done := make(chan struct{})
+	h := newHandler(t, db, func(_ context.Context, _ string, _ gcrun.OldestActiveWriterFunc) (*gcstatus.Status, error) {
+		close(done)
+		return &gcstatus.Status{}, nil
+	})
+
+	resp := doRequest(t, h, http.MethodPost, "/api2/json/admin/datastore/mystore/gc")
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status: got %d, want 202", resp.StatusCode)
+	}
+	body := readBody(t, resp)
+	data, ok := body["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected data object, got %v", body["data"])
+	}
+	taskID, _ := data["task_id"].(string)
+	if taskID == "" {
+		t.Error("expected non-empty task_id")
+	}
+	if data["state"] != "running" {
+		t.Errorf("state: got %v, want running", data["state"])
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Error("runFn never called")
+	}
+}
+
+func TestGET_BeforeRun_ReturnsNullData(t *testing.T) {
+	root := makeDSRoot(t)
+	db := setupDB(t, "mystore", root)
+	h := newHandler(t, db, nil) // runFn won't be called
+
+	resp := doRequest(t, h, http.MethodGet, "/api2/json/admin/datastore/mystore/gc")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+	body := readBody(t, resp)
+	if body["data"] != nil {
+		t.Errorf("expected data=null, got %v", body["data"])
+	}
+}
+
+func TestTwoPOSTs_SecondReturns409(t *testing.T) {
+	root := makeDSRoot(t)
+	db := setupDB(t, "mystore", root)
+
+	blocking := make(chan struct{})
+	h := newHandler(t, db, func(_ context.Context, _ string, _ gcrun.OldestActiveWriterFunc) (*gcstatus.Status, error) {
+		<-blocking // block until test releases
+		return &gcstatus.Status{}, nil
+	})
+
+	// First POST: should be 202.
+	resp1 := doRequest(t, h, http.MethodPost, "/api2/json/admin/datastore/mystore/gc")
+	if resp1.StatusCode != http.StatusAccepted {
+		t.Fatalf("first POST: got %d, want 202", resp1.StatusCode)
+	}
+
+	// Second POST while first is still running: should be 409.
+	resp2 := doRequest(t, h, http.MethodPost, "/api2/json/admin/datastore/mystore/gc")
+	if resp2.StatusCode != http.StatusConflict {
+		t.Errorf("second POST: got %d, want 409", resp2.StatusCode)
+	}
+
+	close(blocking) // let goroutine finish
+}
+
+func TestPOST_AfterFirstCompletes_Succeeds(t *testing.T) {
+	root := makeDSRoot(t)
+	db := setupDB(t, "mystore", root)
+
+	done := make(chan struct{})
+	h := newHandler(t, db, func(_ context.Context, _ string, _ gcrun.OldestActiveWriterFunc) (*gcstatus.Status, error) {
+		close(done)
+		return &gcstatus.Status{}, nil
+	})
+
+	resp1 := doRequest(t, h, http.MethodPost, "/api2/json/admin/datastore/mystore/gc")
+	if resp1.StatusCode != http.StatusAccepted {
+		t.Fatalf("first POST: %d", resp1.StatusCode)
+	}
+	<-done // wait for goroutine to finish
+
+	// Replace runFn to capture the second task's completion.
+	done2 := make(chan struct{})
+	h.runFn = func(_ context.Context, _ string, _ gcrun.OldestActiveWriterFunc) (*gcstatus.Status, error) {
+		close(done2)
+		return &gcstatus.Status{}, nil
+	}
+
+	resp2 := doRequest(t, h, http.MethodPost, "/api2/json/admin/datastore/mystore/gc")
+	if resp2.StatusCode != http.StatusAccepted {
+		t.Errorf("second POST after completion: got %d, want 202", resp2.StatusCode)
+	}
+	<-done2
+}
+
+func TestGET_AfterSucceeded_ShowsSucceeded(t *testing.T) {
+	root := makeDSRoot(t)
+	db := setupDB(t, "mystore", root)
+
+	done := make(chan struct{})
+	h := newHandler(t, db, func(_ context.Context, _ string, _ gcrun.OldestActiveWriterFunc) (*gcstatus.Status, error) {
+		defer close(done)
+		return &gcstatus.Status{DiskChunks: 7, RemovedChunks: 2}, nil
+	})
+
+	doRequest(t, h, http.MethodPost, "/api2/json/admin/datastore/mystore/gc")
+	<-done // wait for goroutine to call Succeed
+
+	resp := doRequest(t, h, http.MethodGet, "/api2/json/admin/datastore/mystore/gc")
+	body := readBody(t, resp)
+	data, ok := body["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected data object, got %v", body["data"])
+	}
+	if data["state"] != "succeeded" {
+		t.Errorf("state: got %v, want succeeded", data["state"])
+	}
+}
+
+func TestGET_AfterFailed_ShowsFailed(t *testing.T) {
+	root := makeDSRoot(t)
+	db := setupDB(t, "mystore", root)
+
+	done := make(chan struct{})
+	h := newHandler(t, db, func(_ context.Context, _ string, _ gcrun.OldestActiveWriterFunc) (*gcstatus.Status, error) {
+		defer close(done)
+		return nil, errors.New("atime probe failed")
+	})
+
+	doRequest(t, h, http.MethodPost, "/api2/json/admin/datastore/mystore/gc")
+	<-done
+
+	resp := doRequest(t, h, http.MethodGet, "/api2/json/admin/datastore/mystore/gc")
+	body := readBody(t, resp)
+	data := body["data"].(map[string]any)
+	if data["state"] != "failed" {
+		t.Errorf("state: got %v, want failed", data["state"])
+	}
+	if data["error"] == "" {
+		t.Error("expected non-empty error field")
+	}
+}
+
+func TestWrongMethod_Returns405(t *testing.T) {
+	root := makeDSRoot(t)
+	db := setupDB(t, "mystore", root)
+	h := newHandler(t, db, nil)
+
+	resp := doRequest(t, h, http.MethodPut, "/api2/json/admin/datastore/mystore/gc")
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status: got %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestUnknownDatastore_Returns400(t *testing.T) {
+	root := makeDSRoot(t)
+	db := setupDB(t, "mystore", root)
+	h := newHandler(t, db, nil)
+
+	resp := doRequest(t, h, http.MethodPost, "/api2/json/admin/datastore/nonexistent/gc")
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestInvalidPath_Returns400(t *testing.T) {
+	root := makeDSRoot(t)
+	db := setupDB(t, "mystore", root)
+	h := newHandler(t, db, nil)
+
+	for _, path := range []string{
+		"/api2/json/admin/datastore//gc",
+		"/api2/json/admin/datastore/mystore",
+		"/api2/json/admin/datastore/mystore/gc/extra",
+	} {
+		resp := doRequest(t, h, http.MethodPost, path)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("path %q: got %d, want 400", path, resp.StatusCode)
+		}
+	}
+}
+
+func TestExtractStore(t *testing.T) {
+	cases := []struct {
+		path    string
+		want    string
+		wantOK  bool
+	}{
+		{"/api2/json/admin/datastore/mystore/gc", "mystore", true},
+		{"/api2/json/admin/datastore/my-store_2/gc", "my-store_2", true},
+		{"/api2/json/admin/datastore//gc", "", false},
+		{"/api2/json/admin/datastore/mystore", "", false},
+		{"/api2/json/admin/datastore/a/b/gc", "", false},
+		{"/api2/json/admin/", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := extractStore(tc.path)
+		if ok != tc.wantOK || got != tc.want {
+			t.Errorf("extractStore(%q) = (%q, %v), want (%q, %v)", tc.path, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+func TestGCRunsWithBackgroundContext_ClientDisconnectDoesNotCancel(t *testing.T) {
+	root := makeDSRoot(t)
+	db := setupDB(t, "mystore", root)
+
+	var capturedCtx context.Context
+	done := make(chan struct{})
+	h := newHandler(t, db, func(ctx context.Context, _ string, _ gcrun.OldestActiveWriterFunc) (*gcstatus.Status, error) {
+		capturedCtx = ctx
+		close(done)
+		return &gcstatus.Status{}, nil
+	})
+
+	doRequest(t, h, http.MethodPost, "/api2/json/admin/datastore/mystore/gc")
+	<-done
+
+	if capturedCtx == nil {
+		t.Fatal("context was nil")
+	}
+	// The goroutine must use context.Background(), not the request context.
+	// context.Background() never cancels.
+	select {
+	case <-capturedCtx.Done():
+		t.Error("context was cancelled — must use context.Background()")
+	default:
+	}
+}

--- a/services/backupos-pbs/internal/gctask/gctask.go
+++ b/services/backupos-pbs/internal/gctask/gctask.go
@@ -1,0 +1,144 @@
+// Package gctask tracks in-memory state for GC runs, one per datastore.
+//
+// The Tracker holds the most recent task per datastore name. When a new GC
+// starts, any completed task for that datastore is replaced. State is
+// ephemeral — a server restart loses task history; the GC itself already ran
+// or didn't.
+package gctask
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcmark"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcstatus"
+)
+
+// State is the lifecycle state of a GC task.
+type State int
+
+const (
+	StateRunning State = iota
+	StateSucceeded
+	StateFailed
+)
+
+func (s State) String() string {
+	switch s {
+	case StateRunning:
+		return "running"
+	case StateSucceeded:
+		return "succeeded"
+	case StateFailed:
+		return "failed"
+	}
+	return "unknown"
+}
+
+// Task is a snapshot of a single GC run for one datastore.
+type Task struct {
+	ID            string           `json:"task_id"`
+	DatastoreName string           `json:"datastore"`
+	State         string           `json:"state"`
+	StartedAt     time.Time        `json:"started_at"`
+	FinishedAt    *time.Time       `json:"finished_at,omitempty"`
+	Status        *gcstatus.Status `json:"status,omitempty"`
+	MarkStats     *gcmark.Stats    `json:"mark_stats,omitempty"`
+	Error         string           `json:"error,omitempty"`
+}
+
+// ErrGCAlreadyRunning is returned by Begin when a task is already running
+// for the requested datastore. The caller should translate this to HTTP 409.
+var ErrGCAlreadyRunning = errors.New("gc already running on this datastore")
+
+// Tracker holds the most recent GC task per datastore ID.
+type Tracker struct {
+	mu    sync.Mutex
+	perDS map[string]*Task // keyed by datastore ID
+}
+
+// NewTracker constructs an empty Tracker.
+func NewTracker() *Tracker {
+	return &Tracker{perDS: make(map[string]*Task)}
+}
+
+// Begin creates a new running task for the datastore identified by datastoreID.
+// Returns ErrGCAlreadyRunning if a task is already in state "running".
+// The datastoreName is stored for display purposes.
+func (t *Tracker) Begin(datastoreID, datastoreName string) (*Task, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if existing, ok := t.perDS[datastoreID]; ok && existing.State == StateRunning.String() {
+		return nil, ErrGCAlreadyRunning
+	}
+	task := &Task{
+		ID:            uuid.NewString(),
+		DatastoreName: datastoreName,
+		State:         StateRunning.String(),
+		StartedAt:     time.Now(),
+	}
+	t.perDS[datastoreID] = task
+	return task, nil
+}
+
+// Succeed transitions the task with the given taskID to succeeded.
+func (t *Tracker) Succeed(taskID string, status *gcstatus.Status, markStats *gcmark.Stats) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	task := t.findByID(taskID)
+	if task == nil {
+		return
+	}
+	now := time.Now()
+	task.State = StateSucceeded.String()
+	task.FinishedAt = &now
+	task.Status = status
+	task.MarkStats = markStats
+}
+
+// Fail transitions the task with the given taskID to failed.
+func (t *Tracker) Fail(taskID string, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	task := t.findByID(taskID)
+	if task == nil {
+		return
+	}
+	now := time.Now()
+	task.State = StateFailed.String()
+	task.FinishedAt = &now
+	task.Error = err.Error()
+}
+
+// Latest returns a defensive copy of the most recent task for the datastore,
+// or nil if no GC has been run for this datastore since process start.
+func (t *Tracker) Latest(datastoreID string) *Task {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	task, ok := t.perDS[datastoreID]
+	if !ok {
+		return nil
+	}
+	cp := *task
+	if task.Status != nil {
+		s := *task.Status
+		cp.Status = &s
+	}
+	if task.MarkStats != nil {
+		m := *task.MarkStats
+		cp.MarkStats = &m
+	}
+	return &cp
+}
+
+func (t *Tracker) findByID(taskID string) *Task {
+	for _, task := range t.perDS {
+		if task.ID == taskID {
+			return task
+		}
+	}
+	return nil
+}

--- a/services/backupos-pbs/internal/gctask/gctask_test.go
+++ b/services/backupos-pbs/internal/gctask/gctask_test.go
@@ -1,0 +1,169 @@
+package gctask
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcstatus"
+)
+
+const (
+	dsID   = "ds-uuid-1"
+	dsName = "mystore"
+	dsID2  = "ds-uuid-2"
+)
+
+func TestBegin_CreatesRunningTask(t *testing.T) {
+	tr := NewTracker()
+	task, err := tr.Begin(dsID, dsName)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if task.ID == "" {
+		t.Error("expected non-empty task ID")
+	}
+	if task.State != StateRunning.String() {
+		t.Errorf("state: got %q, want %q", task.State, StateRunning.String())
+	}
+	if task.DatastoreName != dsName {
+		t.Errorf("datastore: got %q, want %q", task.DatastoreName, dsName)
+	}
+}
+
+func TestBegin_Twice_SameDatastore_ReturnsErrGCAlreadyRunning(t *testing.T) {
+	tr := NewTracker()
+	if _, err := tr.Begin(dsID, dsName); err != nil {
+		t.Fatalf("first Begin: %v", err)
+	}
+	_, err := tr.Begin(dsID, dsName)
+	if !errors.Is(err, ErrGCAlreadyRunning) {
+		t.Errorf("second Begin: got %v, want ErrGCAlreadyRunning", err)
+	}
+}
+
+func TestBegin_DifferentDatastores_BothSucceed(t *testing.T) {
+	tr := NewTracker()
+	t1, err := tr.Begin(dsID, dsName)
+	if err != nil {
+		t.Fatalf("Begin ds1: %v", err)
+	}
+	t2, err := tr.Begin(dsID2, "other")
+	if err != nil {
+		t.Fatalf("Begin ds2: %v", err)
+	}
+	if t1.ID == t2.ID {
+		t.Error("expected distinct task IDs")
+	}
+}
+
+func TestBegin_AfterFinished_Succeeds(t *testing.T) {
+	tr := NewTracker()
+	task, _ := tr.Begin(dsID, dsName)
+	tr.Succeed(task.ID, &gcstatus.Status{}, nil)
+
+	task2, err := tr.Begin(dsID, dsName)
+	if err != nil {
+		t.Fatalf("Begin after finish: %v", err)
+	}
+	if task2.ID == task.ID {
+		t.Error("expected a new task ID")
+	}
+}
+
+func TestBegin_AfterFailed_Succeeds(t *testing.T) {
+	tr := NewTracker()
+	task, _ := tr.Begin(dsID, dsName)
+	tr.Fail(task.ID, errors.New("boom"))
+
+	_, err := tr.Begin(dsID, dsName)
+	if err != nil {
+		t.Fatalf("Begin after fail: %v", err)
+	}
+}
+
+func TestSucceed_TransitionsState(t *testing.T) {
+	tr := NewTracker()
+	task, _ := tr.Begin(dsID, dsName)
+	status := &gcstatus.Status{RemovedChunks: 5, DiskChunks: 10}
+	tr.Succeed(task.ID, status, nil)
+
+	latest := tr.Latest(dsID)
+	if latest.State != StateSucceeded.String() {
+		t.Errorf("state: got %q, want succeeded", latest.State)
+	}
+	if latest.FinishedAt == nil {
+		t.Error("FinishedAt should be set")
+	}
+	if latest.Status == nil || latest.Status.RemovedChunks != 5 {
+		t.Errorf("Status not copied correctly: %+v", latest.Status)
+	}
+}
+
+func TestFail_TransitionsState(t *testing.T) {
+	tr := NewTracker()
+	task, _ := tr.Begin(dsID, dsName)
+	tr.Fail(task.ID, errors.New("disk full"))
+
+	latest := tr.Latest(dsID)
+	if latest.State != StateFailed.String() {
+		t.Errorf("state: got %q, want failed", latest.State)
+	}
+	if latest.Error != "disk full" {
+		t.Errorf("Error: got %q, want \"disk full\"", latest.Error)
+	}
+	if latest.FinishedAt == nil {
+		t.Error("FinishedAt should be set")
+	}
+}
+
+func TestLatest_NeverRun_ReturnsNil(t *testing.T) {
+	tr := NewTracker()
+	if got := tr.Latest(dsID); got != nil {
+		t.Errorf("expected nil for unknown datastore, got %+v", got)
+	}
+}
+
+func TestLatest_ReturnsCopy_MutatingDoesNotAffectTracker(t *testing.T) {
+	tr := NewTracker()
+	task, _ := tr.Begin(dsID, dsName)
+	tr.Succeed(task.ID, &gcstatus.Status{RemovedChunks: 3}, nil)
+
+	cp := tr.Latest(dsID)
+	cp.State = "mutated"
+	cp.Status.RemovedChunks = 999
+
+	canonical := tr.Latest(dsID)
+	if canonical.State != StateSucceeded.String() {
+		t.Errorf("tracker state was mutated: got %q", canonical.State)
+	}
+	if canonical.Status.RemovedChunks != 3 {
+		t.Errorf("tracker Status was mutated: got %d", canonical.Status.RemovedChunks)
+	}
+}
+
+func TestConcurrent_RaceDetectorClean(t *testing.T) {
+	tr := NewTracker()
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			task, err := tr.Begin(dsID, dsName)
+			if err != nil {
+				// another goroutine is running — expected
+				tr.Latest(dsID)
+				return
+			}
+			time.Sleep(time.Millisecond)
+			if i%2 == 0 {
+				tr.Succeed(task.ID, &gcstatus.Status{}, nil)
+			} else {
+				tr.Fail(task.ID, errors.New("err"))
+			}
+			tr.Latest(dsID)
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

- **`internal/gctask`**: In-memory per-datastore task state machine. `Begin` creates a running task or returns `ErrGCAlreadyRunning` if one is already active. `Succeed`/`Fail` transition state. `Latest` returns a defensive copy.
- **`internal/gcadmin`**: HTTP handler for `POST` (202 + task_id, GC runs in background goroutine with `context.Background()`) and `GET` (latest status or `{"data":null}`). Returns 409 on collision, 400 on unknown datastore, 405 on wrong method. `runFn` is injectable so tests don't hit the real filesystem.
- **`cmd/backupos-pbs/main.go`**: Wires `gcTracker` + `gcAdminHandler` behind `requireAuth` on `/api2/json/admin/datastore/` with a `/gc` suffix guard.

## Key correctness properties

- POST returns **202** (not 200)
- Second POST while first running returns **409** (not 503)
- GC goroutine uses **`context.Background()`** — client disconnect cannot cancel GC
- Path is `/api2/json/admin/datastore/{store}/gc` (not `/garbage-collection`)
- Handler does **not** hold `dslock` — `gcrun.Run` acquires it internally

## Test plan

- [ ] `go mod tidy && go build ./cmd/backupos-pbs` — verify no go.sum drift
- [ ] `go test ./internal/gctask/...` — state machine, concurrency (race detector)
- [ ] `go test ./internal/gcadmin/...` — 202/409/404/405, context.Background check, async completion
- [ ] `go test ./...` — full suite still green

> **Note:** Auto-merge is intentionally NOT set per M6 review policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)