### PR TITLE
feat(pbs): incremental backups via reuse-csum — milestone 4d

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -44,6 +44,8 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedchunk"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedclose"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fixedindex"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/previousarchive"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/previoustime"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/download"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcadmin"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/gcrun"
@@ -113,6 +115,8 @@ func main() {
 		dynamicchunk.NewHandler(),
 		dynamicappend.NewHandler(),
 		dynamicclose.NewHandler(),
+		previousarchive.NewHandler(),
+		previoustime.NewHandler(),
 		upgrade.StubStreamHandler(),
 	)
 

--- a/services/backupos-pbs/internal/fidx/read.go
+++ b/services/backupos-pbs/internal/fidx/read.go
@@ -1,0 +1,57 @@
+package fidx
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Header contains the metadata decoded from a .fidx file header.
+type Header struct {
+	IndexCsum [32]byte // SHA256 of the digest bytes
+	Size      uint64   // total content size in bytes
+	ChunkSize uint32   // chunk size in bytes (always 4 MiB in V1)
+}
+
+// ReadHeader reads and validates the 4096-byte header from r.
+// On success r is positioned at byte 4096, ready for ReadDigests.
+func ReadHeader(r io.Reader) (*Header, error) {
+	buf := make([]byte, headerSize)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, fmt.Errorf("read fidx header: %w", err)
+	}
+	var magic [8]byte
+	copy(magic[:], buf[0:8])
+	if magic != Magic {
+		return nil, fmt.Errorf("invalid fidx magic")
+	}
+	var h Header
+	copy(h.IndexCsum[:], buf[32:64])
+	h.Size = binary.LittleEndian.Uint64(buf[64:72])
+	chunkSizeU64 := binary.LittleEndian.Uint64(buf[72:80])
+	if chunkSizeU64 == 0 || chunkSizeU64 > (1<<30) {
+		return nil, fmt.Errorf("fidx chunk_size %d out of range", chunkSizeU64)
+	}
+	h.ChunkSize = uint32(chunkSizeU64)
+	return &h, nil
+}
+
+// ReadDigests reads all chunk digests from r (positioned after the header).
+// Each digest is 32 bytes; reading stops at EOF.
+// Returns an error if the data is not a multiple of 32 bytes.
+func ReadDigests(r io.Reader) ([][32]byte, error) {
+	var digests [][32]byte
+	for {
+		var d [32]byte
+		_, err := io.ReadFull(r, d[:])
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read fidx digest: %w", err)
+		}
+		digests = append(digests, d)
+	}
+	return digests, nil
+}

--- a/services/backupos-pbs/internal/fixedindex/fixedindex.go
+++ b/services/backupos-pbs/internal/fixedindex/fixedindex.go
@@ -7,14 +7,19 @@
 package fixedindex
 
 import (
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fidx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/incremental"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snapshot"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
 )
@@ -47,7 +52,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	archiveName, size, err := parseQuery(r.URL.Query())
+	archiveName, size, reuseCsumStr, err := parseQuery(r.URL.Query())
 	if err != nil {
 		slog.Info("fixed_index rejected", "reason", err.Error(), "session_id", sc.SessionID)
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -71,8 +76,40 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	isIncremental := reuseCsumStr != ""
+	if isIncremental && sc.PreviousBackup != nil {
+		csumBytes, hexErr := hex.DecodeString(reuseCsumStr)
+		if hexErr != nil || len(csumBytes) != 32 {
+			fw.Drop()
+			writeError(w, http.StatusBadRequest, "reuse-csum: invalid hex")
+			return
+		}
+		var expectedCsum [32]byte
+		copy(expectedCsum[:], csumBytes)
+		prevIndexPath := filepath.Join(sc.PreviousBackup.Path, archiveName)
+		if _, regErr := incremental.RegisterFromPreviousIndex(sc.WriterState, prevIndexPath, expectedCsum); regErr != nil {
+			if errors.Is(regErr, incremental.ErrCsumMismatch) {
+				fw.Drop()
+				writeError(w, http.StatusBadRequest, regErr.Error())
+				return
+			}
+			if !errors.Is(regErr, os.ErrNotExist) {
+				fw.Drop()
+				slog.Error("incremental register failed",
+					"error", regErr, "session_id", sc.SessionID, "archive_name", archiveName)
+				writeError(w, http.StatusInternalServerError, "internal error")
+				return
+			}
+			slog.Warn("previous index not found, proceeding non-incrementally",
+				"session_id", sc.SessionID, "archive_name", archiveName)
+			isIncremental = false
+		}
+	} else if isIncremental {
+		isIncremental = false
+	}
+
 	sizeVal := size
-	wid, err := sc.WriterState.RegisterFixedWriter(archiveName, fw, &sizeVal, chunkSize, false)
+	wid, err := sc.WriterState.RegisterFixedWriter(archiveName, fw, &sizeVal, chunkSize, isIncremental)
 	if err != nil {
 		fw.Drop()
 		slog.Error("register fixed writer failed",
@@ -94,7 +131,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // parseQuery validates and extracts query parameters.
-func parseQuery(q map[string][]string) (archiveName string, size uint64, err error) {
+func parseQuery(q map[string][]string) (archiveName string, size uint64, reuseCsumStr string, err error) {
 	get := func(k string) string {
 		if v := q[k]; len(v) > 0 {
 			return v[0]
@@ -102,30 +139,28 @@ func parseQuery(q map[string][]string) (archiveName string, size uint64, err err
 		return ""
 	}
 
-	if get("reuse-csum") != "" {
-		return "", 0, fmt.Errorf("incremental backups (reuse-csum) not supported in V1")
-	}
+	reuseCsumStr = get("reuse-csum")
 
 	archiveName = get("archive-name")
 	if archiveName == "" {
-		return "", 0, fmt.Errorf("missing required parameter \"archive-name\"")
+		return "", 0, "", fmt.Errorf("missing required parameter \"archive-name\"")
 	}
 	if len(archiveName) > 64 {
-		return "", 0, fmt.Errorf("\"archive-name\" too long (max 64 chars)")
+		return "", 0, "", fmt.Errorf("\"archive-name\" too long (max 64 chars)")
 	}
 	if !archiveNameRegex.MatchString(archiveName) {
-		return "", 0, fmt.Errorf("invalid \"archive-name\": must match [A-Za-z0-9_.-]+\\.fidx")
+		return "", 0, "", fmt.Errorf("invalid \"archive-name\": must match [A-Za-z0-9_.-]+\\.fidx")
 	}
 
 	sizeRaw := get("size")
 	if sizeRaw == "" {
-		return "", 0, fmt.Errorf("missing required parameter \"size\" (growable .fidx not supported in V1)")
+		return "", 0, "", fmt.Errorf("missing required parameter \"size\" (growable .fidx not supported in V1)")
 	}
 	sizeI, err2 := strconv.ParseUint(sizeRaw, 10, 64)
 	if err2 != nil || sizeI == 0 {
-		return "", 0, fmt.Errorf("invalid \"size\": must be a positive integer")
+		return "", 0, "", fmt.Errorf("invalid \"size\": must be a positive integer")
 	}
-	return archiveName, sizeI, nil
+	return archiveName, sizeI, reuseCsumStr, nil
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {

--- a/services/backupos-pbs/internal/fixedindex/fixedindex.go
+++ b/services/backupos-pbs/internal/fixedindex/fixedindex.go
@@ -77,35 +77,36 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	isIncremental := reuseCsumStr != ""
-	if isIncremental && sc.PreviousBackup != nil {
+	if isIncremental {
+		if sc.PreviousBackup == nil {
+			fw.Drop()
+			writeError(w, http.StatusBadRequest, "no previous successful backup exists")
+			return
+		}
 		csumBytes, hexErr := hex.DecodeString(reuseCsumStr)
 		if hexErr != nil || len(csumBytes) != 32 {
 			fw.Drop()
-			writeError(w, http.StatusBadRequest, "reuse-csum: invalid hex")
+			writeError(w, http.StatusBadRequest, "reuse-csum: invalid hex (must be 64 hex chars)")
 			return
 		}
 		var expectedCsum [32]byte
 		copy(expectedCsum[:], csumBytes)
 		prevIndexPath := filepath.Join(sc.PreviousBackup.Path, archiveName)
 		if _, regErr := incremental.RegisterFromPreviousIndex(sc.WriterState, prevIndexPath, expectedCsum); regErr != nil {
+			fw.Drop()
 			if errors.Is(regErr, incremental.ErrCsumMismatch) {
-				fw.Drop()
 				writeError(w, http.StatusBadRequest, regErr.Error())
 				return
 			}
-			if !errors.Is(regErr, os.ErrNotExist) {
-				fw.Drop()
-				slog.Error("incremental register failed",
-					"error", regErr, "session_id", sc.SessionID, "archive_name", archiveName)
-				writeError(w, http.StatusInternalServerError, "internal error")
+			if errors.Is(regErr, os.ErrNotExist) {
+				writeError(w, http.StatusBadRequest, fmt.Sprintf("previous archive %q not found", archiveName))
 				return
 			}
-			slog.Warn("previous index not found, proceeding non-incrementally",
-				"session_id", sc.SessionID, "archive_name", archiveName)
-			isIncremental = false
+			slog.Error("incremental register failed",
+				"error", regErr, "session_id", sc.SessionID, "archive_name", archiveName)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
 		}
-	} else if isIncremental {
-		isIncremental = false
 	}
 
 	sizeVal := size

--- a/services/backupos-pbs/internal/incremental/incremental.go
+++ b/services/backupos-pbs/internal/incremental/incremental.go
@@ -1,0 +1,61 @@
+// Package incremental implements pre-population of knownChunks from a previous
+// backup's .fidx index for incremental (reuse-csum) backup sessions.
+package incremental
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fidx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
+)
+
+// ErrCsumMismatch is returned when the reuse-csum supplied by the client does
+// not match the index_csum stored in the previous archive. Maps to HTTP 400.
+var ErrCsumMismatch = errors.New("reuse-csum mismatch with previous backup")
+
+// RegisterFromPreviousIndex opens the previous backup's .fidx file at
+// previousIndexPath, validates that its index_csum equals expectedCsum, and
+// registers every chunk digest into s's knownChunks map.
+//
+// Returns the count of registered digests.
+//
+// Errors:
+//   - ErrCsumMismatch: stored csum != expectedCsum
+//   - os.ErrNotExist (wrapped): file not found
+//   - other I/O errors as appropriate
+//
+// This does NOT verify that the chunks themselves still exist on disk. The
+// close-time validation in wstate catches the rare GC race; GC is separately
+// prevented from removing live chunks by the oldest_writer extension.
+func RegisterFromPreviousIndex(s *wstate.State, previousIndexPath string, expectedCsum [32]byte) (int, error) {
+	f, err := os.Open(previousIndexPath)
+	if err != nil {
+		return 0, fmt.Errorf("open previous index: %w", err)
+	}
+	defer f.Close()
+
+	header, err := fidx.ReadHeader(f)
+	if err != nil {
+		return 0, fmt.Errorf("read previous fidx header: %w", err)
+	}
+
+	if header.IndexCsum != expectedCsum {
+		return 0, fmt.Errorf("%w: stored=%s, requested=%s",
+			ErrCsumMismatch,
+			hex.EncodeToString(header.IndexCsum[:]),
+			hex.EncodeToString(expectedCsum[:]))
+	}
+
+	digests, err := fidx.ReadDigests(f)
+	if err != nil {
+		return 0, fmt.Errorf("read previous fidx digests: %w", err)
+	}
+
+	for _, digest := range digests {
+		s.RegisterKnownChunk(digest, header.ChunkSize)
+	}
+	return len(digests), nil
+}

--- a/services/backupos-pbs/internal/incremental/incremental_test.go
+++ b/services/backupos-pbs/internal/incremental/incremental_test.go
@@ -1,0 +1,100 @@
+package incremental
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fidx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
+)
+
+const chunkSize = 4 * 1024 * 1024
+
+// buildFidx creates a .fidx file at path with the given digests and returns its
+// index_csum. Uses a consistent known size so the file is valid.
+func buildFidx(t *testing.T, path string, digests [][32]byte) [32]byte {
+	t.Helper()
+	totalSize := uint64(len(digests)) * chunkSize
+	if totalSize == 0 {
+		totalSize = chunkSize // at least one slot
+	}
+	w, err := fidx.Create(path, totalSize, chunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, d := range digests {
+		offset := uint64((i + 1)) * chunkSize
+		if err := w.AddChunk(offset, chunkSize, d); err != nil {
+			t.Fatal(err)
+		}
+	}
+	csum, err := w.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return csum
+}
+
+func TestRegister_Success(t *testing.T) {
+	dir := t.TempDir()
+	digests := [][32]byte{{0: 0x11}, {0: 0x22}, {0: 0x33}}
+	path := filepath.Join(dir, "drive-0.img.fidx")
+	csum := buildFidx(t, path, digests)
+
+	s := wstate.New()
+	n, err := RegisterFromPreviousIndex(s, path, csum)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(digests) {
+		t.Errorf("registered %d chunks, want %d", n, len(digests))
+	}
+}
+
+func TestRegister_CsumMismatch_ReturnsErr(t *testing.T) {
+	dir := t.TempDir()
+	digests := [][32]byte{{0: 0xAA}}
+	path := filepath.Join(dir, "drive-0.img.fidx")
+	buildFidx(t, path, digests)
+
+	var wrongCsum [32]byte
+	wrongCsum[0] = 0xFF
+
+	s := wstate.New()
+	_, err := RegisterFromPreviousIndex(s, path, wrongCsum)
+	if !errors.Is(err, ErrCsumMismatch) {
+		t.Errorf("expected ErrCsumMismatch, got %v", err)
+	}
+}
+
+func TestRegister_FileMissing_ReturnsErr(t *testing.T) {
+	s := wstate.New()
+	_, err := RegisterFromPreviousIndex(s, "/no/such/file.fidx", [32]byte{})
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected os.ErrNotExist (wrapped), got %v", err)
+	}
+}
+
+func TestRegister_PopulatesKnownChunks(t *testing.T) {
+	dir := t.TempDir()
+	d1 := [32]byte{0: 0xBB}
+	d2 := [32]byte{0: 0xCC}
+	path := filepath.Join(dir, "drive-0.img.fidx")
+	csum := buildFidx(t, path, [][32]byte{d1, d2})
+
+	s := wstate.New()
+	if _, err := RegisterFromPreviousIndex(s, path, csum); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both digests should now be known.
+	for _, d := range [][32]byte{d1, d2} {
+		if size, ok := s.LookupChunk(d); !ok {
+			t.Errorf("digest %x not in knownChunks after Register", d[:2])
+		} else if size != chunkSize {
+			t.Errorf("digest %x: size=%d, want %d", d[:2], size, chunkSize)
+		}
+	}
+}

--- a/services/backupos-pbs/internal/previous/previous.go
+++ b/services/backupos-pbs/internal/previous/previous.go
@@ -1,0 +1,106 @@
+// Package previous locates the most recent successful backup in a group.
+//
+// A backup is "successful" if its snapshot directory contains at least one
+// non-empty .fidx or .didx file — proving the backup wrote real archive data.
+// (PBS uses a manifest file for this; V1 uses the archive presence heuristic.)
+package previous
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
+)
+
+// Snapshot identifies a previous backup by its directory and timestamp.
+type Snapshot struct {
+	Time time.Time
+	Path string // absolute path to the snapshot directory
+}
+
+// ErrNoPrevious is returned by Find when no qualifying previous backup exists.
+var ErrNoPrevious = errors.New("no previous successful backup")
+
+// dateRegex matches the backup time directory names used by PBS.
+// Example: "2026-05-02T22:55:00Z"
+var dateRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)
+
+// Find returns the most recent successful backup in the given group that
+// predates currentBackupTime. Returns ErrNoPrevious if none qualifies.
+func Find(datastoreRoot string, ns namespace.Namespace, backupType, backupID string, currentBackupTime time.Time) (*Snapshot, error) {
+	groupPath := filepath.Join(ns.JoinPath(datastoreRoot), backupType, backupID)
+	entries, err := os.ReadDir(groupPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNoPrevious
+		}
+		return nil, err
+	}
+
+	type candidate struct {
+		t    time.Time
+		path string
+	}
+	var candidates []candidate
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !dateRegex.MatchString(name) {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, name)
+		if err != nil {
+			continue
+		}
+		// Skip the current backup and anything at or after it.
+		if !t.Before(currentBackupTime) {
+			continue
+		}
+		snapDir := filepath.Join(groupPath, name)
+		if !hasIndex(snapDir) {
+			continue
+		}
+		candidates = append(candidates, candidate{t: t, path: snapDir})
+	}
+
+	if len(candidates) == 0 {
+		return nil, ErrNoPrevious
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].t.After(candidates[j].t)
+	})
+	return &Snapshot{Time: candidates[0].t, Path: candidates[0].path}, nil
+}
+
+// hasIndex returns true if snapDir contains at least one non-empty .fidx or
+// .didx file — our heuristic proof that the backup completed real archive work.
+func hasIndex(snapDir string) bool {
+	entries, err := os.ReadDir(snapDir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		ext := filepath.Ext(name)
+		if ext != ".fidx" && ext != ".didx" {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || info.Size() == 0 {
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/services/backupos-pbs/internal/previous/previous_test.go
+++ b/services/backupos-pbs/internal/previous/previous_test.go
@@ -1,0 +1,147 @@
+package previous
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
+)
+
+const (
+	testBackupType = "vm"
+	testBackupID   = "100"
+	t0Str          = "2024-12-24T00:26:40Z"
+	t1Str          = "2025-01-01T00:00:00Z"
+	t2Str          = "2025-06-01T00:00:00Z"
+	futureStr      = "2099-01-01T00:00:00Z"
+)
+
+var (
+	t0, _ = time.Parse(time.RFC3339, t0Str)
+	t1, _ = time.Parse(time.RFC3339, t1Str)
+	t2, _ = time.Parse(time.RFC3339, t2Str)
+)
+
+// makeGroupDir creates <root>/<backupType>/<backupID>/ and returns root.
+func makeGroupDir(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, testBackupType, testBackupID), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// makeSnapDir creates a snapshot directory with an optional .fidx index file.
+func makeSnapDir(t *testing.T, root string, ts time.Time, withIndex bool) string {
+	t.Helper()
+	name := ts.UTC().Format(time.RFC3339)
+	p := filepath.Join(root, testBackupType, testBackupID, name)
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if withIndex {
+		if err := os.WriteFile(filepath.Join(p, "drive-0.img.fidx"), []byte("fidx"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return p
+}
+
+func TestFind_NoGroup_ReturnsErrNoPrevious(t *testing.T) {
+	root := t.TempDir()
+	_, err := Find(root, namespace.Root(), testBackupType, testBackupID, t2)
+	if err != ErrNoPrevious {
+		t.Errorf("expected ErrNoPrevious, got %v", err)
+	}
+}
+
+func TestFind_EmptyGroup_ReturnsErrNoPrevious(t *testing.T) {
+	root := makeGroupDir(t)
+	_, err := Find(root, namespace.Root(), testBackupType, testBackupID, t2)
+	if err != ErrNoPrevious {
+		t.Errorf("expected ErrNoPrevious, got %v", err)
+	}
+}
+
+func TestFind_NoIndexes_ReturnsErrNoPrevious(t *testing.T) {
+	root := makeGroupDir(t)
+	// Snapshot dir exists but has no .fidx/.didx files.
+	makeSnapDir(t, root, t0, false)
+	_, err := Find(root, namespace.Root(), testBackupType, testBackupID, t2)
+	if err != ErrNoPrevious {
+		t.Errorf("expected ErrNoPrevious (no real archives), got %v", err)
+	}
+}
+
+func TestFind_OnlyCurrentSnapshot_ReturnsErrNoPrevious(t *testing.T) {
+	root := makeGroupDir(t)
+	// The only snapshot is the current one — must not count as previous.
+	makeSnapDir(t, root, t1, true)
+	_, err := Find(root, namespace.Root(), testBackupType, testBackupID, t1)
+	if err != ErrNoPrevious {
+		t.Errorf("expected ErrNoPrevious (only current snapshot), got %v", err)
+	}
+}
+
+func TestFind_OnePrevious_ReturnsIt(t *testing.T) {
+	root := makeGroupDir(t)
+	snapPath := makeSnapDir(t, root, t0, true)
+
+	snap, err := Find(root, namespace.Root(), testBackupType, testBackupID, t1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.Path != snapPath {
+		t.Errorf("path: got %q, want %q", snap.Path, snapPath)
+	}
+	if !snap.Time.Equal(t0) {
+		t.Errorf("time: got %v, want %v", snap.Time, t0)
+	}
+}
+
+func TestFind_MultiplePrevious_ReturnsNewest(t *testing.T) {
+	root := makeGroupDir(t)
+	makeSnapDir(t, root, t0, true)
+	newerPath := makeSnapDir(t, root, t1, true)
+
+	// Current backup is t2 — both t0 and t1 are previous, t1 is newer.
+	snap, err := Find(root, namespace.Root(), testBackupType, testBackupID, t2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.Path != newerPath {
+		t.Errorf("expected newest previous (%q), got %q", newerPath, snap.Path)
+	}
+	if !snap.Time.Equal(t1) {
+		t.Errorf("time: got %v, want %v", snap.Time, t1)
+	}
+}
+
+func TestFind_NamespacedGroup(t *testing.T) {
+	root := t.TempDir()
+	ns, _ := namespace.Parse("alice")
+	// Create snapshot under ns/alice/vm/100/
+	nsGroupPath := filepath.Join(ns.JoinPath(root), testBackupType, testBackupID)
+	if err := os.MkdirAll(nsGroupPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	snapName := t0.UTC().Format(time.RFC3339)
+	snapPath := filepath.Join(nsGroupPath, snapName)
+	if err := os.MkdirAll(snapPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(snapPath, "drive-0.img.fidx"), []byte("fidx"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := Find(root, ns, testBackupType, testBackupID, t1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.Path != snapPath {
+		t.Errorf("path: got %q, want %q", snap.Path, snapPath)
+	}
+}

--- a/services/backupos-pbs/internal/previousarchive/previousarchive.go
+++ b/services/backupos-pbs/internal/previousarchive/previousarchive.go
@@ -1,0 +1,103 @@
+// Package previousarchive implements GET /previous?archive-name=<name>.
+//
+// The client uses this endpoint to download an archive file from the previous
+// backup directory so it can compute its index_csum and pass it back as
+// ?reuse-csum= on POST /fixed_index.
+package previousarchive
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+// archiveNameRegex accepts .fidx, .didx, and .blob archive names.
+var archiveNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_.-]+\.(fidx|didx|blob)$`)
+
+// Handler serves GET /previous.
+type Handler struct{}
+
+// NewHandler constructs a previousarchive Handler.
+func NewHandler() *Handler { return &Handler{} }
+
+// ServeHTTP handles GET /previous?archive-name=<name>.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	if sc.PreviousBackup == nil {
+		writeJSONError(w, http.StatusNotFound, "no previous successful backup")
+		return
+	}
+
+	archiveName := r.URL.Query().Get("archive-name")
+	if archiveName == "" {
+		writeJSONError(w, http.StatusBadRequest, `missing required parameter "archive-name"`)
+		return
+	}
+	if !archiveNameRegex.MatchString(archiveName) {
+		writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("invalid archive-name: %q", archiveName))
+		return
+	}
+
+	fullPath := filepath.Join(sc.PreviousBackup.Path, archiveName)
+	f, err := os.Open(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeJSONError(w, http.StatusNotFound, fmt.Sprintf("archive %q not in previous backup", archiveName))
+			return
+		}
+		slog.Error("previous archive open failed",
+			"error", err, "session_id", sc.SessionID, "archive_name", archiveName)
+		writeJSONError(w, http.StatusInternalServerError, "open failed")
+		return
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "stat failed")
+		return
+	}
+	if !info.Mode().IsRegular() {
+		writeJSONError(w, http.StatusBadRequest, "not a regular file")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", strconv.FormatInt(info.Size(), 10))
+	w.WriteHeader(http.StatusOK)
+
+	n, err := io.Copy(w, f)
+	if err != nil {
+		slog.Warn("previous archive stream failed",
+			"session_id", sc.SessionID,
+			"archive_name", archiveName,
+			"bytes_sent", n,
+			"error", err,
+		)
+	}
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/services/backupos-pbs/internal/previousarchive/previousarchive_test.go
+++ b/services/backupos-pbs/internal/previousarchive/previousarchive_test.go
@@ -1,0 +1,112 @@
+package previousarchive
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/previous"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+func makeRequest(method, archiveName string, sc *streamctx.SessionContext) *http.Request {
+	url := "/previous"
+	if archiveName != "" {
+		url += "?archive-name=" + archiveName
+	}
+	r := httptest.NewRequest(method, url, nil)
+	if sc != nil {
+		r = r.WithContext(streamctx.WithSession(r.Context(), sc))
+	}
+	return r
+}
+
+func TestPreviousArchive_MethodNotAllowed(t *testing.T) {
+	h := NewHandler()
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeRequest(http.MethodPost, "drive-0.img.fidx", &streamctx.SessionContext{}))
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestPreviousArchive_NoStreamCtx_Returns500(t *testing.T) {
+	h := NewHandler()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/previous?archive-name=drive-0.img.fidx", nil)
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestPreviousArchive_NoPreviousBackup_Returns404(t *testing.T) {
+	h := NewHandler()
+	sc := &streamctx.SessionContext{PreviousBackup: nil}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeRequest(http.MethodGet, "drive-0.img.fidx", sc))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestPreviousArchive_MissingArchiveName_Returns400(t *testing.T) {
+	h := NewHandler()
+	sc := &streamctx.SessionContext{PreviousBackup: &previous.Snapshot{}}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeRequest(http.MethodGet, "", sc))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestPreviousArchive_InvalidArchiveName_Returns400(t *testing.T) {
+	h := NewHandler()
+	sc := &streamctx.SessionContext{PreviousBackup: &previous.Snapshot{}}
+	w := httptest.NewRecorder()
+	// URL encoding of "../evil.fidx" — use raw path injection
+	r := httptest.NewRequest(http.MethodGet, "/previous?archive-name=..%2Fevil.fidx", nil)
+	r = r.WithContext(streamctx.WithSession(r.Context(), sc))
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestPreviousArchive_ArchiveNotFound_Returns404(t *testing.T) {
+	h := NewHandler()
+	sc := &streamctx.SessionContext{
+		PreviousBackup: &previous.Snapshot{Path: t.TempDir(), Time: time.Now()},
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeRequest(http.MethodGet, "drive-0.img.fidx", sc))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestPreviousArchive_StreamsFile(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("fidx file data")
+	if err := os.WriteFile(filepath.Join(dir, "drive-0.img.fidx"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := NewHandler()
+	sc := &streamctx.SessionContext{
+		PreviousBackup: &previous.Snapshot{Path: dir, Time: time.Now()},
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeRequest(http.MethodGet, "drive-0.img.fidx", sc))
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if w.Body.String() != string(content) {
+		t.Errorf("body mismatch: got %q, want %q", w.Body.String(), string(content))
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/octet-stream" {
+		t.Errorf("Content-Type: got %q, want application/octet-stream", ct)
+	}
+}

--- a/services/backupos-pbs/internal/previoustime/previoustime.go
+++ b/services/backupos-pbs/internal/previoustime/previoustime.go
@@ -1,0 +1,46 @@
+// Package previoustime implements GET /previous_backup_time.
+//
+// Returns the Unix timestamp of the previous successful backup in this group,
+// or {"data":null} if none exists.
+package previoustime
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+// Handler serves GET /previous_backup_time.
+type Handler struct{}
+
+// NewHandler constructs a previoustime Handler.
+func NewHandler() *Handler { return &Handler{} }
+
+// ServeHTTP handles GET /previous_backup_time.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	sc := streamctx.FromRequest(r)
+	if sc == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "internal error"})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if sc.PreviousBackup == nil {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": nil})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"data": sc.PreviousBackup.Time.Unix(),
+	})
+}

--- a/services/backupos-pbs/internal/previoustime/previoustime_test.go
+++ b/services/backupos-pbs/internal/previoustime/previoustime_test.go
@@ -1,0 +1,78 @@
+package previoustime
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/previous"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+)
+
+func TestPreviousTime_MethodNotAllowed(t *testing.T) {
+	h := NewHandler()
+	r := httptest.NewRequest(http.MethodPost, "/previous_backup_time", nil)
+	r = r.WithContext(streamctx.WithSession(r.Context(), &streamctx.SessionContext{}))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestPreviousTime_NoStreamCtx_Returns500(t *testing.T) {
+	h := NewHandler()
+	r := httptest.NewRequest(http.MethodGet, "/previous_backup_time", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestPreviousTime_NoPrevious_ReturnsNull(t *testing.T) {
+	h := NewHandler()
+	sc := &streamctx.SessionContext{PreviousBackup: nil}
+	r := httptest.NewRequest(http.MethodGet, "/previous_backup_time", nil)
+	r = r.WithContext(streamctx.WithSession(r.Context(), sc))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["data"] != nil {
+		t.Errorf("expected data=null, got %v", body["data"])
+	}
+}
+
+func TestPreviousTime_WithPrevious_ReturnsUnixTimestamp(t *testing.T) {
+	ts, _ := time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")
+	h := NewHandler()
+	sc := &streamctx.SessionContext{
+		PreviousBackup: &previous.Snapshot{Time: ts},
+	}
+	r := httptest.NewRequest(http.MethodGet, "/previous_backup_time", nil)
+	r = r.WithContext(streamctx.WithSession(r.Context(), sc))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := body["data"].(float64)
+	if !ok {
+		t.Fatalf("expected numeric data, got %T %v", body["data"], body["data"])
+	}
+	if int64(got) != ts.Unix() {
+		t.Errorf("timestamp: got %d, want %d", int64(got), ts.Unix())
+	}
+}

--- a/services/backupos-pbs/internal/streamctx/streamctx.go
+++ b/services/backupos-pbs/internal/streamctx/streamctx.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/previous"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/rstate"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
 )
@@ -30,8 +31,9 @@ type SessionContext struct {
 	BackupID      string       // e.g. "100"
 	BackupTime    time.Time    // backup-time
 	Namespace     namespace.Namespace // root if no ?ns= provided
-	WriterState   *wstate.State // per-session writer state (fixed/dynamic index maps); nil for reader sessions
-	ReaderState   *rstate.State // per-session reader state (allowed_chunks set); nil for backup sessions
+	WriterState    *wstate.State      // per-session writer state (fixed/dynamic index maps); nil for reader sessions
+	ReaderState    *rstate.State      // per-session reader state (allowed_chunks set); nil for backup sessions
+	PreviousBackup *previous.Snapshot // most recent prior snapshot for this group, nil if none
 }
 
 type ctxKey struct{}

--- a/services/backupos-pbs/internal/upgrade/handler.go
+++ b/services/backupos-pbs/internal/upgrade/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/owner"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/previous"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
@@ -47,11 +48,13 @@ type Handler struct {
 	fixedChunkHandler   http.Handler
 	fixedAppendHandler  http.Handler
 	fixedCloseHandler   http.Handler
-	dynamicIndexHandler  http.Handler
-	dynamicChunkHandler  http.Handler
-	dynamicAppendHandler http.Handler
-	dynamicCloseHandler  http.Handler
-	streamHandler       http.Handler // fallback 501-stub for unimplemented H2 paths
+	dynamicIndexHandler    http.Handler
+	dynamicChunkHandler    http.Handler
+	dynamicAppendHandler   http.Handler
+	dynamicCloseHandler    http.Handler
+	previousArchiveHandler http.Handler
+	previousTimeHandler    http.Handler
+	streamHandler          http.Handler // fallback 501-stub for unimplemented H2 paths
 }
 
 // NewHandler constructs a new upgrade Handler.
@@ -73,22 +76,26 @@ func NewHandler(
 	dynamicChunkHandler http.Handler,
 	dynamicAppendHandler http.Handler,
 	dynamicCloseHandler http.Handler,
+	previousArchiveHandler http.Handler,
+	previousTimeHandler http.Handler,
 	streamHandler http.Handler,
 ) *Handler {
 	return &Handler{
-		datastores:           datastores,
-		sessions:             sessions,
-		blobHandler:          blobHandler,
-		finishHandler:        finishHandler,
-		fixedIndexHandler:    fixedIndexHandler,
-		fixedChunkHandler:    fixedChunkHandler,
-		fixedAppendHandler:   fixedAppendHandler,
-		fixedCloseHandler:    fixedCloseHandler,
-		dynamicIndexHandler:  dynamicIndexHandler,
-		dynamicChunkHandler:  dynamicChunkHandler,
-		dynamicAppendHandler: dynamicAppendHandler,
-		dynamicCloseHandler:  dynamicCloseHandler,
-		streamHandler:        streamHandler,
+		datastores:             datastores,
+		sessions:               sessions,
+		blobHandler:            blobHandler,
+		finishHandler:          finishHandler,
+		fixedIndexHandler:      fixedIndexHandler,
+		fixedChunkHandler:      fixedChunkHandler,
+		fixedAppendHandler:     fixedAppendHandler,
+		fixedCloseHandler:      fixedCloseHandler,
+		dynamicIndexHandler:    dynamicIndexHandler,
+		dynamicChunkHandler:    dynamicChunkHandler,
+		dynamicAppendHandler:   dynamicAppendHandler,
+		dynamicCloseHandler:    dynamicCloseHandler,
+		previousArchiveHandler: previousArchiveHandler,
+		previousTimeHandler:    previousTimeHandler,
+		streamHandler:          streamHandler,
 	}
 }
 
@@ -196,6 +203,23 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Look up the most recent previous successful backup for this group.
+	// Used by stream handlers to support incremental (reuse-csum) sessions.
+	var prev *previous.Snapshot
+	if kind == session.KindBackup {
+		p, findErr := previous.Find(ds.Path, ns, string(params.BackupType), params.BackupID, params.BackupTime)
+		if findErr == nil {
+			prev = p
+			slog.Info("previous backup found",
+				"session_id", sessionID,
+				"previous_path", p.Path,
+				"previous_time", p.Time,
+			)
+		} else if !errors.Is(findErr, previous.ErrNoPrevious) {
+			slog.Warn("previous backup lookup failed", "error", findErr, "session_id", sessionID)
+		}
+	}
+
 	// Step 5: Hijack the connection.
 	hj, ok := w.(http.Hijacker)
 	if !ok {
@@ -241,14 +265,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer ws.Cleanup()
 
 	sessionCtx := &streamctx.SessionContext{
-		SessionID:     sessionID,
-		DatastoreID:   ds.ID,
-		DatastoreRoot: ds.Path,
-		BackupType:    string(params.BackupType),
-		BackupID:      params.BackupID,
-		BackupTime:    params.BackupTime,
-		Namespace:     ns,
-		WriterState:   ws,
+		SessionID:      sessionID,
+		DatastoreID:    ds.ID,
+		DatastoreRoot:  ds.Path,
+		BackupType:     string(params.BackupType),
+		BackupID:       params.BackupID,
+		BackupTime:     params.BackupTime,
+		Namespace:      ns,
+		WriterState:    ws,
+		PreviousBackup: prev,
 	}
 	sessionRouter := buildSessionRouter(
 		h.blobHandler, h.finishHandler,
@@ -256,6 +281,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.fixedAppendHandler, h.fixedCloseHandler,
 		h.dynamicIndexHandler, h.dynamicChunkHandler,
 		h.dynamicAppendHandler, h.dynamicCloseHandler,
+		h.previousArchiveHandler, h.previousTimeHandler,
 		h.streamHandler,
 	)
 	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -338,6 +364,7 @@ func buildSessionRouter(
 	blobHandler, finishHandler,
 	fixedIndexHandler, fixedChunkHandler, fixedAppendHandler, fixedCloseHandler,
 	dynamicIndexHandler, dynamicChunkHandler, dynamicAppendHandler, dynamicCloseHandler,
+	previousArchiveHandler, previousTimeHandler,
 	fallback http.Handler,
 ) http.Handler {
 	methodNotAllowed := func(w http.ResponseWriter, allow string) {
@@ -378,6 +405,10 @@ func buildSessionRouter(
 			dynamicChunkHandler.ServeHTTP(w, r)
 		case "/dynamic_close":
 			dynamicCloseHandler.ServeHTTP(w, r)
+		case "/previous":
+			previousArchiveHandler.ServeHTTP(w, r)
+		case "/previous_backup_time":
+			previousTimeHandler.ServeHTTP(w, r)
 		default:
 			fallback.ServeHTTP(w, r)
 		}

--- a/services/backupos-pbs/internal/upgrade/handler_test.go
+++ b/services/backupos-pbs/internal/upgrade/handler_test.go
@@ -182,6 +182,8 @@ func newTestHandler(db *sql.DB) *Handler {
 		dynamicchunk.NewHandler(),
 		dynamicappend.NewHandler(),
 		dynamicclose.NewHandler(),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
 		StubStreamHandler(),
 	)
 }

--- a/services/backupos-pbs/internal/wstate/wstate.go
+++ b/services/backupos-pbs/internal/wstate/wstate.go
@@ -127,6 +127,14 @@ func (s *State) LookupChunk(digest [32]byte) (uint32, bool) {
 	return size, ok
 }
 
+// RegisterKnownChunk pre-populates knownChunks from a previous backup index
+// without going through a writer. Used for incremental (reuse-csum) sessions.
+func (s *State) RegisterKnownChunk(digest [32]byte, size uint32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.knownChunks[digest] = size
+}
+
 // RegisterFixedChunk records a successfully uploaded chunk in the known_chunks
 // map and validates size constraints for the associated writer.
 func (s *State) RegisterFixedChunk(wid int, digest [32]byte, size uint32, isDuplicate bool) error {

--- a/services/backupos-pbs/internal/wstate/wstate_test.go
+++ b/services/backupos-pbs/internal/wstate/wstate_test.go
@@ -71,6 +71,22 @@ func TestRegisterFixedWriter_RejectsAfterCleanup(t *testing.T) {
 	}
 }
 
+// ---- RegisterKnownChunk ----
+
+func TestRegisterKnownChunk_AddsToMap(t *testing.T) {
+	ws := New()
+	var d [32]byte
+	d[0] = 0xDE
+	ws.RegisterKnownChunk(d, 4194304)
+	size, ok := ws.LookupChunk(d)
+	if !ok {
+		t.Fatal("chunk not found after RegisterKnownChunk")
+	}
+	if size != 4194304 {
+		t.Errorf("size: got %d, want 4194304", size)
+	}
+}
+
 // ---- RegisterFixedChunk ----
 
 func TestRegisterFixedChunk_AddsToKnownChunks(t *testing.T) {


### PR DESCRIPTION
## Summary

- **fidx/read.go** — `ReadHeader` + `ReadDigests` for parsing existing `.fidx` files
- **internal/previous** — `Find()` scans the backup group directory for the most recent prior snapshot that contains a non-empty index file
- **internal/incremental** — `RegisterFromPreviousIndex` validates the client-supplied `reuse-csum` against the stored `index_csum` and bulk-populates `knownChunks` from the prior index
- **internal/previousarchive** — `GET /previous?archive-name=` streams the named archive file from the previous snapshot so the client can compute its csum
- **internal/previoustime** — `GET /previous_backup_time` returns the prior snapshot's Unix timestamp (or `{"data":null}`)
- **streamctx** — `PreviousBackup *previous.Snapshot` added to `SessionContext`; populated at upgrade time via `previous.Find()`
- **fixedindex** — `reuse-csum` query param accepted; `incremental.RegisterFromPreviousIndex` called when present, `ErrCsumMismatch` → 400
- **wstate** — `RegisterKnownChunk` for bulk pre-population without going through a writer

## Test plan

- [ ] `go mod tidy && go build ./... && timeout 60 go test ./...` passes
- [ ] `internal/previous` — 7 tests covering empty group, no-index, only-current, single previous, newest-of-multiple, namespaced
- [ ] `internal/incremental` — 4 tests covering success, csum mismatch, missing file, knownChunks population
- [ ] `internal/previousarchive` — 7 tests covering 405, no streamctx, no previous backup, missing/invalid archive name, file not found, successful stream
- [ ] `internal/previoustime` — 4 tests covering 405, no streamctx, null response, correct Unix timestamp
- [ ] `internal/wstate` — `TestRegisterKnownChunk_AddsToMap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)