### PR TITLE
feat(pbs): persist GC task results to .gc-status file per datastore

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -133,7 +133,15 @@ func main() {
 		readchunk.NewHandler(),
 	)
 
-	gcTracker := gctask.NewTracker()
+	datastoreRoots := make(map[string]string)
+	if allDS, err := datastoreLookup.All(); err != nil {
+		logger.Warn("could not load datastores for GC tracker hydration", "error", err)
+	} else {
+		for _, ds := range allDS {
+			datastoreRoots[ds.ID] = ds.Path
+		}
+	}
+	gcTracker := gctask.NewTracker(gctask.FilePersister{}, datastoreRoots)
 	oldestActiveWriter := gcrun.OldestActiveWriterFunc(func(ctx context.Context) (time.Time, error) {
 		return sessionStore.OldestActiveStartedAt(ctx)
 	})

--- a/services/backupos-pbs/internal/datastore/datastore.go
+++ b/services/backupos-pbs/internal/datastore/datastore.go
@@ -57,6 +57,32 @@ func NewLookup(db *sql.DB) *Lookup {
 	return &Lookup{db: db}
 }
 
+// All returns every datastore in the table. Used during startup to build
+// the per-datastore-ID root map for GC tracker hydration.
+func (l *Lookup) All() ([]*Datastore, error) {
+	const query = `SELECT id, name, path, created_at FROM pbs_datastores`
+	rows, err := l.db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("list datastores: %w", err)
+	}
+	defer rows.Close()
+	var dss []*Datastore
+	for rows.Next() {
+		var id, name, path string
+		var createdMilli int64
+		if err := rows.Scan(&id, &name, &path, &createdMilli); err != nil {
+			return nil, fmt.Errorf("scan datastore: %w", err)
+		}
+		dss = append(dss, &Datastore{
+			ID:        id,
+			Name:      name,
+			Path:      path,
+			CreatedAt: time.UnixMilli(createdMilli),
+		})
+	}
+	return dss, rows.Err()
+}
+
 // ByName returns the datastore matching the given name.
 //
 // Returns ErrInvalidName if the name doesn't match the expected format,

--- a/services/backupos-pbs/internal/gcadmin/gcadmin.go
+++ b/services/backupos-pbs/internal/gcadmin/gcadmin.go
@@ -106,12 +106,12 @@ func (h *Handler) startGC(w http.ResponseWriter, ds *datastore.Datastore) {
 			if errors.Is(runErr, dslock.ErrGCBusy) {
 				slog.Warn("gc raced with external dslock holder", "task_id", taskID, "datastore_id", dsID)
 			}
-			h.tracker.Fail(taskID, runErr)
+			h.tracker.Fail(dsID, dsRoot, taskID, runErr)
 			slog.Info("gc failed", "task_id", taskID, "datastore_id", dsID, "error", runErr.Error())
 			return
 		}
 
-		h.tracker.Succeed(taskID, status, nil)
+		h.tracker.Succeed(dsID, dsRoot, taskID, status)
 		slog.Info("gc succeeded",
 			"task_id", taskID,
 			"datastore_id", dsID,

--- a/services/backupos-pbs/internal/gcadmin/gcadmin_test.go
+++ b/services/backupos-pbs/internal/gcadmin/gcadmin_test.go
@@ -67,7 +67,7 @@ func noWriter(_ context.Context) (time.Time, error) { return time.Time{}, nil }
 
 func newHandler(t *testing.T, db *sql.DB, runFn func(context.Context, string, gcrun.OldestActiveWriterFunc) (*gcstatus.Status, error)) *Handler {
 	t.Helper()
-	h := NewHandler(datastore.NewLookup(db), gctask.NewTracker(), noWriter)
+	h := NewHandler(datastore.NewLookup(db), gctask.NewTracker(nil, nil), noWriter)
 	if runFn != nil {
 		h.runFn = runFn
 	}
@@ -288,6 +288,63 @@ func TestInvalidPath_Returns400(t *testing.T) {
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Errorf("path %q: got %d, want 400", path, resp.StatusCode)
 		}
+	}
+}
+
+// signalPersister wraps a Persister and closes saveDone when Save is called.
+type signalPersister struct {
+	inner    gctask.Persister
+	saveDone chan struct{}
+}
+
+func (s *signalPersister) Save(datastoreID, datastoreRoot string, task *gctask.Task) error {
+	err := s.inner.Save(datastoreID, datastoreRoot, task)
+	select {
+	case <-s.saveDone:
+	default:
+		close(s.saveDone)
+	}
+	return err
+}
+
+func (s *signalPersister) Load(datastoreID, datastoreRoot string) (*gctask.Task, error) {
+	return s.inner.Load(datastoreID, datastoreRoot)
+}
+
+func TestPOST_Persists_GETAfterRestart_ReturnsLastResult(t *testing.T) {
+	root := makeDSRoot(t)
+	db := setupDB(t, "mystore", root)
+
+	saveDone := make(chan struct{})
+	persister := &signalPersister{
+		inner:    gctask.FilePersister{},
+		saveDone: saveDone,
+	}
+
+	h := newHandler(t, db, func(_ context.Context, _ string, _ gcrun.OldestActiveWriterFunc) (*gcstatus.Status, error) {
+		return &gcstatus.Status{DiskChunks: 3, RemovedChunks: 1}, nil
+	})
+	h.tracker = gctask.NewTracker(persister, nil)
+
+	doRequest(t, h, http.MethodPost, "/api2/json/admin/datastore/mystore/gc")
+	select {
+	case <-saveDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for GC persist")
+	}
+
+	// Simulate restart: new tracker hydrates from the .gc-status file.
+	restarted := gctask.NewTracker(gctask.FilePersister{}, map[string]string{"ds-test-id": root})
+	h.tracker = restarted
+
+	resp := doRequest(t, h, http.MethodGet, "/api2/json/admin/datastore/mystore/gc")
+	body := readBody(t, resp)
+	data, ok := body["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected data object after restart, got %v", body["data"])
+	}
+	if data["state"] != "succeeded" {
+		t.Errorf("state after restart: got %v, want succeeded", data["state"])
 	}
 }
 

--- a/services/backupos-pbs/internal/gctask/file_persister.go
+++ b/services/backupos-pbs/internal/gctask/file_persister.go
@@ -1,0 +1,72 @@
+package gctask
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FilePersister stores Task records as JSON in <datastoreRoot>/.gc-status.
+// Atomic writes via tmp+rename so a crash mid-write can't corrupt the file.
+type FilePersister struct{}
+
+// statusFilename matches PBS reference layout (pbs-datastore/src/datastore.rs).
+const statusFilename = ".gc-status"
+
+func (FilePersister) path(datastoreRoot string) string {
+	return filepath.Join(datastoreRoot, statusFilename)
+}
+
+// Save writes task to <datastoreRoot>/.gc-status atomically.
+func (p FilePersister) Save(datastoreID, datastoreRoot string, task *Task) error {
+	data, err := json.MarshalIndent(task, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal task: %w", err)
+	}
+
+	finalPath := p.path(datastoreRoot)
+	tmpPath := finalPath + ".tmp"
+
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", tmpPath, err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write %s: %w", tmpPath, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("fsync %s: %w", tmpPath, err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename %s → %s: %w", tmpPath, finalPath, err)
+	}
+	return nil
+}
+
+// Load reads <datastoreRoot>/.gc-status and returns the stored Task.
+// Returns (nil, nil) if the file does not exist (fresh datastore).
+func (p FilePersister) Load(datastoreID, datastoreRoot string) (*Task, error) {
+	data, err := os.ReadFile(p.path(datastoreRoot))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil // no record = fresh datastore, not an error
+		}
+		return nil, fmt.Errorf("read .gc-status: %w", err)
+	}
+	var task Task
+	if err := json.Unmarshal(data, &task); err != nil {
+		return nil, fmt.Errorf("unmarshal .gc-status: %w", err)
+	}
+	return &task, nil
+}

--- a/services/backupos-pbs/internal/gctask/file_persister_test.go
+++ b/services/backupos-pbs/internal/gctask/file_persister_test.go
@@ -1,0 +1,186 @@
+package gctask
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcstatus"
+)
+
+func sampleTask() *Task {
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	finished := now.Add(time.Second)
+	return &Task{
+		ID:            "test-task-id",
+		DatastoreName: "mystore",
+		State:         StateSucceeded.String(),
+		StartedAt:     now,
+		FinishedAt:    &finished,
+		Status: &gcstatus.Status{
+			RemovedChunks: 1,
+			RemovedBytes:  28,
+			DiskChunks:    6,
+			DiskBytes:     12058712,
+		},
+	}
+}
+
+func TestFilePersister_Save_NewFile_WritesJSON(t *testing.T) {
+	root := t.TempDir()
+	p := FilePersister{}
+
+	if err := p.Save("ds-1", root, sampleTask()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, statusFilename))
+	if err != nil {
+		t.Fatalf("file not written: %v", err)
+	}
+	var got Task
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody: %s", err, data)
+	}
+	if got.ID != "test-task-id" {
+		t.Errorf("task_id: got %q, want %q", got.ID, "test-task-id")
+	}
+	if got.State != StateSucceeded.String() {
+		t.Errorf("state: got %q, want succeeded", got.State)
+	}
+}
+
+func TestFilePersister_Save_ExistingFile_Overwrites(t *testing.T) {
+	root := t.TempDir()
+	p := FilePersister{}
+
+	first := sampleTask()
+	first.ID = "first"
+	if err := p.Save("ds-1", root, first); err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+
+	second := sampleTask()
+	second.ID = "second"
+	if err := p.Save("ds-1", root, second); err != nil {
+		t.Fatalf("second Save: %v", err)
+	}
+
+	loaded, err := p.Load("ds-1", root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.ID != "second" {
+		t.Errorf("expected second task to overwrite first, got ID=%q", loaded.ID)
+	}
+}
+
+func TestFilePersister_Save_AtomicWrite_NoTmpAfterSuccess(t *testing.T) {
+	root := t.TempDir()
+	p := FilePersister{}
+
+	if err := p.Save("ds-1", root, sampleTask()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	tmpPath := filepath.Join(root, statusFilename+".tmp")
+	if _, err := os.Stat(tmpPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("tmp file should not exist after successful Save, got: %v", err)
+	}
+}
+
+func TestFilePersister_Save_DirectoryDoesNotExist_Errors(t *testing.T) {
+	p := FilePersister{}
+	err := p.Save("ds-1", "/nonexistent/path/that/does/not/exist", sampleTask())
+	if err == nil {
+		t.Error("expected error for nonexistent directory, got nil")
+	}
+}
+
+func TestFilePersister_Load_NonExistent_ReturnsNilNil(t *testing.T) {
+	root := t.TempDir()
+	p := FilePersister{}
+
+	task, err := p.Load("ds-1", root)
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if task != nil {
+		t.Errorf("expected nil task for missing file, got %+v", task)
+	}
+}
+
+func TestFilePersister_Load_ValidFile_ReturnsTask(t *testing.T) {
+	root := t.TempDir()
+	p := FilePersister{}
+
+	want := sampleTask()
+	if err := p.Save("ds-1", root, want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := p.Load("ds-1", root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.ID != want.ID {
+		t.Errorf("ID: got %q, want %q", got.ID, want.ID)
+	}
+	if got.State != want.State {
+		t.Errorf("State: got %q, want %q", got.State, want.State)
+	}
+}
+
+func TestFilePersister_Load_CorruptJSON_ReturnsError(t *testing.T) {
+	root := t.TempDir()
+	p := FilePersister{}
+
+	if err := os.WriteFile(filepath.Join(root, statusFilename), []byte("not-json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := p.Load("ds-1", root)
+	if err == nil {
+		t.Error("expected error for corrupt JSON, got nil")
+	}
+}
+
+func TestFilePersister_RoundTrip(t *testing.T) {
+	root := t.TempDir()
+	p := FilePersister{}
+
+	want := sampleTask()
+	if err := p.Save("ds-1", root, want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := p.Load("ds-1", root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if got.ID != want.ID {
+		t.Errorf("ID: got %q, want %q", got.ID, want.ID)
+	}
+	if got.DatastoreName != want.DatastoreName {
+		t.Errorf("DatastoreName: got %q, want %q", got.DatastoreName, want.DatastoreName)
+	}
+	if got.State != want.State {
+		t.Errorf("State: got %q, want %q", got.State, want.State)
+	}
+	if got.Status == nil {
+		t.Fatal("Status should not be nil after round-trip")
+	}
+	if got.Status.RemovedChunks != want.Status.RemovedChunks {
+		t.Errorf("RemovedChunks: got %d, want %d", got.Status.RemovedChunks, want.Status.RemovedChunks)
+	}
+	if got.Status.DiskBytes != want.Status.DiskBytes {
+		t.Errorf("DiskBytes: got %d, want %d", got.Status.DiskBytes, want.Status.DiskBytes)
+	}
+	if got.FinishedAt == nil {
+		t.Error("FinishedAt should survive round-trip")
+	}
+}

--- a/services/backupos-pbs/internal/gctask/gctask.go
+++ b/services/backupos-pbs/internal/gctask/gctask.go
@@ -1,13 +1,13 @@
 // Package gctask tracks in-memory state for GC runs, one per datastore.
 //
-// The Tracker holds the most recent task per datastore name. When a new GC
-// starts, any completed task for that datastore is replaced. State is
-// ephemeral — a server restart loses task history; the GC itself already ran
-// or didn't.
+// The Tracker holds the most recent task per datastore ID. Running tasks are
+// in-memory only. Succeeded and failed tasks are persisted via the optional
+// Persister (see FilePersister for the disk-backed implementation).
 package gctask
 
 import (
 	"errors"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -50,19 +50,54 @@ type Task struct {
 	Error         string           `json:"error,omitempty"`
 }
 
+// Persister abstracts where Task records are written/read so tests
+// can use an in-memory persister and prod uses a disk-backed one.
+type Persister interface {
+	// Save writes the task for this datastore. Failures are non-fatal
+	// for GC correctness — caller logs but doesn't propagate.
+	Save(datastoreID, datastoreRoot string, task *Task) error
+
+	// Load returns the previously-persisted task for this datastore,
+	// or (nil, nil) if no record exists (fresh datastore).
+	Load(datastoreID, datastoreRoot string) (*Task, error)
+}
+
 // ErrGCAlreadyRunning is returned by Begin when a task is already running
 // for the requested datastore. The caller should translate this to HTTP 409.
 var ErrGCAlreadyRunning = errors.New("gc already running on this datastore")
 
 // Tracker holds the most recent GC task per datastore ID.
 type Tracker struct {
-	mu    sync.Mutex
-	perDS map[string]*Task // keyed by datastore ID
+	mu        sync.Mutex
+	perDS     map[string]*Task // keyed by datastore ID
+	persister Persister        // optional; nil disables persistence
 }
 
-// NewTracker constructs an empty Tracker.
-func NewTracker() *Tracker {
-	return &Tracker{perDS: make(map[string]*Task)}
+// NewTracker creates a tracker. If persister is non-nil and datastoreRoots
+// is non-empty, the tracker hydrates from disk for each provided datastore
+// before returning.
+//
+// Hydration failures are logged but don't prevent tracker creation —
+// a corrupt .gc-status file shouldn't keep the server from starting.
+func NewTracker(persister Persister, datastoreRoots map[string]string) *Tracker {
+	t := &Tracker{
+		perDS:     make(map[string]*Task),
+		persister: persister,
+	}
+	if persister != nil {
+		for dsID, dsRoot := range datastoreRoots {
+			task, err := persister.Load(dsID, dsRoot)
+			if err != nil {
+				slog.Warn("hydrate gc tracker failed", "datastore_id", dsID, "error", err)
+				continue
+			}
+			if task != nil {
+				t.perDS[dsID] = task
+				slog.Info("hydrated gc tracker", "datastore_id", dsID, "state", task.State)
+			}
+		}
+	}
+	return t
 }
 
 // Begin creates a new running task for the datastore identified by datastoreID.
@@ -84,33 +119,54 @@ func (t *Tracker) Begin(datastoreID, datastoreName string) (*Task, error) {
 	return task, nil
 }
 
-// Succeed transitions the task with the given taskID to succeeded.
-func (t *Tracker) Succeed(taskID string, status *gcstatus.Status, markStats *gcmark.Stats) {
+// Succeed transitions the task with the given taskID to succeeded and
+// persists the result if a Persister is configured.
+func (t *Tracker) Succeed(datastoreID, datastoreRoot, taskID string, status *gcstatus.Status) {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	task := t.findByID(taskID)
 	if task == nil {
+		t.mu.Unlock()
 		return
 	}
 	now := time.Now()
 	task.State = StateSucceeded.String()
 	task.FinishedAt = &now
 	task.Status = status
-	task.MarkStats = markStats
+	snapshot := *task
+	if status != nil {
+		s := *status
+		snapshot.Status = &s
+	}
+	t.mu.Unlock()
+
+	if t.persister != nil {
+		if err := t.persister.Save(datastoreID, datastoreRoot, &snapshot); err != nil {
+			slog.Warn("persist gc task failed", "datastore_id", datastoreID, "task_id", taskID, "error", err)
+		}
+	}
 }
 
-// Fail transitions the task with the given taskID to failed.
-func (t *Tracker) Fail(taskID string, err error) {
+// Fail transitions the task with the given taskID to failed and
+// persists the result if a Persister is configured.
+func (t *Tracker) Fail(datastoreID, datastoreRoot, taskID string, err error) {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	task := t.findByID(taskID)
 	if task == nil {
+		t.mu.Unlock()
 		return
 	}
 	now := time.Now()
 	task.State = StateFailed.String()
 	task.FinishedAt = &now
 	task.Error = err.Error()
+	snapshot := *task
+	t.mu.Unlock()
+
+	if t.persister != nil {
+		if saveErr := t.persister.Save(datastoreID, datastoreRoot, &snapshot); saveErr != nil {
+			slog.Warn("persist gc task failed", "datastore_id", datastoreID, "task_id", taskID, "error", saveErr)
+		}
+	}
 }
 
 // Latest returns a defensive copy of the most recent task for the datastore,

--- a/services/backupos-pbs/internal/gctask/gctask_test.go
+++ b/services/backupos-pbs/internal/gctask/gctask_test.go
@@ -13,10 +13,44 @@ const (
 	dsID   = "ds-uuid-1"
 	dsName = "mystore"
 	dsID2  = "ds-uuid-2"
+	dsRoot = "/tmp/test-root-unused" // placeholder root for nil-persister tests
 )
 
+// mockPersister is an in-memory Persister for unit tests.
+type mockPersister struct {
+	tasks     map[string]*Task
+	saveErr   error
+	loadErr   error
+	saveCalls []*Task
+}
+
+func newMockPersister() *mockPersister {
+	return &mockPersister{tasks: make(map[string]*Task)}
+}
+
+func (m *mockPersister) Save(datastoreID, datastoreRoot string, task *Task) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	cp := *task
+	m.tasks[datastoreID] = &cp
+	m.saveCalls = append(m.saveCalls, &cp)
+	return nil
+}
+
+func (m *mockPersister) Load(datastoreID, datastoreRoot string) (*Task, error) {
+	if m.loadErr != nil {
+		return nil, m.loadErr
+	}
+	if task, ok := m.tasks[datastoreID]; ok {
+		cp := *task
+		return &cp, nil
+	}
+	return nil, nil
+}
+
 func TestBegin_CreatesRunningTask(t *testing.T) {
-	tr := NewTracker()
+	tr := NewTracker(nil, nil)
 	task, err := tr.Begin(dsID, dsName)
 	if err != nil {
 		t.Fatalf("Begin: %v", err)
@@ -33,7 +67,7 @@ func TestBegin_CreatesRunningTask(t *testing.T) {
 }
 
 func TestBegin_Twice_SameDatastore_ReturnsErrGCAlreadyRunning(t *testing.T) {
-	tr := NewTracker()
+	tr := NewTracker(nil, nil)
 	if _, err := tr.Begin(dsID, dsName); err != nil {
 		t.Fatalf("first Begin: %v", err)
 	}
@@ -44,7 +78,7 @@ func TestBegin_Twice_SameDatastore_ReturnsErrGCAlreadyRunning(t *testing.T) {
 }
 
 func TestBegin_DifferentDatastores_BothSucceed(t *testing.T) {
-	tr := NewTracker()
+	tr := NewTracker(nil, nil)
 	t1, err := tr.Begin(dsID, dsName)
 	if err != nil {
 		t.Fatalf("Begin ds1: %v", err)
@@ -59,9 +93,9 @@ func TestBegin_DifferentDatastores_BothSucceed(t *testing.T) {
 }
 
 func TestBegin_AfterFinished_Succeeds(t *testing.T) {
-	tr := NewTracker()
+	tr := NewTracker(nil, nil)
 	task, _ := tr.Begin(dsID, dsName)
-	tr.Succeed(task.ID, &gcstatus.Status{}, nil)
+	tr.Succeed(dsID, dsRoot, task.ID, &gcstatus.Status{})
 
 	task2, err := tr.Begin(dsID, dsName)
 	if err != nil {
@@ -73,9 +107,9 @@ func TestBegin_AfterFinished_Succeeds(t *testing.T) {
 }
 
 func TestBegin_AfterFailed_Succeeds(t *testing.T) {
-	tr := NewTracker()
+	tr := NewTracker(nil, nil)
 	task, _ := tr.Begin(dsID, dsName)
-	tr.Fail(task.ID, errors.New("boom"))
+	tr.Fail(dsID, dsRoot, task.ID, errors.New("boom"))
 
 	_, err := tr.Begin(dsID, dsName)
 	if err != nil {
@@ -84,10 +118,10 @@ func TestBegin_AfterFailed_Succeeds(t *testing.T) {
 }
 
 func TestSucceed_TransitionsState(t *testing.T) {
-	tr := NewTracker()
+	tr := NewTracker(nil, nil)
 	task, _ := tr.Begin(dsID, dsName)
 	status := &gcstatus.Status{RemovedChunks: 5, DiskChunks: 10}
-	tr.Succeed(task.ID, status, nil)
+	tr.Succeed(dsID, dsRoot, task.ID, status)
 
 	latest := tr.Latest(dsID)
 	if latest.State != StateSucceeded.String() {
@@ -102,9 +136,9 @@ func TestSucceed_TransitionsState(t *testing.T) {
 }
 
 func TestFail_TransitionsState(t *testing.T) {
-	tr := NewTracker()
+	tr := NewTracker(nil, nil)
 	task, _ := tr.Begin(dsID, dsName)
-	tr.Fail(task.ID, errors.New("disk full"))
+	tr.Fail(dsID, dsRoot, task.ID, errors.New("disk full"))
 
 	latest := tr.Latest(dsID)
 	if latest.State != StateFailed.String() {
@@ -119,16 +153,16 @@ func TestFail_TransitionsState(t *testing.T) {
 }
 
 func TestLatest_NeverRun_ReturnsNil(t *testing.T) {
-	tr := NewTracker()
+	tr := NewTracker(nil, nil)
 	if got := tr.Latest(dsID); got != nil {
 		t.Errorf("expected nil for unknown datastore, got %+v", got)
 	}
 }
 
 func TestLatest_ReturnsCopy_MutatingDoesNotAffectTracker(t *testing.T) {
-	tr := NewTracker()
+	tr := NewTracker(nil, nil)
 	task, _ := tr.Begin(dsID, dsName)
-	tr.Succeed(task.ID, &gcstatus.Status{RemovedChunks: 3}, nil)
+	tr.Succeed(dsID, dsRoot, task.ID, &gcstatus.Status{RemovedChunks: 3})
 
 	cp := tr.Latest(dsID)
 	cp.State = "mutated"
@@ -144,7 +178,7 @@ func TestLatest_ReturnsCopy_MutatingDoesNotAffectTracker(t *testing.T) {
 }
 
 func TestConcurrent_RaceDetectorClean(t *testing.T) {
-	tr := NewTracker()
+	tr := NewTracker(nil, nil)
 	var wg sync.WaitGroup
 	for i := 0; i < 20; i++ {
 		wg.Add(1)
@@ -158,12 +192,114 @@ func TestConcurrent_RaceDetectorClean(t *testing.T) {
 			}
 			time.Sleep(time.Millisecond)
 			if i%2 == 0 {
-				tr.Succeed(task.ID, &gcstatus.Status{}, nil)
+				tr.Succeed(dsID, dsRoot, task.ID, &gcstatus.Status{})
 			} else {
-				tr.Fail(task.ID, errors.New("err"))
+				tr.Fail(dsID, dsRoot, task.ID, errors.New("err"))
 			}
 			tr.Latest(dsID)
 		}(i)
 	}
 	wg.Wait()
+}
+
+// ---- Persister tests ----
+
+func TestNewTracker_NoPersister_StillWorks(t *testing.T) {
+	tr := NewTracker(nil, nil)
+	task, err := tr.Begin(dsID, dsName)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	tr.Succeed(dsID, dsRoot, task.ID, &gcstatus.Status{})
+	if got := tr.Latest(dsID); got == nil || got.State != StateSucceeded.String() {
+		t.Errorf("expected succeeded task, got %+v", got)
+	}
+}
+
+func TestNewTracker_HydratesFromPersister(t *testing.T) {
+	mp := newMockPersister()
+	// Pre-populate persister with a completed task.
+	mp.tasks[dsID] = &Task{
+		ID:            "pre-existing",
+		DatastoreName: dsName,
+		State:         StateSucceeded.String(),
+		StartedAt:     time.Now(),
+	}
+
+	tr := NewTracker(mp, map[string]string{dsID: dsRoot})
+
+	latest := tr.Latest(dsID)
+	if latest == nil {
+		t.Fatal("expected hydrated task, got nil")
+	}
+	if latest.ID != "pre-existing" {
+		t.Errorf("ID: got %q, want %q", latest.ID, "pre-existing")
+	}
+}
+
+func TestNewTracker_PersisterError_DoesntPreventStart(t *testing.T) {
+	mp := newMockPersister()
+	mp.loadErr = errors.New("disk read failed")
+
+	// Even if Load errors, tracker should be constructed successfully.
+	tr := NewTracker(mp, map[string]string{dsID: dsRoot, dsID2: "/tmp/root2"})
+
+	// Both datastores fail to hydrate, but tracker is usable.
+	if got := tr.Latest(dsID); got != nil {
+		t.Errorf("expected nil for failed hydration, got %+v", got)
+	}
+	// Begin should work normally.
+	if _, err := tr.Begin(dsID, dsName); err != nil {
+		t.Errorf("Begin after failed hydration: %v", err)
+	}
+}
+
+func TestSucceed_PersistsAfterTransition(t *testing.T) {
+	mp := newMockPersister()
+	tr := NewTracker(mp, nil)
+
+	task, _ := tr.Begin(dsID, dsName)
+	status := &gcstatus.Status{RemovedChunks: 7}
+	tr.Succeed(dsID, dsRoot, task.ID, status)
+
+	if len(mp.saveCalls) != 1 {
+		t.Fatalf("expected 1 Save call, got %d", len(mp.saveCalls))
+	}
+	saved := mp.saveCalls[0]
+	if saved.State != StateSucceeded.String() {
+		t.Errorf("persisted state: got %q, want succeeded", saved.State)
+	}
+	if saved.Status == nil || saved.Status.RemovedChunks != 7 {
+		t.Errorf("persisted Status: %+v", saved.Status)
+	}
+}
+
+func TestFail_PersistsAfterTransition(t *testing.T) {
+	mp := newMockPersister()
+	tr := NewTracker(mp, nil)
+
+	task, _ := tr.Begin(dsID, dsName)
+	tr.Fail(dsID, dsRoot, task.ID, errors.New("atime probe failed"))
+
+	if len(mp.saveCalls) != 1 {
+		t.Fatalf("expected 1 Save call, got %d", len(mp.saveCalls))
+	}
+	saved := mp.saveCalls[0]
+	if saved.State != StateFailed.String() {
+		t.Errorf("persisted state: got %q, want failed", saved.State)
+	}
+	if saved.Error != "atime probe failed" {
+		t.Errorf("persisted error: got %q", saved.Error)
+	}
+}
+
+func TestBegin_DoesNotPersist(t *testing.T) {
+	mp := newMockPersister()
+	tr := NewTracker(mp, nil)
+
+	_, _ = tr.Begin(dsID, dsName)
+
+	if len(mp.saveCalls) != 0 {
+		t.Errorf("Begin should not call Save, got %d Save calls", len(mp.saveCalls))
+	}
 }


### PR DESCRIPTION
## Summary

- Adds `gctask.Persister` interface (`Save`/`Load`) and `FilePersister` implementation that atomically writes `<datastoreRoot>/.gc-status` (tmp+rename+fsync) — mirrors PBS reference (`pbs-datastore/src/datastore.rs:724`)
- `Tracker` hydrates from disk on startup via `NewTracker(persister, datastoreRoots map[string]string)`; hydration failures are non-fatal (logged, skipped)
- `Succeed`/`Fail` persist after in-memory state transition (mutex released before disk I/O to avoid lock contention)
- Adds `datastore.Lookup.All()` for startup enumeration of datastores; wired in `main.go` alongside `FilePersister{}`
- `Begin` does not persist (crash mid-GC shows the previous completed result after restart, matching PBS behaviour)

## Tests

- `internal/gctask/file_persister_test.go` — 8 tests: atomic write, overwrite, no tmp after success, nonexistent dir error, nil-nil for missing file, valid load, corrupt JSON error, round-trip
- `internal/gctask/gctask_test.go` — 6 new tests: no-persister still works, hydrates from persister, persister error doesn't prevent start, Succeed persists, Fail persists, Begin does not persist
- `internal/gcadmin/gcadmin_test.go` — `signalPersister` wrapper + `TestPOST_Persists_GETAfterRestart_ReturnsLastResult`: runs GC, waits for disk write via channel, swaps tracker to a freshly hydrated one, verifies state = "succeeded"

## Test plan

- [ ] CI Go tests pass for `backupos-pbs`
- [ ] `go vet ./...` clean
- [ ] `TestPOST_Persists_GETAfterRestart_ReturnsLastResult` passes (hydration round-trip)
- [ ] `TestFilePersister_Save_AtomicWrite_NoTmpAfterSuccess` passes (no leftover tmp)
- [ ] `TestFilePersister_Load_CorruptJSON_ReturnsError` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)