### PR TITLE
feat(pbs): auth hardening — token datastore scoping + last_used_at tracking

### DIFF
--- a/services/backupos-pbs/internal/auth/auth.go
+++ b/services/backupos-pbs/internal/auth/auth.go
@@ -14,17 +14,19 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 )
 
 // Identity is the result of a successful auth.
 type Identity struct {
-	TokenID     string
-	User        string
-	Realm       string
-	TokenName   string
-	Permissions string
+	TokenID          string
+	User             string
+	Realm            string
+	TokenName        string
+	Permissions      string
+	TokenDatastoreID string // empty = unrestricted; non-empty = token scoped to this datastore ID
 }
 
 // ParsedHeader is the result of parsing the Authorization header.
@@ -125,7 +127,7 @@ func NewValidator(db *sql.DB) *Validator {
 // errors are distinct here for logging purposes.
 func (v *Validator) Validate(parsed *ParsedHeader) (*Identity, error) {
 	const query = `
-		SELECT id, secret_hash, permissions, expires_at
+		SELECT id, secret_hash, permissions, expires_at, datastore_id
 		FROM pbs_tokens
 		WHERE user = ? AND realm = ? AND token_name = ?
 		LIMIT 1
@@ -135,9 +137,10 @@ func (v *Validator) Validate(parsed *ParsedHeader) (*Identity, error) {
 		storedHash      string
 		permissions     string
 		expiresAtMillis sql.NullInt64
+		datastoreID     sql.NullString
 	)
 	err := v.db.QueryRow(query, parsed.User, parsed.Realm, parsed.TokenName).
-		Scan(&tokenID, &storedHash, &permissions, &expiresAtMillis)
+		Scan(&tokenID, &storedHash, &permissions, &expiresAtMillis, &datastoreID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrTokenNotFound
 	}
@@ -159,12 +162,21 @@ func (v *Validator) Validate(parsed *ParsedHeader) (*Identity, error) {
 		}
 	}
 
+	// Non-fatal: record the time this token was last used.
+	if _, err := v.db.Exec(
+		`UPDATE pbs_tokens SET last_used_at = ? WHERE id = ?`,
+		time.Now().UnixMilli(), tokenID,
+	); err != nil {
+		slog.Warn("failed to update last_used_at", "token_id", tokenID, "error", err)
+	}
+
 	return &Identity{
-		TokenID:     tokenID,
-		User:        parsed.User,
-		Realm:       parsed.Realm,
-		TokenName:   parsed.TokenName,
-		Permissions: permissions,
+		TokenID:          tokenID,
+		User:             parsed.User,
+		Realm:            parsed.Realm,
+		TokenName:        parsed.TokenName,
+		Permissions:      permissions,
+		TokenDatastoreID: datastoreID.String,
 	}, nil
 }
 

--- a/services/backupos-pbs/internal/auth/authorize.go
+++ b/services/backupos-pbs/internal/auth/authorize.go
@@ -1,0 +1,24 @@
+package auth
+
+import "errors"
+
+// ErrDatastoreNotAuthorized is returned by AuthorizeDatastore when the token
+// is scoped to a different datastore than the one being accessed.
+var ErrDatastoreNotAuthorized = errors.New("token not authorized for this datastore")
+
+// AuthorizeDatastore checks whether id is allowed to access datastoreID.
+// A nil identity returns ErrDatastoreNotAuthorized.
+// An empty TokenDatastoreID means the token is unrestricted.
+// A non-empty TokenDatastoreID must match datastoreID exactly.
+func AuthorizeDatastore(id *Identity, datastoreID string) error {
+	if id == nil {
+		return ErrDatastoreNotAuthorized
+	}
+	if id.TokenDatastoreID == "" {
+		return nil
+	}
+	if id.TokenDatastoreID == datastoreID {
+		return nil
+	}
+	return ErrDatastoreNotAuthorized
+}

--- a/services/backupos-pbs/internal/auth/authorize_test.go
+++ b/services/backupos-pbs/internal/auth/authorize_test.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAuthorizeDatastore_NilIdentity_Denied(t *testing.T) {
+	err := AuthorizeDatastore(nil, "ds-1")
+	if !errors.Is(err, ErrDatastoreNotAuthorized) {
+		t.Errorf("expected ErrDatastoreNotAuthorized, got %v", err)
+	}
+}
+
+func TestAuthorizeDatastore_EmptyTokenDatastoreID_Unrestricted(t *testing.T) {
+	id := &Identity{TokenID: "tok", TokenDatastoreID: ""}
+	if err := AuthorizeDatastore(id, "ds-1"); err != nil {
+		t.Errorf("expected nil for unrestricted token, got %v", err)
+	}
+}
+
+func TestAuthorizeDatastore_MatchingDatastoreID_Allowed(t *testing.T) {
+	id := &Identity{TokenID: "tok", TokenDatastoreID: "ds-1"}
+	if err := AuthorizeDatastore(id, "ds-1"); err != nil {
+		t.Errorf("expected nil for matching datastore, got %v", err)
+	}
+}
+
+func TestAuthorizeDatastore_NonMatchingDatastoreID_Denied(t *testing.T) {
+	id := &Identity{TokenID: "tok", TokenDatastoreID: "ds-1"}
+	err := AuthorizeDatastore(id, "ds-2")
+	if !errors.Is(err, ErrDatastoreNotAuthorized) {
+		t.Errorf("expected ErrDatastoreNotAuthorized, got %v", err)
+	}
+}

--- a/services/backupos-pbs/internal/auth/validator_test.go
+++ b/services/backupos-pbs/internal/auth/validator_test.go
@@ -24,13 +24,15 @@ func setupTestDB(t *testing.T) *sql.DB {
 
 	_, err = db.Exec(`
 		CREATE TABLE pbs_tokens (
-			id          TEXT PRIMARY KEY,
-			user        TEXT NOT NULL,
-			realm       TEXT NOT NULL,
-			token_name  TEXT NOT NULL,
-			secret_hash TEXT NOT NULL,
-			permissions TEXT NOT NULL,
-			expires_at  INTEGER
+			id            TEXT PRIMARY KEY,
+			user          TEXT NOT NULL,
+			realm         TEXT NOT NULL,
+			token_name    TEXT NOT NULL,
+			secret_hash   TEXT NOT NULL,
+			permissions   TEXT NOT NULL,
+			expires_at    INTEGER,
+			datastore_id  TEXT,
+			last_used_at  INTEGER
 		);
 	`)
 	if err != nil {
@@ -105,6 +107,72 @@ func TestValidator_SecretMismatch(t *testing.T) {
 	_, err := v.Validate(parsed)
 	if !errors.Is(err, ErrSecretMismatch) {
 		t.Errorf("expected ErrSecretMismatch, got %v", err)
+	}
+}
+
+func TestValidator_DatastoreID_Null_IsUnrestricted(t *testing.T) {
+	db := setupTestDB(t)
+	v := NewValidator(db)
+
+	parsed := &ParsedHeader{User: "root", Realm: "pbs", TokenName: "test1", Secret: "topsecret"}
+	id, err := v.Validate(parsed)
+	if err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+	if id.TokenDatastoreID != "" {
+		t.Errorf("expected empty TokenDatastoreID for NULL db row, got %q", id.TokenDatastoreID)
+	}
+}
+
+func TestValidator_DatastoreID_NonNull_IsSet(t *testing.T) {
+	db := setupTestDB(t)
+	_, err := db.Exec(`UPDATE pbs_tokens SET datastore_id = 'ds-abc' WHERE id = 'test-id-1'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v := NewValidator(db)
+	parsed := &ParsedHeader{User: "root", Realm: "pbs", TokenName: "test1", Secret: "topsecret"}
+	id, err := v.Validate(parsed)
+	if err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+	if id.TokenDatastoreID != "ds-abc" {
+		t.Errorf("expected TokenDatastoreID %q, got %q", "ds-abc", id.TokenDatastoreID)
+	}
+}
+
+func TestValidator_LastUsedAt_SetOnSuccess(t *testing.T) {
+	db := setupTestDB(t)
+	v := NewValidator(db)
+
+	parsed := &ParsedHeader{User: "root", Realm: "pbs", TokenName: "test1", Secret: "topsecret"}
+	if _, err := v.Validate(parsed); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	var lastUsed *int64
+	if err := db.QueryRow(`SELECT last_used_at FROM pbs_tokens WHERE id = 'test-id-1'`).Scan(&lastUsed); err != nil {
+		t.Fatal(err)
+	}
+	if lastUsed == nil {
+		t.Error("expected last_used_at to be set after successful Validate")
+	}
+}
+
+func TestValidator_LastUsedAt_NotSetOnBadSecret(t *testing.T) {
+	db := setupTestDB(t)
+	v := NewValidator(db)
+
+	parsed := &ParsedHeader{User: "root", Realm: "pbs", TokenName: "test1", Secret: "wrong"}
+	_, _ = v.Validate(parsed)
+
+	var lastUsed *int64
+	if err := db.QueryRow(`SELECT last_used_at FROM pbs_tokens WHERE id = 'test-id-1'`).Scan(&lastUsed); err != nil {
+		t.Fatal(err)
+	}
+	if lastUsed != nil {
+		t.Error("expected last_used_at to remain NULL after failed Validate")
 	}
 }
 

--- a/services/backupos-pbs/internal/gcadmin/gcadmin.go
+++ b/services/backupos-pbs/internal/gcadmin/gcadmin.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/dslock"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcrun"
@@ -65,6 +66,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	identity := auth.FromContext(r.Context())
+	if err := auth.AuthorizeDatastore(identity, ds.ID); err != nil {
+		writeJSONError(w, http.StatusForbidden, "token not authorized for this datastore")
 		return
 	}
 

--- a/services/backupos-pbs/internal/gcadmin/gcadmin_test.go
+++ b/services/backupos-pbs/internal/gcadmin/gcadmin_test.go
@@ -15,6 +15,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcrun"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcstatus"
@@ -76,8 +77,10 @@ func newHandler(t *testing.T, db *sql.DB, runFn func(context.Context, string, gc
 func doRequest(t *testing.T, h *Handler, method, path string) *http.Response {
 	t.Helper()
 	req := httptest.NewRequest(method, path, nil)
+	// Inject an unrestricted identity (empty TokenDatastoreID) to satisfy AuthorizeDatastore.
+	ctx := auth.WithIdentity(req.Context(), &auth.Identity{TokenID: "test-token"})
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
+	h.ServeHTTP(w, req.WithContext(ctx))
 	return w.Result()
 }
 
@@ -285,6 +288,24 @@ func TestInvalidPath_Returns400(t *testing.T) {
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Errorf("path %q: got %d, want 400", path, resp.StatusCode)
 		}
+	}
+}
+
+func TestPOST_ScopedTokenWrongDatastore_Returns403(t *testing.T) {
+	root := makeDSRoot(t)
+	db := setupDB(t, "mystore", root)
+	h := newHandler(t, db, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api2/json/admin/datastore/mystore/gc", nil)
+	ctx := auth.WithIdentity(req.Context(), &auth.Identity{
+		TokenID:          "scoped-token",
+		TokenDatastoreID: "other-ds-id",
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req.WithContext(ctx))
+	resp := w.Result()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", resp.StatusCode)
 	}
 }
 

--- a/services/backupos-pbs/internal/readerupgrade/handler.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler.go
@@ -156,6 +156,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// AuthorizeDatastore: token must be unrestricted or scoped to this datastore.
+	if err := auth.AuthorizeDatastore(identity, ds.ID); err != nil {
+		writeJSONError(w, http.StatusForbidden, "token not authorized for this datastore")
+		return
+	}
+
 	// Step 6: Resolve snapshot (must exist) and acquire shared lock.
 	snapDir, err := snapshot.ResolveDir(ds.Path, backupType, backupID, backupTime)
 	if err != nil {

--- a/services/backupos-pbs/internal/readerupgrade/handler_test.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler_test.go
@@ -40,13 +40,15 @@ func setupTestDB(t *testing.T, dsPath string) *sql.DB {
 
 	stmts := []string{
 		`CREATE TABLE pbs_tokens (
-			id          TEXT PRIMARY KEY,
-			user        TEXT NOT NULL,
-			realm       TEXT NOT NULL,
-			token_name  TEXT NOT NULL,
-			secret_hash TEXT NOT NULL,
-			permissions TEXT NOT NULL DEFAULT '',
-			expires_at  INTEGER
+			id            TEXT PRIMARY KEY,
+			user          TEXT NOT NULL,
+			realm         TEXT NOT NULL,
+			token_name    TEXT NOT NULL,
+			secret_hash   TEXT NOT NULL,
+			permissions   TEXT NOT NULL DEFAULT '',
+			expires_at    INTEGER,
+			datastore_id  TEXT,
+			last_used_at  INTEGER
 		)`,
 		`CREATE TABLE pbs_datastores (
 			id                TEXT PRIMARY KEY,
@@ -109,6 +111,39 @@ func newTestHandler(db *sql.DB) *Handler {
 
 func readerAuthHeader() string {
 	return "PBSAPIToken=root@pbs!test1:" + testSecret
+}
+
+func TestHandler_WrongDatastore_Returns403(t *testing.T) {
+	tmp := t.TempDir()
+	db := setupTestDB(t, tmp)
+
+	const scopedSecret = "scoped-secret-reader-test"
+	if _, err := db.Exec(
+		`INSERT INTO pbs_tokens (id, user, realm, token_name, secret_hash, permissions, datastore_id)
+		 VALUES ('tok-scoped', 'root', 'pbs', 'scoped', ?, '', 'other-ds-id')`,
+		auth.HashSecret(scopedSecret),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newTestHandler(db)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader"+readerQuerySfx, nil)
+	req.Header.Set("Authorization", "PBSAPIToken=root@pbs!scoped:"+scopedSecret)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", ReaderProtocolID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", resp.StatusCode)
+	}
 }
 
 func TestHandler_WrongMethod_Returns405(t *testing.T) {

--- a/services/backupos-pbs/internal/upgrade/handler.go
+++ b/services/backupos-pbs/internal/upgrade/handler.go
@@ -140,6 +140,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := auth.AuthorizeDatastore(identity, ds.ID); err != nil {
+		writeUpgradeError(w, http.StatusForbidden, "token not authorized for this datastore")
+		slog.Info("upgrade rejected: datastore not authorized",
+			"token_datastore_id", identity.TokenDatastoreID,
+			"datastore_id", ds.ID,
+			"remote", r.RemoteAddr,
+		)
+		return
+	}
+
 	kind := session.KindBackup
 	if identifyKind(r.URL.Path) == "reader" {
 		kind = session.KindReader

--- a/services/backupos-pbs/internal/upgrade/handler_test.go
+++ b/services/backupos-pbs/internal/upgrade/handler_test.go
@@ -100,6 +100,39 @@ func newTestHandler(db *sql.DB) *Handler {
 	)
 }
 
+func TestHandler_WrongDatastore_Returns403(t *testing.T) {
+	db := setupTestDB(t)
+	h := newTestHandler(db)
+
+	// Token scoped to a different datastore — test-ds-1 is the real one.
+	scoped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.WithIdentity(r.Context(), &auth.Identity{
+			TokenID:          "test-token-id",
+			User:             "root",
+			Realm:            "pbs",
+			TokenName:        "test1",
+			TokenDatastoreID: "different-ds-id",
+		})
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+
+	srv := httptest.NewServer(scoped)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/backup?store=default&backup-type=vm&backup-id=1&backup-time=1735000000", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", UpgradeToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
 func TestHandler_NoUpgradeHeaders_Returns501(t *testing.T) {
 	db := setupTestDB(t)
 	h := newTestHandler(db)


### PR DESCRIPTION
## Summary

- **TokenDatastoreID scoping**: `Validate` now SELECTs `datastore_id` from `pbs_tokens`; NULL means unrestricted, non-NULL means the token may only access that specific datastore ID. The field is surfaced as `Identity.TokenDatastoreID`.
- **`AuthorizeDatastore` helper**: new `internal/auth/authorize.go` exposes `AuthorizeDatastore(identity, datastoreID)` returning `ErrDatastoreNotAuthorized` for nil identity or scope mismatch.
- **Handler enforcement**: `upgrade`, `readerupgrade`, and `gcadmin` handlers call `AuthorizeDatastore` immediately after datastore lookup, returning **403** before any session creation, lock acquisition, or GC goroutine is spawned.
- **`last_used_at` tracking**: `Validate` performs a non-fatal `UPDATE pbs_tokens SET last_used_at = ?` on every successful validation; failure is logged at WARN and does not affect the returned `Identity`.

## Test plan

- [ ] `go test ./services/backupos-pbs/internal/auth/...` — 4 new `AuthorizeDatastore` unit tests + 4 new `Validate` tests (datastore_id population, last_used_at set/not-set)
- [ ] `go test ./services/backupos-pbs/internal/upgrade/...` — new `TestHandler_WrongDatastore_Returns403`
- [ ] `go test ./services/backupos-pbs/internal/readerupgrade/...` — new `TestHandler_WrongDatastore_Returns403`, pbs_tokens schema includes `datastore_id`/`last_used_at`
- [ ] `go test ./services/backupos-pbs/internal/gcadmin/...` — `doRequest` now injects unrestricted identity; new `TestPOST_ScopedTokenWrongDatastore_Returns403`
- [ ] `go test ./services/backupos-pbs/...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)