### PR TITLE
feat(pbs): tighten owner check to PBS-spec token-level ownership

### DIFF
--- a/services/backupos-pbs/internal/auth/auth.go
+++ b/services/backupos-pbs/internal/auth/auth.go
@@ -180,6 +180,13 @@ func (v *Validator) Validate(parsed *ParsedHeader) (*Identity, error) {
 	}, nil
 }
 
+// Authid returns the full PBS authid string: "user@realm!tokenname".
+// Since ParseAuthHeader always requires a non-empty tokenName, this is
+// always a token authid (never bare user@realm).
+func (id *Identity) Authid() string {
+	return id.User + "@" + id.Realm + "!" + id.TokenName
+}
+
 // identityCtxKey is the context key type for stashing an Identity. Unexported
 // so external packages can only access it via WithIdentity / FromContext.
 type identityCtxKey struct{}

--- a/services/backupos-pbs/internal/owner/owner.go
+++ b/services/backupos-pbs/internal/owner/owner.go
@@ -4,9 +4,8 @@
 //
 //	<datastoreRoot>/<backupType>/<backupID>/owner
 //
-// File contents: <user>@<realm>\n — user-level only, no token suffix.
-// Mirrors PBS reference's owner_path layout with V1 simplification
-// (user-level ownership, no token-level granularity).
+// File contents: <authid>\n where authid is user@realm!tokenname.
+// Mirrors PBS reference's owner_path layout and check_backup_owner semantics.
 package owner
 
 import (
@@ -32,11 +31,8 @@ func Path(datastoreRoot, backupType, backupID string) string {
 	return filepath.Join(datastoreRoot, backupType, backupID, "owner")
 }
 
-// Read returns the user@realm string stored in the owner file for the
-// given group. Returns os.ErrNotExist (wrapped) if the owner file
-// doesn't exist — caller decides whether that's allow-by-default
-// (V1 backcompat) or deny-by-default (future tightening).
-//
+// Read returns the authid string stored in the owner file for the given group.
+// Returns os.ErrNotExist (wrapped) if the owner file doesn't exist.
 // Returns ErrInvalidOwnerFile if the file exists but can't be parsed.
 func Read(datastoreRoot, backupType, backupID string) (string, error) {
 	path := Path(datastoreRoot, backupType, backupID)
@@ -48,29 +44,21 @@ func Read(datastoreRoot, backupType, backupID string) (string, error) {
 	if !strings.Contains(line, "@") {
 		return "", fmt.Errorf("%w: missing @ separator in %q", ErrInvalidOwnerFile, line)
 	}
-	// Disallow token name suffix in our V1 owner files.
-	if strings.Contains(line, "!") {
-		return "", fmt.Errorf("%w: V1 owner files must be user@realm without token name", ErrInvalidOwnerFile)
-	}
 	return line, nil
 }
 
 // SetIfAbsent writes the owner file atomically if it doesn't exist.
-// Returns nil if the file was created OR if it already exists with the
-// SAME contents (idempotent for the original owner).
+// Returns nil if the file was created OR if AuthidMatches(existing, authid)
+// (idempotent for the original owner and for the token→user direction).
 //
-// Returns ErrOwnerMismatch if the file exists with DIFFERENT contents
-// (a different user is trying to write to a group they don't own).
+// Returns ErrOwnerMismatch if the file exists with non-matching authid.
 //
 // The atomic write is: create owner.tmp, write contents+newline, fsync,
 // rename to owner. A crash mid-write leaves owner.tmp orphaned but no
 // corrupt owner file.
-func SetIfAbsent(datastoreRoot, backupType, backupID, userRealm string) error {
-	if !strings.Contains(userRealm, "@") {
-		return fmt.Errorf("%w: %q is not user@realm", ErrInvalidOwnerFile, userRealm)
-	}
-	if strings.Contains(userRealm, "!") {
-		return fmt.Errorf("%w: must not include token name", ErrInvalidOwnerFile)
+func SetIfAbsent(datastoreRoot, backupType, backupID, authid string) error {
+	if !strings.Contains(authid, "@") {
+		return fmt.Errorf("%w: %q is not a valid authid", ErrInvalidOwnerFile, authid)
 	}
 
 	groupDir := filepath.Join(datastoreRoot, backupType, backupID)
@@ -82,10 +70,10 @@ func SetIfAbsent(datastoreRoot, backupType, backupID, userRealm string) error {
 
 	// Try to read existing owner; if it matches, we're idempotent.
 	if existing, err := Read(datastoreRoot, backupType, backupID); err == nil {
-		if existing == userRealm {
+		if AuthidMatches(existing, authid) {
 			return nil // already ours, nothing to do
 		}
-		return fmt.Errorf("%w: existing=%q, attempted=%q", ErrOwnerMismatch, existing, userRealm)
+		return fmt.Errorf("%w: existing=%q, attempted=%q", ErrOwnerMismatch, existing, authid)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("read existing owner: %w", err)
 	}
@@ -96,7 +84,7 @@ func SetIfAbsent(datastoreRoot, backupType, backupID, userRealm string) error {
 	if err != nil {
 		return fmt.Errorf("create owner.tmp: %w", err)
 	}
-	if _, err := f.WriteString(userRealm + "\n"); err != nil {
+	if _, err := f.WriteString(authid + "\n"); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("write owner.tmp: %w", err)
@@ -117,11 +105,12 @@ func SetIfAbsent(datastoreRoot, backupType, backupID, userRealm string) error {
 	return nil
 }
 
-// Check returns nil if userRealm owns the group, ErrOwnerMismatch otherwise.
+// Check returns nil if callerAuthid matches the stored owner per PBS
+// check_backup_owner semantics (AuthidMatches). Returns ErrOwnerMismatch
+// if the authids don't match.
 //
-// V1 backwards-compat: if the owner file doesn't exist, returns nil
-// (allow). Future versions may flip this to deny-by-default.
-func Check(datastoreRoot, backupType, backupID, userRealm string) error {
+// V1 backwards-compat: if the owner file doesn't exist, returns nil (allow).
+func Check(datastoreRoot, backupType, backupID, callerAuthid string) error {
 	existing, err := Read(datastoreRoot, backupType, backupID)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -129,8 +118,23 @@ func Check(datastoreRoot, backupType, backupID, userRealm string) error {
 		}
 		return err
 	}
-	if existing != userRealm {
-		return fmt.Errorf("%w: owner=%q, requester=%q", ErrOwnerMismatch, existing, userRealm)
+	if !AuthidMatches(existing, callerAuthid) {
+		return fmt.Errorf("%w: owner=%q, requester=%q", ErrOwnerMismatch, existing, callerAuthid)
 	}
 	return nil
+}
+
+// AuthidMatches implements PBS check_backup_owner semantics:
+//
+//   - stored == caller (exact match)
+//   - stored is a token authid (contains "!") AND caller equals the user
+//     portion of stored — a bare-user caller can read a token-owned group.
+func AuthidMatches(stored, caller string) bool {
+	if stored == caller {
+		return true
+	}
+	if bangIdx := strings.Index(stored, "!"); bangIdx != -1 {
+		return stored[:bangIdx] == caller
+	}
+	return false
 }

--- a/services/backupos-pbs/internal/owner/owner_test.go
+++ b/services/backupos-pbs/internal/owner/owner_test.go
@@ -92,19 +92,21 @@ func TestRead_InvalidFormat_ReturnsErrInvalidOwnerFile(t *testing.T) {
 	}
 }
 
-func TestRead_TokenNameInFile_Rejected(t *testing.T) {
+func TestRead_TokenNameInFile_Accepted(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "vm", "400")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// V1 rejects token-suffixed owner file contents.
 	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("root@pbs!alice\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, err := Read(root, "vm", "400")
-	if !errors.Is(err, ErrInvalidOwnerFile) {
-		t.Errorf("expected ErrInvalidOwnerFile for token-suffix, got %v", err)
+	got, err := Read(root, "vm", "400")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "root@pbs!alice" {
+		t.Errorf("got %q, want %q", got, "root@pbs!alice")
 	}
 }
 
@@ -154,11 +156,62 @@ func TestSetIfAbsent_AtomicWrite_NoOwnerTmpAfterSuccess(t *testing.T) {
 	}
 }
 
-func TestSetIfAbsent_RejectsTokenNameInInput(t *testing.T) {
+func TestSetIfAbsent_AcceptsTokenInInput(t *testing.T) {
 	root := t.TempDir()
-	err := SetIfAbsent(root, "vm", "900", "root@pbs!alice")
-	if !errors.Is(err, ErrInvalidOwnerFile) {
-		t.Errorf("expected ErrInvalidOwnerFile for token-suffix input, got %v", err)
+	if err := SetIfAbsent(root, "vm", "900", "root@pbs!alice"); err != nil {
+		t.Fatalf("SetIfAbsent with token authid: %v", err)
+	}
+	got, err := Read(root, "vm", "900")
+	if err != nil {
+		t.Fatalf("Read after set: %v", err)
+	}
+	if got != "root@pbs!alice" {
+		t.Errorf("owner = %q, want %q", got, "root@pbs!alice")
+	}
+}
+
+func TestSetIfAbsent_TokenStored_UserCaller_Idempotent(t *testing.T) {
+	root := t.TempDir()
+	// Pre-create owner as token authid.
+	if err := SetIfAbsent(root, "vm", "910", "root@pbs!test1"); err != nil {
+		t.Fatalf("first SetIfAbsent: %v", err)
+	}
+	// Same user's bare authid should match via AuthidMatches (token stored, user calling).
+	if err := SetIfAbsent(root, "vm", "910", "root@pbs"); err != nil {
+		t.Errorf("SetIfAbsent for user portion of token owner: %v", err)
+	}
+}
+
+func TestSetIfAbsent_UserStored_TokenCaller_Mismatch(t *testing.T) {
+	root := t.TempDir()
+	// Pre-create owner as bare user.
+	if err := SetIfAbsent(root, "vm", "920", "root@pbs"); err != nil {
+		t.Fatalf("first SetIfAbsent: %v", err)
+	}
+	// Token caller does NOT match bare-user stored owner (asymmetric rule).
+	err := SetIfAbsent(root, "vm", "920", "root@pbs!test1")
+	if !errors.Is(err, ErrOwnerMismatch) {
+		t.Errorf("expected ErrOwnerMismatch for token caller vs user owner, got %v", err)
+	}
+}
+
+func TestAuthidMatches(t *testing.T) {
+	tests := []struct {
+		stored string
+		caller string
+		want   bool
+	}{
+		{"root@pbs!test1", "root@pbs!test1", true},  // exact token match
+		{"root@pbs", "root@pbs", true},               // exact user match
+		{"root@pbs!test1", "root@pbs", true},         // token stored, bare user calling
+		{"root@pbs", "root@pbs!test1", false},        // user stored, token calling — asymmetric
+		{"root@pbs!test1", "root@pbs!other", false},  // different tokens
+		{"root@pbs!test1", "alice@pbs", false},       // different user
+	}
+	for _, tc := range tests {
+		if got := AuthidMatches(tc.stored, tc.caller); got != tc.want {
+			t.Errorf("AuthidMatches(%q, %q) = %v, want %v", tc.stored, tc.caller, got, tc.want)
+		}
 	}
 }
 

--- a/services/backupos-pbs/internal/readerupgrade/handler.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler.go
@@ -163,12 +163,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Owner check: requesting user must own the backup group (or no owner file exists — V1 backcompat).
-	userRealm := identity.User + "@" + identity.Realm
-	if err := owner.Check(ds.Path, backupType, backupID, userRealm); err != nil {
+	// Owner check: caller must match the stored authid per PBS check_backup_owner semantics.
+	callerAuthid := identity.Authid()
+	if err := owner.Check(ds.Path, backupType, backupID, callerAuthid); err != nil {
 		if errors.Is(err, owner.ErrOwnerMismatch) {
 			slog.Info("reader rejected: backup group owner mismatch",
-				"user", userRealm,
+				"user", callerAuthid,
 				"datastore_id", ds.ID,
 				"backup_type", backupType,
 				"backup_id", backupID,

--- a/services/backupos-pbs/internal/readerupgrade/handler_test.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler_test.go
@@ -152,9 +152,9 @@ func TestReader_OwnerMatches_Allowed(t *testing.T) {
 	makeSnapDir(t, tmp)
 	db := setupTestDB(t, tmp)
 
-	// Write owner file as root@pbs — matches the test token's user@realm.
+	// Write owner file as root@pbs!test1 — exact match for the test token.
 	groupDir := filepath.Join(tmp, "vm", "100")
-	if err := os.WriteFile(filepath.Join(groupDir, "owner"), []byte("root@pbs\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(groupDir, "owner"), []byte("root@pbs!test1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -315,6 +315,47 @@ func TestHandler_WrongMethod_Returns405(t *testing.T) {
 
 	if resp.StatusCode != http.StatusMethodNotAllowed {
 		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestReader_TokenStored_DifferentToken_Denied(t *testing.T) {
+	tmp := t.TempDir()
+	makeSnapDir(t, tmp)
+	db := setupTestDB(t, tmp)
+
+	// Write owner file as root@pbs!test1 (the standard test token).
+	groupDir := filepath.Join(tmp, "vm", "100")
+	if err := os.WriteFile(filepath.Join(groupDir, "owner"), []byte("root@pbs!test1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a second token for the same user with a different token name.
+	const otherSecret = "other-secret-reader-test"
+	if _, err := db.Exec(
+		`INSERT INTO pbs_tokens (id, user, realm, token_name, secret_hash, permissions)
+		 VALUES ('tok-other', 'root', 'pbs', 'other', ?, '')`,
+		auth.HashSecret(otherSecret),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newTestHandler(db)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader"+readerQuerySfx, nil)
+	req.Header.Set("Authorization", "PBSAPIToken=root@pbs!other:"+otherSecret)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", ReaderProtocolID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for different token same user, got %d", resp.StatusCode)
 	}
 }
 

--- a/services/backupos-pbs/internal/upgrade/handler.go
+++ b/services/backupos-pbs/internal/upgrade/handler.go
@@ -151,11 +151,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userRealm := identity.User + "@" + identity.Realm
-	if err := owner.SetIfAbsent(ds.Path, string(params.BackupType), params.BackupID, userRealm); err != nil {
+	authid := identity.Authid()
+	if err := owner.SetIfAbsent(ds.Path, string(params.BackupType), params.BackupID, authid); err != nil {
 		if errors.Is(err, owner.ErrOwnerMismatch) {
 			slog.Info("upgrade rejected: backup group owner mismatch",
-				"user", userRealm,
+				"user", authid,
 				"datastore_id", ds.ID,
 				"backup_type", params.BackupType,
 				"backup_id", params.BackupID,

--- a/services/backupos-pbs/internal/upgrade/handler_test.go
+++ b/services/backupos-pbs/internal/upgrade/handler_test.go
@@ -438,7 +438,7 @@ func TestHandler_DatastoreNotFound_Returns404(t *testing.T) {
 // This is the moment-of-truth integration test — the same dance that
 // crashed Node in PR #244.
 func TestHandler_FullUpgradeDance(t *testing.T) {
-	db := setupTestDB(t)
+	db := setupTestDBAtPath(t, t.TempDir())
 	h := newTestHandler(db)
 
 	// Use a TLS test server. EnableHTTP2=false so the test server doesn't

--- a/services/backupos-pbs/internal/upgrade/handler_test.go
+++ b/services/backupos-pbs/internal/upgrade/handler_test.go
@@ -237,20 +237,20 @@ func TestUpgrade_NewGroup_WritesOwnerFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("owner file not written: %v", err)
 	}
-	if got := strings.TrimRight(string(data), "\n"); got != "root@pbs" {
-		t.Errorf("owner file contents: got %q, want %q", got, "root@pbs")
+	if got := strings.TrimRight(string(data), "\n"); got != "root@pbs!test1" {
+		t.Errorf("owner file contents: got %q, want %q", got, "root@pbs!test1")
 	}
 }
 
 func TestUpgrade_SameUserSameGroup_AllowedIdempotent(t *testing.T) {
 	tmp := t.TempDir()
 
-	// Pre-create owner file as root@pbs (same user who will back up).
+	// Pre-create owner file as root@pbs!test1 (same token that will back up).
 	groupDir := filepath.Join(tmp, "vm", "999")
 	if err := os.MkdirAll(groupDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(groupDir, "owner"), []byte("root@pbs\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(groupDir, "owner"), []byte("root@pbs!test1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -272,8 +272,51 @@ func TestUpgrade_SameUserSameGroup_AllowedIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("owner file missing: %v", err)
 	}
-	if got := strings.TrimRight(string(data), "\n"); got != "root@pbs" {
-		t.Errorf("owner file changed: got %q, want %q", got, "root@pbs")
+	if got := strings.TrimRight(string(data), "\n"); got != "root@pbs!test1" {
+		t.Errorf("owner file changed: got %q, want %q", got, "root@pbs!test1")
+	}
+}
+
+func TestUpgrade_DifferentTokenSameUser_Returns403(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Pre-create owner as root@pbs!test1 (the standard test token).
+	groupDir := filepath.Join(tmp, "vm", "999")
+	if err := os.MkdirAll(groupDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(groupDir, "owner"), []byte("root@pbs!test1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	db := setupTestDBAtPath(t, tmp)
+	h := newTestHandler(db)
+
+	// Inject a different token of the same user.
+	otherToken := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.WithIdentity(r.Context(), &auth.Identity{
+			TokenID:   "other-token-id",
+			User:      "root",
+			Realm:     "pbs",
+			TokenName: "other",
+		})
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+
+	srv := httptest.NewServer(otherToken)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/backup?store=default&backup-type=vm&backup-id=999&backup-time=1735000000", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", UpgradeToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for different token same user, got %d", resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
## Summary

- V1 stored backup group owners as `user@realm`, letting any token of that user access the group. This PR tightens ownership to full authid (`user@realm!tokenname`) following PBS reference `check_backup_owner` semantics.
- `owner.AuthidMatches(stored, caller)`: exact match OR stored-is-token AND caller==user-portion (the one direction PBS allows bare-user callers to match token-stored owners).
- `auth.Identity.Authid()` added; both upgrade and readerupgrade handlers now pass the full authid into owner ops instead of constructing a bare `user@realm` string.

## Test plan

- [ ] `go test ./internal/owner/...` — `TestAuthidMatches` (6 cases), `TestRead_TokenNameInFile_Accepted`, `TestSetIfAbsent_AcceptsTokenInInput`, `TestSetIfAbsent_TokenStored_UserCaller_Idempotent`, `TestSetIfAbsent_UserStored_TokenCaller_Mismatch`
- [ ] `go test ./internal/upgrade/...` — `TestUpgrade_NewGroup_WritesOwnerFile` (expects `root@pbs!test1`), `TestUpgrade_SameUserSameGroup_AllowedIdempotent` (pre-creates `root@pbs!test1`), `TestUpgrade_DifferentTokenSameUser_Returns403`
- [ ] `go test ./internal/readerupgrade/...` — `TestReader_OwnerMatches_Allowed` (pre-creates `root@pbs!test1`), `TestReader_TokenStored_DifferentToken_Denied`
- [ ] CI green across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)