### PR TITLE
feat(pbs): periodic stale-session reaper

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/readchunk"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/readerupgrade"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/sessionreaper"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/upgrade"
 )
 
@@ -153,6 +154,14 @@ func main() {
 	))
 	mux.HandleFunc("/", notFound)
 
+	// serverCtx is cancelled on SIGINT/SIGTERM so background goroutines
+	// (reaper, future cron jobs) stop cleanly alongside the HTTP server.
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+
+	reaper := sessionreaper.New(database, 0, 0)
+	go reaper.Run(serverCtx)
+
 	server := &http.Server{
 		Addr:    *bind,
 		Handler: mux,
@@ -172,6 +181,7 @@ func main() {
 		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 		sig := <-sigCh
 		logger.Info("received signal, shutting down", "signal", sig)
+		serverCancel() // stop background goroutines
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		if err := server.Shutdown(ctx); err != nil {

--- a/services/backupos-pbs/internal/sessionreaper/reaper.go
+++ b/services/backupos-pbs/internal/sessionreaper/reaper.go
@@ -1,0 +1,102 @@
+// Package sessionreaper periodically aborts stale pbs_active_sessions rows.
+//
+// A session is stale when it has been in state 'backup' or 'reader' for
+// longer than StaleThreshold. This happens when a backup client crashes
+// mid-upload: the HTTP/2 connection closes, Finalize() is called, but if
+// that path fails (e.g. a panic before Finalize runs), the row stays
+// active. Stale rows poison GC's safety extension by making
+// OldestActiveStartedAt return ancient timestamps.
+//
+// The UPDATE is a single statement — no read-modify-write — so it cannot
+// race with session.Finish() or session.Finalize().
+package sessionreaper
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"time"
+)
+
+// DefaultStaleThreshold is how long a session can remain in an active state
+// before the reaper considers it crashed. Generous on purpose: a legitimate
+// slow upload over a poor link still completes in minutes, not an hour.
+const DefaultStaleThreshold = 1 * time.Hour
+
+// DefaultInterval is how often the reaper sweeps.
+const DefaultInterval = 5 * time.Minute
+
+// Reaper periodically sweeps stale sessions in pbs_active_sessions.
+type Reaper struct {
+	db       *sql.DB
+	stale    time.Duration
+	interval time.Duration
+}
+
+// New constructs a Reaper. Zero values for stale and interval use the defaults.
+func New(db *sql.DB, stale, interval time.Duration) *Reaper {
+	if stale == 0 {
+		stale = DefaultStaleThreshold
+	}
+	if interval == 0 {
+		interval = DefaultInterval
+	}
+	return &Reaper{db: db, stale: stale, interval: interval}
+}
+
+// Run blocks until ctx is cancelled, sweeping at the configured interval.
+// It sweeps once immediately on start to catch sessions left over from a
+// previous process crash. Errors from individual sweeps are logged but do
+// not abort the loop.
+func (r *Reaper) Run(ctx context.Context) {
+	slog.Info("session reaper started",
+		"stale_threshold", r.stale,
+		"interval", r.interval,
+	)
+
+	r.sweep(ctx)
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("session reaper stopped")
+			return
+		case <-ticker.C:
+			r.sweep(ctx)
+		}
+	}
+}
+
+func (r *Reaper) sweep(ctx context.Context) {
+	n, err := r.SweepOnce(ctx)
+	if err != nil {
+		slog.Warn("session reaper sweep failed", "error", err)
+		return
+	}
+	if n > 0 {
+		slog.Info("session reaper aborted stale sessions", "count", n)
+	}
+}
+
+// SweepOnce runs one sweep, marking sessions older than the stale threshold
+// as 'aborted'. Returns the number of rows affected.
+//
+// Only 'backup' and 'reader' rows are touched — 'finished' and 'aborted'
+// rows are left unchanged.
+func (r *Reaper) SweepOnce(ctx context.Context) (int64, error) {
+	cutoff := time.Now().Add(-r.stale).UnixMilli()
+	const q = `
+		UPDATE pbs_active_sessions
+		SET state = 'aborted'
+		WHERE state IN ('backup', 'reader')
+		  AND started_at < ?
+	`
+	res, err := r.db.ExecContext(ctx, q, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}

--- a/services/backupos-pbs/internal/sessionreaper/reaper_test.go
+++ b/services/backupos-pbs/internal/sessionreaper/reaper_test.go
@@ -1,0 +1,245 @@
+package sessionreaper
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE pbs_active_sessions (
+			id           TEXT PRIMARY KEY,
+			token_id     TEXT,
+			datastore_id TEXT,
+			backup_type  TEXT NOT NULL,
+			backup_id    TEXT NOT NULL,
+			backup_time  INTEGER NOT NULL,
+			started_at   INTEGER NOT NULL,
+			state        TEXT NOT NULL,
+			scratch_path TEXT
+		)
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func insertSession(t *testing.T, db *sql.DB, id, state string, startedAt time.Time) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO pbs_active_sessions
+		 (id, token_id, datastore_id, backup_type, backup_id, backup_time, started_at, state)
+		 VALUES (?, '', '', 'vm', '100', 0, ?, ?)`,
+		id, startedAt.UnixMilli(), state,
+	)
+	if err != nil {
+		t.Fatalf("insertSession %s: %v", id, err)
+	}
+}
+
+func getState(t *testing.T, db *sql.DB, id string) string {
+	t.Helper()
+	var state string
+	err := db.QueryRow(`SELECT state FROM pbs_active_sessions WHERE id = ?`, id).Scan(&state)
+	if err != nil {
+		t.Fatalf("getState %s: %v", id, err)
+	}
+	return state
+}
+
+func newReaper(db *sql.DB, stale time.Duration) *Reaper {
+	return New(db, stale, DefaultInterval)
+}
+
+func TestSweepOnce_NoStaleSessions_NoChange(t *testing.T) {
+	db := setupDB(t)
+	insertSession(t, db, "s1", "backup", time.Now().Add(-30*time.Minute))
+
+	r := newReaper(db, DefaultStaleThreshold)
+	n, err := r.SweepOnce(context.Background())
+	if err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("rows affected: got %d, want 0", n)
+	}
+	if got := getState(t, db, "s1"); got != "backup" {
+		t.Errorf("state: got %q, want backup", got)
+	}
+}
+
+func TestSweepOnce_OldBackupSession_Aborted(t *testing.T) {
+	db := setupDB(t)
+	insertSession(t, db, "s1", "backup", time.Now().Add(-2*time.Hour))
+
+	r := newReaper(db, DefaultStaleThreshold)
+	n, err := r.SweepOnce(context.Background())
+	if err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("rows affected: got %d, want 1", n)
+	}
+	if got := getState(t, db, "s1"); got != "aborted" {
+		t.Errorf("state: got %q, want aborted", got)
+	}
+}
+
+func TestSweepOnce_OldReaderSession_Aborted(t *testing.T) {
+	db := setupDB(t)
+	insertSession(t, db, "s1", "reader", time.Now().Add(-2*time.Hour))
+
+	r := newReaper(db, DefaultStaleThreshold)
+	n, err := r.SweepOnce(context.Background())
+	if err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("rows affected: got %d, want 1", n)
+	}
+	if got := getState(t, db, "s1"); got != "aborted" {
+		t.Errorf("state: got %q, want aborted", got)
+	}
+}
+
+func TestSweepOnce_FinishedSession_NotTouched(t *testing.T) {
+	db := setupDB(t)
+	insertSession(t, db, "s1", "finished", time.Now().Add(-2*time.Hour))
+
+	r := newReaper(db, DefaultStaleThreshold)
+	n, err := r.SweepOnce(context.Background())
+	if err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("rows affected: got %d, want 0", n)
+	}
+	if got := getState(t, db, "s1"); got != "finished" {
+		t.Errorf("state: got %q, want finished", got)
+	}
+}
+
+func TestSweepOnce_AbortedSession_NotTouched(t *testing.T) {
+	db := setupDB(t)
+	insertSession(t, db, "s1", "aborted", time.Now().Add(-2*time.Hour))
+
+	r := newReaper(db, DefaultStaleThreshold)
+	n, err := r.SweepOnce(context.Background())
+	if err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("rows affected: got %d, want 0", n)
+	}
+	if got := getState(t, db, "s1"); got != "aborted" {
+		t.Errorf("state unchanged: got %q", got)
+	}
+}
+
+func TestSweepOnce_RecentSession_NotTouched(t *testing.T) {
+	db := setupDB(t)
+	insertSession(t, db, "s1", "backup", time.Now().Add(-30*time.Minute))
+
+	r := newReaper(db, 1*time.Hour)
+	n, err := r.SweepOnce(context.Background())
+	if err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("rows affected: got %d, want 0", n)
+	}
+	if got := getState(t, db, "s1"); got != "backup" {
+		t.Errorf("state: got %q, want backup", got)
+	}
+}
+
+func TestSweepOnce_MultipleStale_AllAborted(t *testing.T) {
+	db := setupDB(t)
+	// 3 stale active, 1 recent active, 1 finished old.
+	insertSession(t, db, "old1", "backup", time.Now().Add(-2*time.Hour))
+	insertSession(t, db, "old2", "backup", time.Now().Add(-3*time.Hour))
+	insertSession(t, db, "old3", "reader", time.Now().Add(-90*time.Minute))
+	insertSession(t, db, "fresh", "backup", time.Now().Add(-10*time.Minute))
+	insertSession(t, db, "done", "finished", time.Now().Add(-4*time.Hour))
+
+	r := newReaper(db, 1*time.Hour)
+	n, err := r.SweepOnce(context.Background())
+	if err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("rows affected: got %d, want 3", n)
+	}
+	for _, id := range []string{"old1", "old2", "old3"} {
+		if got := getState(t, db, id); got != "aborted" {
+			t.Errorf("%s: got %q, want aborted", id, got)
+		}
+	}
+	if got := getState(t, db, "fresh"); got != "backup" {
+		t.Errorf("fresh: got %q, want backup", got)
+	}
+	if got := getState(t, db, "done"); got != "finished" {
+		t.Errorf("done: got %q, want finished", got)
+	}
+}
+
+func TestRun_StopsOnContextCancel(t *testing.T) {
+	db := setupDB(t)
+	r := New(db, DefaultStaleThreshold, 10*time.Second) // long interval so only initial sweep runs
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		r.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Run did not stop within 100ms of context cancellation")
+	}
+}
+
+func TestRun_RunsAtInterval(t *testing.T) {
+	db := setupDB(t)
+	// Use a very short interval (10ms) and count how many sweeps run in ~80ms.
+	sweepCount := 0
+	// We can't inject a counter directly, so we use a tiny stale threshold
+	// and insert + re-insert to observe multiple sweeps.
+	// Easier: just verify Run doesn't panic and completes sweeps by checking
+	// that a stale session inserted before Run starts gets aborted.
+	insertSession(t, db, "s1", "backup", time.Now().Add(-2*time.Hour))
+
+	r := New(db, DefaultStaleThreshold, 10*time.Millisecond)
+	_ = sweepCount
+
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		r.Run(ctx)
+		close(done)
+	}()
+
+	<-done
+
+	if got := getState(t, db, "s1"); got != "aborted" {
+		t.Errorf("s1: got %q, want aborted after reaper ran", got)
+	}
+}


### PR DESCRIPTION
## Summary

- **`internal/sessionreaper`**: Periodic goroutine that sweeps `pbs_active_sessions` rows stuck in `'backup'` or `'reader'` state past a configurable threshold (default 1h). Crashed HTTP clients leave rows that poison GC's `OldestActiveStartedAt` safety extension indefinitely.
- **`cmd/backupos-pbs/main.go`**: Plumbs a `serverCtx` (cancelled on SIGINT/SIGTERM) through main so the reaper stops cleanly. Reaper starts with `go reaper.Run(serverCtx)` immediately after the DB is opened.

## Key design decisions

- **Single `UPDATE` statement** — no read-modify-write, cannot race with `Finish()` or `Finalize()`
- **Sweeps immediately on start** — catches sessions orphaned by a previous process crash before any client connects
- **Generous threshold (1h)** — legitimate slow uploads complete in minutes; a session idle for an hour is almost certainly dead
- **Only touches `'backup'` and `'reader'`** — `'finished'` and `'aborted'` rows are never modified

## Test plan

- [ ] `go mod tidy && go build ./cmd/backupos-pbs` — build clean
- [ ] `go test ./internal/sessionreaper/...` — all 9 tests pass
- [ ] `go test ./...` — full suite still green
- [ ] Specifically: `TestSweepOnce_OldBackupSession_Aborted`, `TestSweepOnce_FinishedSession_NotTouched`, `TestSweepOnce_RecentSession_NotTouched`, `TestRun_StopsOnContextCancel`

> Auto-merge intentionally NOT set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)