### PR TITLE
feat(pbs): /speedtest reader endpoint — 1 MiB block download

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/handlers"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/readchunk"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/readerupgrade"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/speedtest"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/sessionreaper"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/upgrade"
@@ -132,6 +133,7 @@ func main() {
 		datastoreLookup,
 		download.NewHandler(),
 		readchunk.NewHandler(),
+		speedtest.Handler(),
 	)
 
 	datastoreRoots := make(map[string]string)

--- a/services/backupos-pbs/internal/readerupgrade/handler.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler.go
@@ -44,26 +44,30 @@ const (
 
 // Handler handles a PBS reader-protocol upgrade request.
 type Handler struct {
-	validator       *auth.Validator
-	datastores      *datastore.Lookup
-	downloadHandler http.Handler
-	chunkHandler    http.Handler
+	validator        *auth.Validator
+	datastores       *datastore.Lookup
+	downloadHandler  http.Handler
+	chunkHandler     http.Handler
+	speedtestHandler http.Handler
 }
 
 // NewHandler constructs a reader upgrade Handler.
 // validator is used for inline auth (no requireAuth middleware needed).
-// downloadHandler serves GET /download; chunkHandler serves GET /chunk.
+// downloadHandler serves GET /download; chunkHandler serves GET /chunk;
+// speedtestHandler serves GET /speedtest.
 func NewHandler(
 	validator *auth.Validator,
 	datastores *datastore.Lookup,
 	downloadHandler http.Handler,
 	chunkHandler http.Handler,
+	speedtestHandler http.Handler,
 ) *Handler {
 	return &Handler{
-		validator:       validator,
-		datastores:      datastores,
-		downloadHandler: downloadHandler,
-		chunkHandler:    chunkHandler,
+		validator:        validator,
+		datastores:       datastores,
+		downloadHandler:  downloadHandler,
+		chunkHandler:     chunkHandler,
+		speedtestHandler: speedtestHandler,
 	}
 }
 
@@ -259,9 +263,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		case "/chunk":
 			h.chunkHandler.ServeHTTP(w, r)
 		case "/speedtest":
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusNotImplemented)
-			_ = json.NewEncoder(w).Encode(map[string]string{"error": "speedtest not implemented in V1"})
+			h.speedtestHandler.ServeHTTP(w, r)
 		default:
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)

--- a/services/backupos-pbs/internal/readerupgrade/handler_test.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler_test.go
@@ -107,6 +107,7 @@ func newTestHandler(db *sql.DB) *Handler {
 		datastore.NewLookup(db),
 		stub,
 		stub,
+		stub,
 	)
 }
 

--- a/services/backupos-pbs/internal/speedtest/speedtest.go
+++ b/services/backupos-pbs/internal/speedtest/speedtest.go
@@ -1,0 +1,39 @@
+// Package speedtest implements the /speedtest endpoint for the
+// reader-protocol-v1 H2 stream.
+//
+// PBS reference: src/api2/reader/mod.rs::speedtest — "Test 1M block download speed"
+// Returns exactly 1 MiB of zero bytes with Content-Type: application/octet-stream.
+package speedtest
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+// BlockSize is the speedtest payload size — matches PBS reference's 1 MiB.
+const BlockSize = 1024 * 1024
+
+// Handler serves a fixed-size block of zeros for connection speed testing.
+// Mounted under the reader-protocol-v1 H2 stream alongside /download and /chunk.
+//
+// The zero buffer is pre-allocated once and shared across all requests (read-only).
+func Handler() http.HandlerFunc {
+	block := make([]byte, BlockSize)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", "1048576")
+		w.WriteHeader(http.StatusOK)
+
+		n, err := w.Write(block)
+		if err != nil {
+			slog.Debug("speedtest write failed", "wrote", n, "error", err)
+		}
+	}
+}

--- a/services/backupos-pbs/internal/speedtest/speedtest_test.go
+++ b/services/backupos-pbs/internal/speedtest/speedtest_test.go
@@ -1,0 +1,64 @@
+package speedtest
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func callHandler(t *testing.T, method string) *httptest.ResponseRecorder {
+	t.Helper()
+	h := Handler()
+	req := httptest.NewRequest(method, "/speedtest", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+	return w
+}
+
+func TestHandler_ReturnsExactly1MiB(t *testing.T) {
+	w := callHandler(t, http.MethodGet)
+	body, err := io.ReadAll(w.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if len(body) != BlockSize {
+		t.Errorf("body length: got %d, want %d", len(body), BlockSize)
+	}
+}
+
+func TestHandler_AllZeros(t *testing.T) {
+	w := callHandler(t, http.MethodGet)
+	body, _ := io.ReadAll(w.Body)
+	for i, b := range body {
+		if b != 0 {
+			t.Errorf("non-zero byte at offset %d: got %d", i, b)
+			return
+		}
+	}
+}
+
+func TestHandler_ContentLength(t *testing.T) {
+	w := callHandler(t, http.MethodGet)
+	got := w.Header().Get("Content-Length")
+	if got != "1048576" {
+		t.Errorf("Content-Length: got %q, want %q", got, "1048576")
+	}
+}
+
+func TestHandler_OctetStream(t *testing.T) {
+	w := callHandler(t, http.MethodGet)
+	got := w.Header().Get("Content-Type")
+	if got != "application/octet-stream" {
+		t.Errorf("Content-Type: got %q, want %q", got, "application/octet-stream")
+	}
+}
+
+func TestHandler_WrongMethod_Returns405(t *testing.T) {
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+		w := callHandler(t, method)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("method %s: got %d, want 405", method, w.Code)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Creates `internal/speedtest` package: `Handler()` returns an `http.HandlerFunc` that writes exactly 1 MiB of zero bytes with `Content-Type: application/octet-stream` and `Content-Length: 1048576`
- The zero buffer is pre-allocated once at handler construction and shared read-only across all requests (no per-request allocation)
- Replaces the existing 501 stub in the reader-protocol-v1 H2 router with the real implementation
- `readerupgrade.NewHandler` gains a `speedtestHandler http.Handler` parameter (5th arg); test helper updated accordingly
- Auth gate: implicit — `/speedtest` is reachable only inside an established reader session (upgrade handshake is the auth gate)

## Mirrors PBS reference

`src/api2/reader/mod.rs::speedtest` — "Test 1M block download speed", returns 1 MiB to caller.

## V1 deferral

Upload-side `/speedtest` (writer protocol) not implemented — clients use it less, and our writers haven't shown latency issues.

## Test plan

- [ ] CI Go tests pass for `backupos-pbs`
- [ ] `TestHandler_ReturnsExactly1MiB` — body is exactly 1 048 576 bytes
- [ ] `TestHandler_AllZeros` — body is all zero bytes
- [ ] `TestHandler_ContentLength` — header matches body
- [ ] `TestHandler_OctetStream` — `Content-Type: application/octet-stream`
- [ ] `TestHandler_WrongMethod_Returns405` — POST/PUT/DELETE return 405

🤖 Generated with [Claude Code](https://claude.com/claude-code)