### PR TITLE
feat(pbs): namespace multi-tenancy — milestone 4c

### DIFF
--- a/packages/db/migrations/0043_pbs_session_namespace.sql
+++ b/packages/db/migrations/0043_pbs_session_namespace.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pbs_active_sessions ADD COLUMN namespace text DEFAULT '';

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -699,6 +699,7 @@ export const pbsActiveSessions = sqliteTable('pbs_active_sessions', {
   startedAt:    integer('started_at', { mode: 'timestamp_ms' }).notNull(),
   state:        text('state').notNull(),
   scratchPath:  text('scratch_path'),
+  namespace:    text('namespace').default(''),
 })
 
 export const pbsActiveWrites = sqliteTable('pbs_active_writes', {

--- a/services/backupos-pbs/internal/blob/blob.go
+++ b/services/backupos-pbs/internal/blob/blob.go
@@ -79,7 +79,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	snapDir, err := snapshot.EnsureDir(sc.DatastoreRoot, sc.BackupType, sc.BackupID, sc.BackupTime)
+	snapDir, err := snapshot.EnsureDir(sc.DatastoreRoot, sc.Namespace, sc.BackupType, sc.BackupID, sc.BackupTime)
 	if err != nil {
 		slog.Error("snapshot dir ensure failed",
 			"error", err,

--- a/services/backupos-pbs/internal/download/download.go
+++ b/services/backupos-pbs/internal/download/download.go
@@ -60,7 +60,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	snapDir := filepath.Join(
-		sc.DatastoreRoot,
+		sc.Namespace.JoinPath(sc.DatastoreRoot),
 		sc.BackupType,
 		sc.BackupID,
 		sc.BackupTime.UTC().Format("2006-01-02T15:04:05Z"),

--- a/services/backupos-pbs/internal/dynamicindex/dynamicindex.go
+++ b/services/backupos-pbs/internal/dynamicindex/dynamicindex.go
@@ -49,7 +49,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	snapDir, err := snapshot.EnsureDir(sc.DatastoreRoot, sc.BackupType, sc.BackupID, sc.BackupTime)
+	snapDir, err := snapshot.EnsureDir(sc.DatastoreRoot, sc.Namespace, sc.BackupType, sc.BackupID, sc.BackupTime)
 	if err != nil {
 		slog.Error("snapshot dir ensure failed",
 			"error", err, "session_id", sc.SessionID, "datastore_root", sc.DatastoreRoot)

--- a/services/backupos-pbs/internal/finish/finish.go
+++ b/services/backupos-pbs/internal/finish/finish.go
@@ -68,7 +68,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Best-effort durability: fsync the snapshot directory.
-	snapDir, pathErr := snapshot.Path(sc.DatastoreRoot, sc.BackupType, sc.BackupID, sc.BackupTime)
+	snapDir, pathErr := snapshot.Path(sc.DatastoreRoot, sc.Namespace, sc.BackupType, sc.BackupID, sc.BackupTime)
 	if pathErr != nil {
 		// Path validation failure here is unexpected — upgrade.ParseParams
 		// already validated the same fields. Log and continue.

--- a/services/backupos-pbs/internal/finish/finish_test.go
+++ b/services/backupos-pbs/internal/finish/finish_test.go
@@ -34,7 +34,8 @@ func setupTestStore(t *testing.T) (*sql.DB, *session.Store) {
 			backup_time   INTEGER NOT NULL,
 			started_at    INTEGER NOT NULL,
 			state         TEXT NOT NULL,
-			scratch_path  TEXT
+			scratch_path  TEXT,
+			namespace      TEXT NOT NULL DEFAULT ''
 		);
 	`)
 	if err != nil {

--- a/services/backupos-pbs/internal/fixedindex/fixedindex.go
+++ b/services/backupos-pbs/internal/fixedindex/fixedindex.go
@@ -54,7 +54,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	snapDir, err := snapshot.EnsureDir(sc.DatastoreRoot, sc.BackupType, sc.BackupID, sc.BackupTime)
+	snapDir, err := snapshot.EnsureDir(sc.DatastoreRoot, sc.Namespace, sc.BackupType, sc.BackupID, sc.BackupTime)
 	if err != nil {
 		slog.Error("snapshot dir ensure failed",
 			"error", err, "session_id", sc.SessionID, "datastore_root", sc.DatastoreRoot)

--- a/services/backupos-pbs/internal/gcmark/gcmark_test.go
+++ b/services/backupos-pbs/internal/gcmark/gcmark_test.go
@@ -276,6 +276,48 @@ func TestMark_CtxCancelled(t *testing.T) {
 	}
 }
 
+func TestMark_NamespacedSnapshot_Processed(t *testing.T) {
+	root := setupDatastore(t)
+
+	// Create snapshot under ns/alice/vm/100/<time>/ (one namespace level).
+	nsSnapDir := filepath.Join(root, "ns", "alice", "vm", "100", snapshotSubdir[len("vm/100/"):])
+	if err := os.MkdirAll(nsSnapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	digest := [32]byte{0: 0xDD}
+	const chunkSize = 4096
+	idxPath := filepath.Join(nsSnapDir, "drive-0.img.fidx")
+	w, err := fidx.Create(idxPath, chunkSize, chunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.AddChunk(chunkSize, chunkSize, digest); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	chunkPath := writeChunk(t, root, digest, true)
+
+	stats, err := Mark(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Mark: %v", err)
+	}
+	if len(stats.Errors) != 0 {
+		t.Errorf("unexpected errors: %v", stats.Errors)
+	}
+	if stats.IndexFilesProcessed != 1 {
+		t.Errorf("index files: got %d, want 1", stats.IndexFilesProcessed)
+	}
+	if stats.DigestsTouched != 1 {
+		t.Errorf("digests touched: got %d, want 1", stats.DigestsTouched)
+	}
+	if !recentAtime(t, chunkPath) {
+		t.Errorf("namespaced chunk atime not advanced by Mark")
+	}
+}
+
 func TestMark_SkipsChunkStore(t *testing.T) {
 	root := setupDatastore(t)
 

--- a/services/backupos-pbs/internal/namespace/namespace.go
+++ b/services/backupos-pbs/internal/namespace/namespace.go
@@ -1,0 +1,94 @@
+// Package namespace implements PBS backup namespace parsing and path resolution.
+//
+// A namespace is an ordered list of path components that isolates backup
+// groups within a datastore. The empty namespace (root) maps to the datastore
+// root — today's layout is unchanged. Each non-root component adds two path
+// segments: ns/<part>, mirroring pbs-datastore/src/datastore.rs:namespace_path.
+//
+// "alice"     → ns/alice/
+// "alice/dev" → ns/alice/ns/dev/
+package namespace
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	MaxDepth     = 4
+	MaxStringLen = 64
+)
+
+var (
+	ErrInvalidNamespace = errors.New("invalid namespace")
+	componentPattern    = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+)
+
+// Namespace represents a backup namespace as an ordered list of path
+// components. The empty namespace (zero components) is the root namespace —
+// equivalent to today's no-namespace layout.
+type Namespace struct {
+	components []string
+}
+
+// Root returns the empty namespace (no components).
+func Root() Namespace {
+	return Namespace{}
+}
+
+// Parse builds a Namespace from a slash-separated string. Empty string
+// returns the root namespace. Validates depth, length, and component format.
+func Parse(s string) (Namespace, error) {
+	if s == "" {
+		return Root(), nil
+	}
+	if len(s) > MaxStringLen {
+		return Namespace{}, fmt.Errorf("%w: longer than %d chars", ErrInvalidNamespace, MaxStringLen)
+	}
+	parts := strings.Split(s, "/")
+	if len(parts) > MaxDepth {
+		return Namespace{}, fmt.Errorf("%w: depth %d exceeds max %d", ErrInvalidNamespace, len(parts), MaxDepth)
+	}
+	for _, p := range parts {
+		if !componentPattern.MatchString(p) {
+			return Namespace{}, fmt.Errorf("%w: component %q invalid (must match [a-zA-Z0-9_-]+)", ErrInvalidNamespace, p)
+		}
+	}
+	return Namespace{components: parts}, nil
+}
+
+// IsRoot returns true for the empty namespace.
+func (n Namespace) IsRoot() bool {
+	return len(n.components) == 0
+}
+
+// String returns the slash-separated representation. Root → "".
+func (n Namespace) String() string {
+	return strings.Join(n.components, "/")
+}
+
+// PathSegments returns the on-disk path segments for this namespace.
+// Root → nil. "alice" → ["ns","alice"]. "alice/dev" → ["ns","alice","ns","dev"].
+func (n Namespace) PathSegments() []string {
+	if n.IsRoot() {
+		return nil
+	}
+	segments := make([]string, 0, len(n.components)*2)
+	for _, c := range n.components {
+		segments = append(segments, "ns", c)
+	}
+	return segments
+}
+
+// JoinPath returns the absolute path of the namespace under the given root.
+// Root namespace returns root unchanged.
+func (n Namespace) JoinPath(root string) string {
+	segments := n.PathSegments()
+	if len(segments) == 0 {
+		return root
+	}
+	return filepath.Join(append([]string{root}, segments...)...)
+}

--- a/services/backupos-pbs/internal/namespace/namespace_test.go
+++ b/services/backupos-pbs/internal/namespace/namespace_test.go
@@ -1,0 +1,156 @@
+package namespace
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParse_EmptyString_ReturnsRoot(t *testing.T) {
+	ns, err := Parse("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ns.IsRoot() {
+		t.Errorf("expected root namespace, got %q", ns)
+	}
+}
+
+func TestParse_SingleComponent(t *testing.T) {
+	ns, err := Parse("alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ns.String() != "alice" {
+		t.Errorf("got %q, want %q", ns, "alice")
+	}
+}
+
+func TestParse_MultipleComponents(t *testing.T) {
+	ns, err := Parse("alice/dev")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ns.String() != "alice/dev" {
+		t.Errorf("got %q, want %q", ns, "alice/dev")
+	}
+}
+
+func TestParse_TooDeep_ReturnsError(t *testing.T) {
+	// 5 components exceeds MaxDepth=4
+	_, err := Parse("a/b/c/d/e")
+	if !errors.Is(err, ErrInvalidNamespace) {
+		t.Errorf("expected ErrInvalidNamespace for depth 5, got %v", err)
+	}
+}
+
+func TestParse_ExactlyMaxDepth_Accepted(t *testing.T) {
+	_, err := Parse("a/b/c/d")
+	if err != nil {
+		t.Errorf("expected depth 4 to be accepted, got %v", err)
+	}
+}
+
+func TestParse_TooLong_ReturnsError(t *testing.T) {
+	// 65 chars exceeds MaxStringLen=64
+	long := strings.Repeat("a", 65)
+	_, err := Parse(long)
+	if !errors.Is(err, ErrInvalidNamespace) {
+		t.Errorf("expected ErrInvalidNamespace for length 65, got %v", err)
+	}
+}
+
+func TestParse_InvalidCharacter_ReturnsError(t *testing.T) {
+	cases := []string{
+		"alice/with space",
+		"alice/..",
+		"alice/.",
+		"alice/with.dot",
+		"alice//double",
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			_, err := Parse(c)
+			if !errors.Is(err, ErrInvalidNamespace) {
+				t.Errorf("Parse(%q): expected ErrInvalidNamespace, got %v", c, err)
+			}
+		})
+	}
+}
+
+func TestParse_EmptyComponent_ReturnsError(t *testing.T) {
+	cases := []string{"/alice", "alice/"}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			_, err := Parse(c)
+			if !errors.Is(err, ErrInvalidNamespace) {
+				t.Errorf("Parse(%q): expected ErrInvalidNamespace, got %v", c, err)
+			}
+		})
+	}
+}
+
+func TestPathSegments_Root_ReturnsNil(t *testing.T) {
+	ns := Root()
+	if segs := ns.PathSegments(); segs != nil {
+		t.Errorf("Root().PathSegments() = %v, want nil", segs)
+	}
+}
+
+func TestPathSegments_OneLevel(t *testing.T) {
+	ns, _ := Parse("alice")
+	want := []string{"ns", "alice"}
+	got := ns.PathSegments()
+	if len(got) != len(want) {
+		t.Fatalf("PathSegments() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("PathSegments()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPathSegments_TwoLevels(t *testing.T) {
+	ns, _ := Parse("alice/dev")
+	want := []string{"ns", "alice", "ns", "dev"}
+	got := ns.PathSegments()
+	if len(got) != len(want) {
+		t.Fatalf("PathSegments() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("PathSegments()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestJoinPath_Root_ReturnsRoot(t *testing.T) {
+	ns := Root()
+	root := "/var/lib/backupos/pbs/mystore"
+	if got := ns.JoinPath(root); got != root {
+		t.Errorf("Root().JoinPath(%q) = %q, want %q", root, got, root)
+	}
+}
+
+func TestJoinPath_OneLevel(t *testing.T) {
+	ns, _ := Parse("alice")
+	got := ns.JoinPath("/data")
+	want := "/data/ns/alice"
+	if got != want {
+		t.Errorf("JoinPath = %q, want %q", got, want)
+	}
+}
+
+func TestString_RoundTrip(t *testing.T) {
+	cases := []string{"alice", "alice/dev", "a/b/c/d", ""}
+	for _, s := range cases {
+		ns, err := Parse(s)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", s, err)
+		}
+		if got := ns.String(); got != s {
+			t.Errorf("Parse(%q).String() = %q, want %q", s, got, s)
+		}
+	}
+}

--- a/services/backupos-pbs/internal/owner/owner.go
+++ b/services/backupos-pbs/internal/owner/owner.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 )
 
 // ErrOwnerMismatch is returned when the requested operation's caller
@@ -26,16 +28,16 @@ var ErrInvalidOwnerFile = errors.New("invalid owner file format")
 
 // Path returns the absolute path to the owner file for a backup group.
 //
-// Layout: <datastoreRoot>/<backupType>/<backupID>/owner
-func Path(datastoreRoot, backupType, backupID string) string {
-	return filepath.Join(datastoreRoot, backupType, backupID, "owner")
+// Layout: <ns-path>/<backupType>/<backupID>/owner
+func Path(datastoreRoot string, ns namespace.Namespace, backupType, backupID string) string {
+	return filepath.Join(ns.JoinPath(datastoreRoot), backupType, backupID, "owner")
 }
 
 // Read returns the authid string stored in the owner file for the given group.
 // Returns os.ErrNotExist (wrapped) if the owner file doesn't exist.
 // Returns ErrInvalidOwnerFile if the file exists but can't be parsed.
-func Read(datastoreRoot, backupType, backupID string) (string, error) {
-	path := Path(datastoreRoot, backupType, backupID)
+func Read(datastoreRoot string, ns namespace.Namespace, backupType, backupID string) (string, error) {
+	path := Path(datastoreRoot, ns, backupType, backupID)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", err // includes wrapped os.ErrNotExist
@@ -56,12 +58,12 @@ func Read(datastoreRoot, backupType, backupID string) (string, error) {
 // The atomic write is: create owner.tmp, write contents+newline, fsync,
 // rename to owner. A crash mid-write leaves owner.tmp orphaned but no
 // corrupt owner file.
-func SetIfAbsent(datastoreRoot, backupType, backupID, authid string) error {
+func SetIfAbsent(datastoreRoot string, ns namespace.Namespace, backupType, backupID, authid string) error {
 	if !strings.Contains(authid, "@") {
 		return fmt.Errorf("%w: %q is not a valid authid", ErrInvalidOwnerFile, authid)
 	}
 
-	groupDir := filepath.Join(datastoreRoot, backupType, backupID)
+	groupDir := filepath.Join(ns.JoinPath(datastoreRoot), backupType, backupID)
 	if err := os.MkdirAll(groupDir, 0o755); err != nil {
 		return fmt.Errorf("create group dir: %w", err)
 	}
@@ -69,7 +71,7 @@ func SetIfAbsent(datastoreRoot, backupType, backupID, authid string) error {
 	ownerPath := filepath.Join(groupDir, "owner")
 
 	// Try to read existing owner; if it matches, we're idempotent.
-	if existing, err := Read(datastoreRoot, backupType, backupID); err == nil {
+	if existing, err := Read(datastoreRoot, ns, backupType, backupID); err == nil {
 		if AuthidMatches(existing, authid) {
 			return nil // already ours, nothing to do
 		}
@@ -110,8 +112,8 @@ func SetIfAbsent(datastoreRoot, backupType, backupID, authid string) error {
 // if the authids don't match.
 //
 // V1 backwards-compat: if the owner file doesn't exist, returns nil (allow).
-func Check(datastoreRoot, backupType, backupID, callerAuthid string) error {
-	existing, err := Read(datastoreRoot, backupType, backupID)
+func Check(datastoreRoot string, ns namespace.Namespace, backupType, backupID, callerAuthid string) error {
+	existing, err := Read(datastoreRoot, ns, backupType, backupID)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil // V1: legacy groups without owner files are allowed

--- a/services/backupos-pbs/internal/owner/owner_test.go
+++ b/services/backupos-pbs/internal/owner/owner_test.go
@@ -5,10 +5,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 )
 
 func TestPath_Format(t *testing.T) {
-	got := Path("/var/lib/backupos/pbs/mystore", "vm", "100")
+	got := Path("/var/lib/backupos/pbs/mystore", namespace.Root(), "vm", "100")
 	want := "/var/lib/backupos/pbs/mystore/vm/100/owner"
 	if got != want {
 		t.Errorf("Path = %q, want %q", got, want)
@@ -17,7 +19,7 @@ func TestPath_Format(t *testing.T) {
 
 func TestRead_NonExistent_ReturnsErrNotExist(t *testing.T) {
 	root := t.TempDir()
-	_, err := Read(root, "vm", "100")
+	_, err := Read(root, namespace.Root(), "vm", "100")
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("expected os.ErrNotExist, got %v", err)
 	}
@@ -32,7 +34,7 @@ func TestRead_ValidFile_ReturnsUserRealm(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("root@pbs\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := Read(root, "vm", "100")
+	got, err := Read(root, namespace.Root(), "vm", "100")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -50,7 +52,7 @@ func TestRead_TrimsTrailingNewline(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("alice@pbs\n\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := Read(root, "vm", "200")
+	got, err := Read(root, namespace.Root(), "vm", "200")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -68,7 +70,7 @@ func TestRead_NoNewline_AlsoWorks(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("root@pam"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := Read(root, "ct", "42")
+	got, err := Read(root, namespace.Root(), "ct", "42")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -86,7 +88,7 @@ func TestRead_InvalidFormat_ReturnsErrInvalidOwnerFile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("not-valid-garbage\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, err := Read(root, "vm", "300")
+	_, err := Read(root, namespace.Root(), "vm", "300")
 	if !errors.Is(err, ErrInvalidOwnerFile) {
 		t.Errorf("expected ErrInvalidOwnerFile, got %v", err)
 	}
@@ -101,7 +103,7 @@ func TestRead_TokenNameInFile_Accepted(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("root@pbs!alice\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := Read(root, "vm", "400")
+	got, err := Read(root, namespace.Root(), "vm", "400")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -112,10 +114,10 @@ func TestRead_TokenNameInFile_Accepted(t *testing.T) {
 
 func TestSetIfAbsent_FreshGroup_WritesFile(t *testing.T) {
 	root := t.TempDir()
-	if err := SetIfAbsent(root, "vm", "500", "root@pbs"); err != nil {
+	if err := SetIfAbsent(root, namespace.Root(), "vm", "500", "root@pbs"); err != nil {
 		t.Fatalf("SetIfAbsent: %v", err)
 	}
-	got, err := Read(root, "vm", "500")
+	got, err := Read(root, namespace.Root(), "vm", "500")
 	if err != nil {
 		t.Fatalf("Read after set: %v", err)
 	}
@@ -126,20 +128,20 @@ func TestSetIfAbsent_FreshGroup_WritesFile(t *testing.T) {
 
 func TestSetIfAbsent_SameOwner_Idempotent(t *testing.T) {
 	root := t.TempDir()
-	if err := SetIfAbsent(root, "vm", "600", "root@pbs"); err != nil {
+	if err := SetIfAbsent(root, namespace.Root(), "vm", "600", "root@pbs"); err != nil {
 		t.Fatalf("first SetIfAbsent: %v", err)
 	}
-	if err := SetIfAbsent(root, "vm", "600", "root@pbs"); err != nil {
+	if err := SetIfAbsent(root, namespace.Root(), "vm", "600", "root@pbs"); err != nil {
 		t.Errorf("second SetIfAbsent (same owner): %v", err)
 	}
 }
 
 func TestSetIfAbsent_DifferentOwner_ReturnsErrOwnerMismatch(t *testing.T) {
 	root := t.TempDir()
-	if err := SetIfAbsent(root, "vm", "700", "root@pbs"); err != nil {
+	if err := SetIfAbsent(root, namespace.Root(), "vm", "700", "root@pbs"); err != nil {
 		t.Fatalf("first SetIfAbsent: %v", err)
 	}
-	err := SetIfAbsent(root, "vm", "700", "alice@pbs")
+	err := SetIfAbsent(root, namespace.Root(), "vm", "700", "alice@pbs")
 	if !errors.Is(err, ErrOwnerMismatch) {
 		t.Errorf("expected ErrOwnerMismatch, got %v", err)
 	}
@@ -147,10 +149,10 @@ func TestSetIfAbsent_DifferentOwner_ReturnsErrOwnerMismatch(t *testing.T) {
 
 func TestSetIfAbsent_AtomicWrite_NoOwnerTmpAfterSuccess(t *testing.T) {
 	root := t.TempDir()
-	if err := SetIfAbsent(root, "vm", "800", "root@pbs"); err != nil {
+	if err := SetIfAbsent(root, namespace.Root(), "vm", "800", "root@pbs"); err != nil {
 		t.Fatalf("SetIfAbsent: %v", err)
 	}
-	tmpPath := Path(root, "vm", "800") + ".tmp"
+	tmpPath := Path(root, namespace.Root(), "vm", "800") + ".tmp"
 	if _, err := os.Stat(tmpPath); !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("owner.tmp should not exist after successful write, got: %v", err)
 	}
@@ -158,10 +160,10 @@ func TestSetIfAbsent_AtomicWrite_NoOwnerTmpAfterSuccess(t *testing.T) {
 
 func TestSetIfAbsent_AcceptsTokenInInput(t *testing.T) {
 	root := t.TempDir()
-	if err := SetIfAbsent(root, "vm", "900", "root@pbs!alice"); err != nil {
+	if err := SetIfAbsent(root, namespace.Root(), "vm", "900", "root@pbs!alice"); err != nil {
 		t.Fatalf("SetIfAbsent with token authid: %v", err)
 	}
-	got, err := Read(root, "vm", "900")
+	got, err := Read(root, namespace.Root(), "vm", "900")
 	if err != nil {
 		t.Fatalf("Read after set: %v", err)
 	}
@@ -173,11 +175,11 @@ func TestSetIfAbsent_AcceptsTokenInInput(t *testing.T) {
 func TestSetIfAbsent_TokenStored_UserCaller_Idempotent(t *testing.T) {
 	root := t.TempDir()
 	// Pre-create owner as token authid.
-	if err := SetIfAbsent(root, "vm", "910", "root@pbs!test1"); err != nil {
+	if err := SetIfAbsent(root, namespace.Root(), "vm", "910", "root@pbs!test1"); err != nil {
 		t.Fatalf("first SetIfAbsent: %v", err)
 	}
 	// Same user's bare authid should match via AuthidMatches (token stored, user calling).
-	if err := SetIfAbsent(root, "vm", "910", "root@pbs"); err != nil {
+	if err := SetIfAbsent(root, namespace.Root(), "vm", "910", "root@pbs"); err != nil {
 		t.Errorf("SetIfAbsent for user portion of token owner: %v", err)
 	}
 }
@@ -185,11 +187,11 @@ func TestSetIfAbsent_TokenStored_UserCaller_Idempotent(t *testing.T) {
 func TestSetIfAbsent_UserStored_TokenCaller_Mismatch(t *testing.T) {
 	root := t.TempDir()
 	// Pre-create owner as bare user.
-	if err := SetIfAbsent(root, "vm", "920", "root@pbs"); err != nil {
+	if err := SetIfAbsent(root, namespace.Root(), "vm", "920", "root@pbs"); err != nil {
 		t.Fatalf("first SetIfAbsent: %v", err)
 	}
 	// Token caller does NOT match bare-user stored owner (asymmetric rule).
-	err := SetIfAbsent(root, "vm", "920", "root@pbs!test1")
+	err := SetIfAbsent(root, namespace.Root(), "vm", "920", "root@pbs!test1")
 	if !errors.Is(err, ErrOwnerMismatch) {
 		t.Errorf("expected ErrOwnerMismatch for token caller vs user owner, got %v", err)
 	}
@@ -218,27 +220,27 @@ func TestAuthidMatches(t *testing.T) {
 func TestCheck_OwnerFileMissing_AllowsAccess(t *testing.T) {
 	root := t.TempDir()
 	// No owner file — V1 backcompat: allow.
-	if err := Check(root, "vm", "100", "root@pbs"); err != nil {
+	if err := Check(root, namespace.Root(), "vm", "100", "root@pbs"); err != nil {
 		t.Errorf("expected nil for missing owner file (V1 backcompat), got %v", err)
 	}
 }
 
 func TestCheck_MatchingOwner_Allowed(t *testing.T) {
 	root := t.TempDir()
-	if err := SetIfAbsent(root, "vm", "100", "root@pbs"); err != nil {
+	if err := SetIfAbsent(root, namespace.Root(), "vm", "100", "root@pbs"); err != nil {
 		t.Fatal(err)
 	}
-	if err := Check(root, "vm", "100", "root@pbs"); err != nil {
+	if err := Check(root, namespace.Root(), "vm", "100", "root@pbs"); err != nil {
 		t.Errorf("expected nil for matching owner, got %v", err)
 	}
 }
 
 func TestCheck_DifferentOwner_Denied(t *testing.T) {
 	root := t.TempDir()
-	if err := SetIfAbsent(root, "vm", "100", "root@pbs"); err != nil {
+	if err := SetIfAbsent(root, namespace.Root(), "vm", "100", "root@pbs"); err != nil {
 		t.Fatal(err)
 	}
-	err := Check(root, "vm", "100", "alice@pbs")
+	err := Check(root, namespace.Root(), "vm", "100", "alice@pbs")
 	if !errors.Is(err, ErrOwnerMismatch) {
 		t.Errorf("expected ErrOwnerMismatch, got %v", err)
 	}
@@ -253,7 +255,7 @@ func TestCheck_InvalidFile_Errors(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "owner"), []byte("garbage-no-at\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	err := Check(root, "vm", "100", "root@pbs")
+	err := Check(root, namespace.Root(), "vm", "100", "root@pbs")
 	if err == nil {
 		t.Error("expected error for invalid owner file, got nil")
 	}

--- a/services/backupos-pbs/internal/readerupgrade/handler.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/owner"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/rstate"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snaplock"
@@ -114,8 +115,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Step 4: Parse query parameters.
 	q := r.URL.Query()
 
-	if ns := q.Get("ns"); ns != "" {
-		writeJSONError(w, http.StatusBadRequest, "namespaces not supported in V1")
+	ns, err := namespace.Parse(q.Get("ns"))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("invalid namespace: %s", err))
 		return
 	}
 
@@ -169,7 +171,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Owner check: caller must match the stored authid per PBS check_backup_owner semantics.
 	callerAuthid := identity.Authid()
-	if err := owner.Check(ds.Path, backupType, backupID, callerAuthid); err != nil {
+	if err := owner.Check(ds.Path, ns, backupType, backupID, callerAuthid); err != nil {
 		if errors.Is(err, owner.ErrOwnerMismatch) {
 			slog.Info("reader rejected: backup group owner mismatch",
 				"user", callerAuthid,
@@ -187,7 +189,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Step 6: Resolve snapshot (must exist) and acquire shared lock.
-	snapDir, err := snapshot.ResolveDir(ds.Path, backupType, backupID, backupTime)
+	snapDir, err := snapshot.ResolveDir(ds.Path, ns, backupType, backupID, backupTime)
 	if err != nil {
 		slog.Info("reader rejected: snapshot not found",
 			"store", storeName, "backup_type", backupType,
@@ -251,6 +253,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		BackupType:    backupType,
 		BackupID:      backupID,
 		BackupTime:    backupTime,
+		Namespace:     ns,
 		ReaderState:   rs,
 	}
 

--- a/services/backupos-pbs/internal/readerupgrade/handler_test.go
+++ b/services/backupos-pbs/internal/readerupgrade/handler_test.go
@@ -455,7 +455,9 @@ func TestHandler_InvalidBackupType_Returns400(t *testing.T) {
 	}
 }
 
-func TestHandler_NamespaceProvided_Returns400(t *testing.T) {
+func TestHandler_NamespaceProvided_SnapshotNotFound_Returns404(t *testing.T) {
+	// Validates that ?ns= is accepted (not rejected 400) and the namespace is
+	// threaded through: snapshot lookup in ns/alice/ fails with 404, not 400.
 	tmp := t.TempDir()
 	db := setupTestDB(t, tmp)
 	h := newTestHandler(db)
@@ -463,7 +465,7 @@ func TestHandler_NamespaceProvided_Returns400(t *testing.T) {
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
-	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader"+readerQuerySfx+"&ns=mynamespace", nil)
+	req, _ := http.NewRequest("GET", srv.URL+"/api2/json/reader"+readerQuerySfx+"&ns=alice", nil)
 	req.Header.Set("Authorization", readerAuthHeader())
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", ReaderProtocolID)
@@ -474,8 +476,8 @@ func TestHandler_NamespaceProvided_Returns400(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 (snapshot missing in ns/alice), got %d", resp.StatusCode)
 	}
 }
 

--- a/services/backupos-pbs/internal/session/session.go
+++ b/services/backupos-pbs/internal/session/session.go
@@ -44,6 +44,7 @@ type BeginParams struct {
 	BackupID    string
 	BackupTime  time.Time
 	Kind        Kind
+	Namespace   string // "" for root namespace
 }
 
 // Store provides session lifecycle operations against pbs_active_sessions.
@@ -64,8 +65,8 @@ func (s *Store) Begin(p BeginParams) (string, error) {
 	const query = `
 		INSERT INTO pbs_active_sessions (
 			id, token_id, datastore_id, backup_type, backup_id, backup_time,
-			started_at, state, scratch_path
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+			started_at, state, scratch_path, namespace
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
 	`
 	_, err := s.db.Exec(query,
 		id,
@@ -76,6 +77,7 @@ func (s *Store) Begin(p BeginParams) (string, error) {
 		p.BackupTime.UnixMilli(),
 		now,
 		string(p.Kind),
+		p.Namespace,
 	)
 	if err != nil {
 		return "", fmt.Errorf("insert session: %w", err)

--- a/services/backupos-pbs/internal/session/session_test.go
+++ b/services/backupos-pbs/internal/session/session_test.go
@@ -27,7 +27,8 @@ func setupTestDB(t *testing.T) *sql.DB {
 			backup_time   INTEGER NOT NULL,
 			started_at    INTEGER NOT NULL,
 			state         TEXT NOT NULL,
-			scratch_path  TEXT
+			scratch_path  TEXT,
+			namespace      TEXT NOT NULL DEFAULT ''
 		);
 	`)
 	if err != nil {

--- a/services/backupos-pbs/internal/sessionreaper/reaper_test.go
+++ b/services/backupos-pbs/internal/sessionreaper/reaper_test.go
@@ -28,7 +28,8 @@ func setupDB(t *testing.T) *sql.DB {
 			backup_time  INTEGER NOT NULL,
 			started_at   INTEGER NOT NULL,
 			state        TEXT NOT NULL,
-			scratch_path TEXT
+			scratch_path TEXT,
+			namespace     TEXT NOT NULL DEFAULT ''
 		)
 	`)
 	if err != nil {

--- a/services/backupos-pbs/internal/snapshot/snapshot.go
+++ b/services/backupos-pbs/internal/snapshot/snapshot.go
@@ -1,10 +1,10 @@
 // Package snapshot implements snapshot directory layout helpers for the
 // PBS protocol. Per the PBS spec, snapshots live at:
 //
-//	<datastore-root>/<backup-type>/<backup-id>/<backup-time-ISO>/
+//	<ns-path>/<backup-type>/<backup-id>/<backup-time-ISO>/
 //
-// The Go service creates the snapshot directory lazily on first write
-// (blob, index, etc.) so aborted sessions leave no filesystem footprint.
+// where <ns-path> is the namespace-adjusted datastore root (empty namespace
+// = datastore root unchanged; "alice" → <root>/ns/alice).
 package snapshot
 
 import (
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 )
 
 // backupIDRegex matches the same constraints upgrade.ParseParams enforces.
@@ -38,7 +40,7 @@ func (e *ErrInvalidBackupParams) Error() string { return e.Reason }
 // The PBS time format is RFC3339 with second precision and no fractional
 // seconds, suffixed with Z (e.g. "2024-12-24T00:26:40Z"). The timestamp is
 // always normalized to UTC.
-func Path(datastoreRoot, backupType, backupID string, backupTime time.Time) (string, error) {
+func Path(datastoreRoot string, ns namespace.Namespace, backupType, backupID string, backupTime time.Time) (string, error) {
 	if !validBackupTypes[backupType] {
 		return "", &ErrInvalidBackupParams{Reason: fmt.Sprintf("invalid backup-type %q", backupType)}
 	}
@@ -46,14 +48,14 @@ func Path(datastoreRoot, backupType, backupID string, backupTime time.Time) (str
 		return "", &ErrInvalidBackupParams{Reason: fmt.Sprintf("invalid backup-id %q", backupID)}
 	}
 	timeStr := backupTime.UTC().Format("2006-01-02T15:04:05Z")
-	return filepath.Join(datastoreRoot, backupType, backupID, timeStr), nil
+	return filepath.Join(ns.JoinPath(datastoreRoot), backupType, backupID, timeStr), nil
 }
 
 // EnsureDir returns the canonical snapshot path AND ensures it exists on
 // disk (creating parent directories as needed). Idempotent — safe to call
 // multiple times for the same snapshot.
-func EnsureDir(datastoreRoot, backupType, backupID string, backupTime time.Time) (string, error) {
-	p, err := Path(datastoreRoot, backupType, backupID, backupTime)
+func EnsureDir(datastoreRoot string, ns namespace.Namespace, backupType, backupID string, backupTime time.Time) (string, error) {
+	p, err := Path(datastoreRoot, ns, backupType, backupID, backupTime)
 	if err != nil {
 		return "", err
 	}
@@ -66,8 +68,8 @@ func EnsureDir(datastoreRoot, backupType, backupID string, backupTime time.Time)
 // ResolveDir returns the absolute path to an existing snapshot directory, or
 // an error if it doesn't exist. Unlike EnsureDir, this never creates anything.
 // Used by reader sessions which require the snapshot to already exist.
-func ResolveDir(datastoreRoot, backupType, backupID string, backupTime time.Time) (string, error) {
-	p, err := Path(datastoreRoot, backupType, backupID, backupTime)
+func ResolveDir(datastoreRoot string, ns namespace.Namespace, backupType, backupID string, backupTime time.Time) (string, error) {
+	p, err := Path(datastoreRoot, ns, backupType, backupID, backupTime)
 	if err != nil {
 		return "", err
 	}

--- a/services/backupos-pbs/internal/snapshot/snapshot_test.go
+++ b/services/backupos-pbs/internal/snapshot/snapshot_test.go
@@ -6,10 +6,12 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 )
 
 func TestPath_Valid(t *testing.T) {
-	p, err := Path("/data", "vm", "100", time.Unix(1735000000, 0))
+	p, err := Path("/data", namespace.Root(), "vm", "100", time.Unix(1735000000, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,7 +24,7 @@ func TestPath_Valid(t *testing.T) {
 func TestPath_NormalizesToUTC(t *testing.T) {
 	loc, _ := time.LoadLocation("America/New_York")
 	t1 := time.Unix(1735000000, 0).In(loc)
-	p, err := Path("/data", "vm", "100", t1)
+	p, err := Path("/data", namespace.Root(), "vm", "100", t1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +35,7 @@ func TestPath_NormalizesToUTC(t *testing.T) {
 }
 
 func TestPath_RejectsInvalidBackupType(t *testing.T) {
-	_, err := Path("/data", "tape", "100", time.Unix(1735000000, 0))
+	_, err := Path("/data", namespace.Root(), "tape", "100", time.Unix(1735000000, 0))
 	var e *ErrInvalidBackupParams
 	if !errors.As(err, &e) {
 		t.Errorf("expected ErrInvalidBackupParams, got %v", err)
@@ -44,7 +46,7 @@ func TestPath_RejectsTraversal(t *testing.T) {
 	cases := []string{"../escape", "../../root", "with/slash", "with space", ""}
 	for _, bid := range cases {
 		t.Run(bid, func(t *testing.T) {
-			_, err := Path("/data", "vm", bid, time.Unix(1735000000, 0))
+			_, err := Path("/data", namespace.Root(), "vm", bid, time.Unix(1735000000, 0))
 			var e *ErrInvalidBackupParams
 			if !errors.As(err, &e) {
 				t.Errorf("expected ErrInvalidBackupParams, got %v", err)
@@ -55,7 +57,7 @@ func TestPath_RejectsTraversal(t *testing.T) {
 
 func TestEnsureDir_CreatesDirs(t *testing.T) {
 	tmp := t.TempDir()
-	p, err := EnsureDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	p, err := EnsureDir(tmp, namespace.Root(), "vm", "100", time.Unix(1735000000, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,11 +76,11 @@ func TestEnsureDir_CreatesDirs(t *testing.T) {
 
 func TestEnsureDir_Idempotent(t *testing.T) {
 	tmp := t.TempDir()
-	p1, err := EnsureDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	p1, err := EnsureDir(tmp, namespace.Root(), "vm", "100", time.Unix(1735000000, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
-	p2, err := EnsureDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	p2, err := EnsureDir(tmp, namespace.Root(), "vm", "100", time.Unix(1735000000, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,11 +92,11 @@ func TestEnsureDir_Idempotent(t *testing.T) {
 func TestResolveDir_ExistingSnapshot_ReturnsPath(t *testing.T) {
 	tmp := t.TempDir()
 	// Pre-create the snapshot dir.
-	p, err := EnsureDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	p, err := EnsureDir(tmp, namespace.Root(), "vm", "100", time.Unix(1735000000, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, err := ResolveDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	got, err := ResolveDir(tmp, namespace.Root(), "vm", "100", time.Unix(1735000000, 0))
 	if err != nil {
 		t.Fatalf("ResolveDir: %v", err)
 	}
@@ -105,7 +107,7 @@ func TestResolveDir_ExistingSnapshot_ReturnsPath(t *testing.T) {
 
 func TestResolveDir_NonexistentSnapshot_ReturnsError(t *testing.T) {
 	tmp := t.TempDir()
-	_, err := ResolveDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	_, err := ResolveDir(tmp, namespace.Root(), "vm", "100", time.Unix(1735000000, 0))
 	if err == nil {
 		t.Error("expected error for nonexistent snapshot, got nil")
 	}
@@ -114,7 +116,7 @@ func TestResolveDir_NonexistentSnapshot_ReturnsError(t *testing.T) {
 func TestResolveDir_NonDirectoryPath_ReturnsError(t *testing.T) {
 	tmp := t.TempDir()
 	// Create a file where the snapshot dir would be.
-	p, _ := Path(tmp, "vm", "100", time.Unix(1735000000, 0))
+	p, _ := Path(tmp, namespace.Root(), "vm", "100", time.Unix(1735000000, 0))
 	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +126,7 @@ func TestResolveDir_NonDirectoryPath_ReturnsError(t *testing.T) {
 	}
 	f.Close()
 
-	_, err = ResolveDir(tmp, "vm", "100", time.Unix(1735000000, 0))
+	_, err = ResolveDir(tmp, namespace.Root(), "vm", "100", time.Unix(1735000000, 0))
 	if err == nil {
 		t.Error("expected error for non-directory path, got nil")
 	}

--- a/services/backupos-pbs/internal/streamctx/streamctx.go
+++ b/services/backupos-pbs/internal/streamctx/streamctx.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/rstate"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
 )
@@ -28,7 +29,7 @@ type SessionContext struct {
 	BackupType    string       // "vm" | "ct" | "host"
 	BackupID      string       // e.g. "100"
 	BackupTime    time.Time    // backup-time
-	Namespace     string       // optional, "" if none
+	Namespace     namespace.Namespace // root if no ?ns= provided
 	WriterState   *wstate.State // per-session writer state (fixed/dynamic index maps); nil for reader sessions
 	ReaderState   *rstate.State // per-session reader state (allowed_chunks set); nil for backup sessions
 }

--- a/services/backupos-pbs/internal/streamctx/streamctx_test.go
+++ b/services/backupos-pbs/internal/streamctx/streamctx_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 )
 
 func TestWithSession_RoundTrip(t *testing.T) {
@@ -15,7 +17,7 @@ func TestWithSession_RoundTrip(t *testing.T) {
 		BackupType:    "vm",
 		BackupID:      "100",
 		BackupTime:    time.Unix(1735000000, 0),
-		Namespace:     "",
+		Namespace:     namespace.Root(),
 	}
 	ctx := WithSession(context.Background(), want)
 	got := FromContext(ctx)

--- a/services/backupos-pbs/internal/upgrade/handler.go
+++ b/services/backupos-pbs/internal/upgrade/handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/owner"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
@@ -113,6 +114,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ns, err := namespace.Parse(params.Namespace)
+	if err != nil {
+		writeUpgradeError(w, http.StatusBadRequest, fmt.Sprintf("invalid namespace: %s", err))
+		return
+	}
+
 	// Step 3: Datastore lookup.
 	ds, err := h.datastores.ByName(params.Store)
 	if errors.Is(err, datastore.ErrNotFound) {
@@ -152,7 +159,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	authid := identity.Authid()
-	if err := owner.SetIfAbsent(ds.Path, string(params.BackupType), params.BackupID, authid); err != nil {
+	if err := owner.SetIfAbsent(ds.Path, ns, string(params.BackupType), params.BackupID, authid); err != nil {
 		if errors.Is(err, owner.ErrOwnerMismatch) {
 			slog.Info("upgrade rejected: backup group owner mismatch",
 				"user", authid,
@@ -181,6 +188,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		BackupID:    params.BackupID,
 		BackupTime:  params.BackupTime,
 		Kind:        kind,
+		Namespace:   params.Namespace,
 	})
 	if err != nil {
 		slog.Error("session begin failed", "error", err, "datastore_id", ds.ID)
@@ -239,7 +247,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		BackupType:    string(params.BackupType),
 		BackupID:      params.BackupID,
 		BackupTime:    params.BackupTime,
-		Namespace:     params.Namespace,
+		Namespace:     ns,
 		WriterState:   ws,
 	}
 	sessionRouter := buildSessionRouter(

--- a/services/backupos-pbs/internal/upgrade/handler_test.go
+++ b/services/backupos-pbs/internal/upgrade/handler_test.go
@@ -61,7 +61,8 @@ func setupTestDB(t *testing.T) *sql.DB {
 			backup_time   INTEGER NOT NULL,
 			started_at    INTEGER NOT NULL,
 			state         TEXT NOT NULL,
-			scratch_path  TEXT
+			scratch_path  TEXT,
+			namespace      TEXT NOT NULL DEFAULT ''
 		);
 	`)
 	if err != nil {
@@ -97,7 +98,8 @@ func setupTestDBAtPath(t *testing.T, dsPath string) *sql.DB {
 			backup_time   INTEGER NOT NULL,
 			started_at    INTEGER NOT NULL,
 			state         TEXT NOT NULL,
-			scratch_path  TEXT
+			scratch_path  TEXT,
+			namespace      TEXT NOT NULL DEFAULT ''
 		);
 	`)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Adds `?ns=<name>` parameter to backup writer and reader upgrade endpoints
- New `internal/namespace` package: validates namespace strings per PBS spec (`[a-zA-Z0-9_-]+` per component, max depth 4, max len 64); computes `ns/<part>` path segments matching `pbs-datastore/src/datastore.rs:namespace_path`
- `snapshot.Path/EnsureDir/ResolveDir` and `owner.Path/Read/SetIfAbsent/Check` all gain `ns namespace.Namespace` as 2nd parameter
- Stream handlers (`blob`, `fixedindex`, `dynamicindex`, `finish`, `download`) thread `sc.Namespace` through to filesystem paths
- Both upgrade handlers parse `?ns=` and propagate the typed `Namespace` into `SessionContext`, owner checks, snapshot resolution, and the session DB row
- Drizzle migration 0043 adds `namespace TEXT DEFAULT ''` to `pbs_active_sessions`; schema.ts updated

## Test plan

- [ ] `go mod tidy && go build ./... && timeout 60 go test ./...` passes green
- [ ] `TestMark_NamespacedSnapshot_Processed` — GC mark finds chunks in `ns/alice/` snapshot
- [ ] `TestHandler_NamespaceProvided_SnapshotNotFound_Returns404` — `?ns=alice` returns 404 (not 400), confirming namespace is parsed and used
- [ ] All 13 `namespace` package tests pass
- [ ] All existing upgrade, owner, snapshot, session, finish, sessionreaper tests pass with fixture column added

🤖 Generated with [Claude Code](https://claude.ai/claude-code)