### PR TITLE
feat(pbs): backup group owner check (per-group user@realm ownership)

### DIFF
--- a/services/backupos-pbs/internal/owner/owner.go
+++ b/services/backupos-pbs/internal/owner/owner.go
@@ -1,0 +1,136 @@
+// Package owner manages per-backup-group ownership files.
+//
+// Each backup group has an owner file at:
+//
+//	<datastoreRoot>/<backupType>/<backupID>/owner
+//
+// File contents: <user>@<realm>\n — user-level only, no token suffix.
+// Mirrors PBS reference's owner_path layout with V1 simplification
+// (user-level ownership, no token-level granularity).
+package owner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrOwnerMismatch is returned when the requested operation's caller
+// doesn't match the existing group owner.
+var ErrOwnerMismatch = errors.New("backup group owner mismatch")
+
+// ErrInvalidOwnerFile is returned when the owner file exists but its
+// contents can't be parsed as user@realm.
+var ErrInvalidOwnerFile = errors.New("invalid owner file format")
+
+// Path returns the absolute path to the owner file for a backup group.
+//
+// Layout: <datastoreRoot>/<backupType>/<backupID>/owner
+func Path(datastoreRoot, backupType, backupID string) string {
+	return filepath.Join(datastoreRoot, backupType, backupID, "owner")
+}
+
+// Read returns the user@realm string stored in the owner file for the
+// given group. Returns os.ErrNotExist (wrapped) if the owner file
+// doesn't exist — caller decides whether that's allow-by-default
+// (V1 backcompat) or deny-by-default (future tightening).
+//
+// Returns ErrInvalidOwnerFile if the file exists but can't be parsed.
+func Read(datastoreRoot, backupType, backupID string) (string, error) {
+	path := Path(datastoreRoot, backupType, backupID)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err // includes wrapped os.ErrNotExist
+	}
+	line := strings.TrimRight(string(data), "\n")
+	if !strings.Contains(line, "@") {
+		return "", fmt.Errorf("%w: missing @ separator in %q", ErrInvalidOwnerFile, line)
+	}
+	// Disallow token name suffix in our V1 owner files.
+	if strings.Contains(line, "!") {
+		return "", fmt.Errorf("%w: V1 owner files must be user@realm without token name", ErrInvalidOwnerFile)
+	}
+	return line, nil
+}
+
+// SetIfAbsent writes the owner file atomically if it doesn't exist.
+// Returns nil if the file was created OR if it already exists with the
+// SAME contents (idempotent for the original owner).
+//
+// Returns ErrOwnerMismatch if the file exists with DIFFERENT contents
+// (a different user is trying to write to a group they don't own).
+//
+// The atomic write is: create owner.tmp, write contents+newline, fsync,
+// rename to owner. A crash mid-write leaves owner.tmp orphaned but no
+// corrupt owner file.
+func SetIfAbsent(datastoreRoot, backupType, backupID, userRealm string) error {
+	if !strings.Contains(userRealm, "@") {
+		return fmt.Errorf("%w: %q is not user@realm", ErrInvalidOwnerFile, userRealm)
+	}
+	if strings.Contains(userRealm, "!") {
+		return fmt.Errorf("%w: must not include token name", ErrInvalidOwnerFile)
+	}
+
+	groupDir := filepath.Join(datastoreRoot, backupType, backupID)
+	if err := os.MkdirAll(groupDir, 0o755); err != nil {
+		return fmt.Errorf("create group dir: %w", err)
+	}
+
+	ownerPath := filepath.Join(groupDir, "owner")
+
+	// Try to read existing owner; if it matches, we're idempotent.
+	if existing, err := Read(datastoreRoot, backupType, backupID); err == nil {
+		if existing == userRealm {
+			return nil // already ours, nothing to do
+		}
+		return fmt.Errorf("%w: existing=%q, attempted=%q", ErrOwnerMismatch, existing, userRealm)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read existing owner: %w", err)
+	}
+
+	// Atomic write.
+	tmpPath := ownerPath + ".tmp"
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("create owner.tmp: %w", err)
+	}
+	if _, err := f.WriteString(userRealm + "\n"); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write owner.tmp: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("fsync owner.tmp: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close owner.tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, ownerPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename owner.tmp → owner: %w", err)
+	}
+	return nil
+}
+
+// Check returns nil if userRealm owns the group, ErrOwnerMismatch otherwise.
+//
+// V1 backwards-compat: if the owner file doesn't exist, returns nil
+// (allow). Future versions may flip this to deny-by-default.
+func Check(datastoreRoot, backupType, backupID, userRealm string) error {
+	existing, err := Read(datastoreRoot, backupType, backupID)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // V1: legacy groups without owner files are allowed
+		}
+		return err
+	}
+	if existing != userRealm {
+		return fmt.Errorf("%w: owner=%q, requester=%q", ErrOwnerMismatch, existing, userRealm)
+	}
+	return nil
+}

--- a/services/backupos-pbs/internal/owner/owner_test.go
+++ b/services/backupos-pbs/internal/owner/owner_test.go
@@ -1,0 +1,210 @@
+package owner
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPath_Format(t *testing.T) {
+	got := Path("/var/lib/backupos/pbs/mystore", "vm", "100")
+	want := "/var/lib/backupos/pbs/mystore/vm/100/owner"
+	if got != want {
+		t.Errorf("Path = %q, want %q", got, want)
+	}
+}
+
+func TestRead_NonExistent_ReturnsErrNotExist(t *testing.T) {
+	root := t.TempDir()
+	_, err := Read(root, "vm", "100")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected os.ErrNotExist, got %v", err)
+	}
+}
+
+func TestRead_ValidFile_ReturnsUserRealm(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "vm", "100")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("root@pbs\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Read(root, "vm", "100")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "root@pbs" {
+		t.Errorf("got %q, want %q", got, "root@pbs")
+	}
+}
+
+func TestRead_TrimsTrailingNewline(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "vm", "200")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("alice@pbs\n\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Read(root, "vm", "200")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "alice@pbs" {
+		t.Errorf("got %q, want %q", got, "alice@pbs")
+	}
+}
+
+func TestRead_NoNewline_AlsoWorks(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "ct", "42")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("root@pam"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Read(root, "ct", "42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "root@pam" {
+		t.Errorf("got %q, want %q", got, "root@pam")
+	}
+}
+
+func TestRead_InvalidFormat_ReturnsErrInvalidOwnerFile(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "vm", "300")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("not-valid-garbage\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Read(root, "vm", "300")
+	if !errors.Is(err, ErrInvalidOwnerFile) {
+		t.Errorf("expected ErrInvalidOwnerFile, got %v", err)
+	}
+}
+
+func TestRead_TokenNameInFile_Rejected(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "vm", "400")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// V1 rejects token-suffixed owner file contents.
+	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("root@pbs!alice\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Read(root, "vm", "400")
+	if !errors.Is(err, ErrInvalidOwnerFile) {
+		t.Errorf("expected ErrInvalidOwnerFile for token-suffix, got %v", err)
+	}
+}
+
+func TestSetIfAbsent_FreshGroup_WritesFile(t *testing.T) {
+	root := t.TempDir()
+	if err := SetIfAbsent(root, "vm", "500", "root@pbs"); err != nil {
+		t.Fatalf("SetIfAbsent: %v", err)
+	}
+	got, err := Read(root, "vm", "500")
+	if err != nil {
+		t.Fatalf("Read after set: %v", err)
+	}
+	if got != "root@pbs" {
+		t.Errorf("owner = %q, want %q", got, "root@pbs")
+	}
+}
+
+func TestSetIfAbsent_SameOwner_Idempotent(t *testing.T) {
+	root := t.TempDir()
+	if err := SetIfAbsent(root, "vm", "600", "root@pbs"); err != nil {
+		t.Fatalf("first SetIfAbsent: %v", err)
+	}
+	if err := SetIfAbsent(root, "vm", "600", "root@pbs"); err != nil {
+		t.Errorf("second SetIfAbsent (same owner): %v", err)
+	}
+}
+
+func TestSetIfAbsent_DifferentOwner_ReturnsErrOwnerMismatch(t *testing.T) {
+	root := t.TempDir()
+	if err := SetIfAbsent(root, "vm", "700", "root@pbs"); err != nil {
+		t.Fatalf("first SetIfAbsent: %v", err)
+	}
+	err := SetIfAbsent(root, "vm", "700", "alice@pbs")
+	if !errors.Is(err, ErrOwnerMismatch) {
+		t.Errorf("expected ErrOwnerMismatch, got %v", err)
+	}
+}
+
+func TestSetIfAbsent_AtomicWrite_NoOwnerTmpAfterSuccess(t *testing.T) {
+	root := t.TempDir()
+	if err := SetIfAbsent(root, "vm", "800", "root@pbs"); err != nil {
+		t.Fatalf("SetIfAbsent: %v", err)
+	}
+	tmpPath := Path(root, "vm", "800") + ".tmp"
+	if _, err := os.Stat(tmpPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("owner.tmp should not exist after successful write, got: %v", err)
+	}
+}
+
+func TestSetIfAbsent_RejectsTokenNameInInput(t *testing.T) {
+	root := t.TempDir()
+	err := SetIfAbsent(root, "vm", "900", "root@pbs!alice")
+	if !errors.Is(err, ErrInvalidOwnerFile) {
+		t.Errorf("expected ErrInvalidOwnerFile for token-suffix input, got %v", err)
+	}
+}
+
+func TestCheck_OwnerFileMissing_AllowsAccess(t *testing.T) {
+	root := t.TempDir()
+	// No owner file — V1 backcompat: allow.
+	if err := Check(root, "vm", "100", "root@pbs"); err != nil {
+		t.Errorf("expected nil for missing owner file (V1 backcompat), got %v", err)
+	}
+}
+
+func TestCheck_MatchingOwner_Allowed(t *testing.T) {
+	root := t.TempDir()
+	if err := SetIfAbsent(root, "vm", "100", "root@pbs"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Check(root, "vm", "100", "root@pbs"); err != nil {
+		t.Errorf("expected nil for matching owner, got %v", err)
+	}
+}
+
+func TestCheck_DifferentOwner_Denied(t *testing.T) {
+	root := t.TempDir()
+	if err := SetIfAbsent(root, "vm", "100", "root@pbs"); err != nil {
+		t.Fatal(err)
+	}
+	err := Check(root, "vm", "100", "alice@pbs")
+	if !errors.Is(err, ErrOwnerMismatch) {
+		t.Errorf("expected ErrOwnerMismatch, got %v", err)
+	}
+}
+
+func TestCheck_InvalidFile_Errors(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "vm", "100")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("garbage-no-at\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := Check(root, "vm", "100", "root@pbs")
+	if err == nil {
+		t.Error("expected error for invalid owner file, got nil")
+	}
+	if errors.Is(err, ErrOwnerMismatch) {
+		t.Error("invalid file should not produce ErrOwnerMismatch — it's ErrInvalidOwnerFile")
+	}
+}

--- a/services/backupos-pbs/internal/readerupgrade/handler.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/owner"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/rstate"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snaplock"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snapshot"
@@ -159,6 +160,25 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// AuthorizeDatastore: token must be unrestricted or scoped to this datastore.
 	if err := auth.AuthorizeDatastore(identity, ds.ID); err != nil {
 		writeJSONError(w, http.StatusForbidden, "token not authorized for this datastore")
+		return
+	}
+
+	// Owner check: requesting user must own the backup group (or no owner file exists — V1 backcompat).
+	userRealm := identity.User + "@" + identity.Realm
+	if err := owner.Check(ds.Path, backupType, backupID, userRealm); err != nil {
+		if errors.Is(err, owner.ErrOwnerMismatch) {
+			slog.Info("reader rejected: backup group owner mismatch",
+				"user", userRealm,
+				"datastore_id", ds.ID,
+				"backup_type", backupType,
+				"backup_id", backupID,
+				"remote", r.RemoteAddr,
+			)
+			writeJSONError(w, http.StatusForbidden, "backup group owned by a different user")
+			return
+		}
+		slog.Error("owner check failed", "error", err, "datastore_id", ds.ID)
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
 

--- a/services/backupos-pbs/internal/readerupgrade/handler_test.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler_test.go
@@ -146,6 +146,153 @@ func TestHandler_WrongDatastore_Returns403(t *testing.T) {
 	}
 }
 
+func TestReader_OwnerMatches_Allowed(t *testing.T) {
+	tmp := t.TempDir()
+	makeSnapDir(t, tmp)
+	db := setupTestDB(t, tmp)
+
+	// Write owner file as root@pbs — matches the test token's user@realm.
+	groupDir := filepath.Join(tmp, "vm", "100")
+	if err := os.WriteFile(filepath.Join(groupDir, "owner"), []byte("root@pbs\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newTestHandler(db)
+	srv := httptest.NewUnstartedServer(h)
+	srv.EnableHTTP2 = false
+	srv.StartTLS()
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "https://")
+	certPool := x509.NewCertPool()
+	certPool.AddCert(srv.Certificate())
+
+	tlsConn, err := tls.Dial("tcp", host, &tls.Config{RootCAs: certPool, NextProtos: []string{"http/1.1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tlsConn.Close()
+	_ = tlsConn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	req := "GET /api2/json/reader" + readerQuerySfx + " HTTP/1.1\r\n" +
+		"Host: " + host + "\r\n" +
+		"Authorization: " + readerAuthHeader() + "\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Upgrade: " + ReaderProtocolID + "\r\n" +
+		"\r\n"
+	if _, err := tlsConn.Write([]byte(req)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	got := []byte{}
+	deadline := time.Now().Add(5 * time.Second)
+	for !strings.Contains(string(got), "\r\n\r\n") {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out reading response; got: %q", got)
+		}
+		n, readErr := tlsConn.Read(buf)
+		if n > 0 {
+			got = append(got, buf[:n]...)
+		}
+		if readErr != nil {
+			break
+		}
+	}
+	headers, _, _ := strings.Cut(string(got), "\r\n\r\n")
+	if !strings.HasPrefix(headers, "HTTP/1.1 101") {
+		t.Errorf("expected 101 for matching owner, got:\n%s", headers)
+	}
+}
+
+func TestReader_OwnerMismatch_Returns403(t *testing.T) {
+	tmp := t.TempDir()
+	db := setupTestDB(t, tmp)
+
+	// Write owner file as alice@pbs — does NOT match root@pbs test token.
+	// MkdirAll is required because makeSnapDir is not called here.
+	groupDir := filepath.Join(tmp, "vm", "100")
+	if err := os.MkdirAll(groupDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(groupDir, "owner"), []byte("alice@pbs\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newTestHandler(db)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader"+readerQuerySfx, nil)
+	req.Header.Set("Authorization", readerAuthHeader())
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", ReaderProtocolID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for owner mismatch, got %d", resp.StatusCode)
+	}
+}
+
+func TestReader_LegacyGroup_NoOwnerFile_Allowed(t *testing.T) {
+	tmp := t.TempDir()
+	makeSnapDir(t, tmp)
+	db := setupTestDB(t, tmp)
+
+	// No owner file written — V1 backcompat: should allow.
+	h := newTestHandler(db)
+	srv := httptest.NewUnstartedServer(h)
+	srv.EnableHTTP2 = false
+	srv.StartTLS()
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "https://")
+	certPool := x509.NewCertPool()
+	certPool.AddCert(srv.Certificate())
+
+	tlsConn, err := tls.Dial("tcp", host, &tls.Config{RootCAs: certPool, NextProtos: []string{"http/1.1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tlsConn.Close()
+	_ = tlsConn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	req := "GET /api2/json/reader" + readerQuerySfx + " HTTP/1.1\r\n" +
+		"Host: " + host + "\r\n" +
+		"Authorization: " + readerAuthHeader() + "\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Upgrade: " + ReaderProtocolID + "\r\n" +
+		"\r\n"
+	if _, err := tlsConn.Write([]byte(req)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	got := []byte{}
+	deadline := time.Now().Add(5 * time.Second)
+	for !strings.Contains(string(got), "\r\n\r\n") {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out reading response; got: %q", got)
+		}
+		n, readErr := tlsConn.Read(buf)
+		if n > 0 {
+			got = append(got, buf[:n]...)
+		}
+		if readErr != nil {
+			break
+		}
+	}
+	headers, _, _ := strings.Cut(string(got), "\r\n\r\n")
+	if !strings.HasPrefix(headers, "HTTP/1.1 101") {
+		t.Errorf("expected 101 for legacy group (no owner file), got:\n%s", headers)
+	}
+}
+
 func TestHandler_WrongMethod_Returns405(t *testing.T) {
 	tmp := t.TempDir()
 	db := setupTestDB(t, tmp)

--- a/services/backupos-pbs/internal/upgrade/handler.go
+++ b/services/backupos-pbs/internal/upgrade/handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/owner"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
@@ -147,6 +148,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"datastore_id", ds.ID,
 			"remote", r.RemoteAddr,
 		)
+		return
+	}
+
+	userRealm := identity.User + "@" + identity.Realm
+	if err := owner.SetIfAbsent(ds.Path, string(params.BackupType), params.BackupID, userRealm); err != nil {
+		if errors.Is(err, owner.ErrOwnerMismatch) {
+			slog.Info("upgrade rejected: backup group owner mismatch",
+				"user", userRealm,
+				"datastore_id", ds.ID,
+				"backup_type", params.BackupType,
+				"backup_id", params.BackupID,
+				"remote", r.RemoteAddr,
+			)
+			writeUpgradeError(w, http.StatusForbidden, "backup group owned by a different user")
+			return
+		}
+		slog.Error("set owner failed", "error", err, "datastore_id", ds.ID)
+		writeUpgradeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
 

--- a/services/backupos-pbs/internal/upgrade/handler_test.go
+++ b/services/backupos-pbs/internal/upgrade/handler_test.go
@@ -4,8 +4,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -65,6 +68,87 @@ func setupTestDB(t *testing.T) *sql.DB {
 		t.Fatal(err)
 	}
 	return db
+}
+
+func setupTestDBAtPath(t *testing.T, dsPath string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(`
+		CREATE TABLE pbs_datastores (
+			id           TEXT PRIMARY KEY,
+			name         TEXT NOT NULL UNIQUE,
+			path         TEXT NOT NULL,
+			created_at   INTEGER NOT NULL,
+			prune_schedule TEXT, gc_schedule TEXT, last_gc_at INTEGER,
+			total_size_bytes INTEGER, unique_size_bytes INTEGER, chunk_count INTEGER
+		);
+		CREATE TABLE pbs_active_sessions (
+			id            TEXT PRIMARY KEY,
+			token_id      TEXT,
+			datastore_id  TEXT,
+			backup_type   TEXT NOT NULL,
+			backup_id     TEXT NOT NULL,
+			backup_time   INTEGER NOT NULL,
+			started_at    INTEGER NOT NULL,
+			state         TEXT NOT NULL,
+			scratch_path  TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO pbs_datastores (id, name, path, created_at) VALUES ('test-ds-1', 'default', ?, 1735000000000)`,
+		dsPath,
+	); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+// do101 sends a raw HTTP/1.1 upgrade request to addr and reads until it
+// receives the complete 101 response header block. Returns the header text.
+func do101(t *testing.T, addr, host, query string) string {
+	t.Helper()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	req := "GET " + query + " HTTP/1.1\r\n" +
+		"Host: " + host + "\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Upgrade: " + UpgradeToken + "\r\n" +
+		"\r\n"
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	got := []byte{}
+	deadline := time.Now().Add(5 * time.Second)
+	for !strings.Contains(string(got), "\r\n\r\n") {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out reading response; got: %q", got)
+		}
+		n, readErr := conn.Read(buf)
+		if n > 0 {
+			got = append(got, buf[:n]...)
+		}
+		if readErr != nil {
+			break
+		}
+	}
+	headers, _, _ := strings.Cut(string(got), "\r\n\r\n")
+	return headers
 }
 
 // wrapWithTestIdentity injects a synthetic auth.Identity into the request
@@ -130,6 +214,113 @@ func TestHandler_WrongDatastore_Returns403(t *testing.T) {
 
 	if resp.StatusCode != http.StatusForbidden {
 		t.Errorf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpgrade_NewGroup_WritesOwnerFile(t *testing.T) {
+	tmp := t.TempDir()
+	db := setupTestDBAtPath(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewServer(wrapWithTestIdentity(h))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	headers := do101(t, host, host, "/api2/json/backup?store=default&backup-type=vm&backup-id=999&backup-time=1735000000")
+
+	if !strings.HasPrefix(headers, "HTTP/1.1 101") {
+		t.Fatalf("expected 101, got:\n%s", headers)
+	}
+
+	ownerPath := filepath.Join(tmp, "vm", "999", "owner")
+	data, err := os.ReadFile(ownerPath)
+	if err != nil {
+		t.Fatalf("owner file not written: %v", err)
+	}
+	if got := strings.TrimRight(string(data), "\n"); got != "root@pbs" {
+		t.Errorf("owner file contents: got %q, want %q", got, "root@pbs")
+	}
+}
+
+func TestUpgrade_SameUserSameGroup_AllowedIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Pre-create owner file as root@pbs (same user who will back up).
+	groupDir := filepath.Join(tmp, "vm", "999")
+	if err := os.MkdirAll(groupDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(groupDir, "owner"), []byte("root@pbs\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	db := setupTestDBAtPath(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewServer(wrapWithTestIdentity(h))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	headers := do101(t, host, host, "/api2/json/backup?store=default&backup-type=vm&backup-id=999&backup-time=1735000000")
+
+	if !strings.HasPrefix(headers, "HTTP/1.1 101") {
+		t.Errorf("expected 101 for same-owner re-backup, got:\n%s", headers)
+	}
+
+	// Owner file must be unchanged.
+	data, err := os.ReadFile(filepath.Join(groupDir, "owner"))
+	if err != nil {
+		t.Fatalf("owner file missing: %v", err)
+	}
+	if got := strings.TrimRight(string(data), "\n"); got != "root@pbs" {
+		t.Errorf("owner file changed: got %q, want %q", got, "root@pbs")
+	}
+}
+
+func TestUpgrade_DifferentUser_Returns403(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Pre-create owner file as alice@pbs (different from root@pbs who will attempt backup).
+	groupDir := filepath.Join(tmp, "vm", "999")
+	if err := os.MkdirAll(groupDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(groupDir, "owner"), []byte("alice@pbs\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	db := setupTestDBAtPath(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewServer(wrapWithTestIdentity(h)) // wrapWithTestIdentity uses root@pbs
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/backup?store=default&backup-type=vm&backup-id=999&backup-time=1735000000", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", UpgradeToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for owner mismatch, got %d", resp.StatusCode)
+	}
+
+	// No session row should have been inserted.
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pbs_active_sessions`).Scan(&count); err != nil {
+		t.Fatalf("session count query: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected no session rows, got %d", count)
+	}
+
+	// Owner file must be unchanged.
+	data, _ := os.ReadFile(filepath.Join(groupDir, "owner"))
+	if got := strings.TrimRight(string(data), "\n"); got != "alice@pbs" {
+		t.Errorf("owner file was modified: got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **`internal/owner` package** (new): manages `<datastoreRoot>/<backupType>/<backupID>/owner` files. `SetIfAbsent` writes atomically (tmp+rename+fsync) on first access; `Check` reads and compares. V1 simplification: user-level ownership only (`user@realm`, no token suffix). 15 unit tests covering all edge cases including idempotency, mismatch, atomic write proof, and legacy backcompat path.
- **Upgrade handler** (backup writer): calls `owner.SetIfAbsent` at session begin, after `AuthorizeDatastore`, before `session.Begin`. Fresh group → owner file written; same user → idempotent; different user → **403**, no session row inserted.
- **ReaderUpgrade handler**: calls `owner.Check` after datastore lookup and `AuthorizeDatastore`, before snapshot resolve. Match → proceed; mismatch → **403**; missing owner file → **allow** (V1 backcompat for existing groups).

## Test plan

- [ ] `go test ./services/backupos-pbs/internal/owner/...` — 15 unit tests (Path, Read, SetIfAbsent, Check variants)
- [ ] `go test ./services/backupos-pbs/internal/upgrade/...` — `TestUpgrade_NewGroup_WritesOwnerFile`, `TestUpgrade_SameUserSameGroup_AllowedIdempotent`, `TestUpgrade_DifferentUser_Returns403`
- [ ] `go test ./services/backupos-pbs/internal/readerupgrade/...` — `TestReader_OwnerMatches_Allowed`, `TestReader_OwnerMismatch_Returns403`, `TestReader_LegacyGroup_NoOwnerFile_Allowed`
- [ ] `go test ./services/backupos-pbs/...` — full suite green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)