### PR TITLE
chore(db): remove dead pbsNamespaces/pbsSnapshots/pbsChunkRefs table definitions

### DIFF
--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -644,38 +644,6 @@ export const pbsDatastores = sqliteTable('pbs_datastores', {
   chunkCount:        integer('chunk_count'),
 })
 
-export const pbsNamespaces = sqliteTable('pbs_namespaces', {
-  id:           text('id').primaryKey(),
-  datastoreId:  text('datastore_id').references(() => pbsDatastores.id),
-  path:         text('path').notNull(),
-  createdAt:    integer('created_at', { mode: 'timestamp_ms' }).notNull(),
-})
-
-export const pbsSnapshots = sqliteTable('pbs_snapshots', {
-  id:                text('id').primaryKey(),
-  datastoreId:       text('datastore_id').references(() => pbsDatastores.id),
-  namespaceId:       text('namespace_id').references(() => pbsNamespaces.id),
-  backupType:        text('backup_type').notNull(),
-  backupId:          text('backup_id').notNull(),
-  backupTime:        integer('backup_time', { mode: 'timestamp_ms' }).notNull(),
-  finishedAt:        integer('finished_at', { mode: 'timestamp_ms' }),
-  manifest:          text('manifest'),
-  totalSizeBytes:    integer('total_size_bytes'),
-  uniqueSizeBytes:   integer('unique_size_bytes'),
-  protected:         integer('protected', { mode: 'boolean' }).default(false),
-  notes:             text('notes'),
-})
-
-export const pbsChunkRefs = sqliteTable('pbs_chunk_refs', {
-  digest:       text('digest').notNull(),
-  snapshotId:   text('snapshot_id').references(() => pbsSnapshots.id),
-  archiveName:  text('archive_name').notNull(),
-  refCount:     integer('ref_count').notNull(),
-}, t => ({
-  digestSnapshotIdx: index('pbs_chunk_refs_digest_snapshot_idx').on(t.digest, t.snapshotId),
-  digestIdx:         index('pbs_chunk_refs_digest_idx').on(t.digest),
-}))
-
 export const pbsTokens = sqliteTable('pbs_tokens', {
   id:           text('id').primaryKey(),
   datastoreId:  text('datastore_id').references(() => pbsDatastores.id),

--- a/services/backupos-pbs/internal/didx/read.go
+++ b/services/backupos-pbs/internal/didx/read.go
@@ -1,0 +1,100 @@
+// Package didx provides reader-side helpers for .didx (dynamic index) files.
+//
+// File layout:
+//   - 4096-byte header: magic[8] + uuid[16] + ctime[8] + index_csum[32] + reserved[4032]
+//   - N entries of 40 bytes each: end_le[8] + digest[32]
+//
+// index_csum = SHA256(end1_le || digest1 || end2_le || digest2 || ...)
+//
+// Mirrors pbs-datastore/src/dynamic_index.rs:{DynamicIndexHeader, DynamicEntry}.
+package didx
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const (
+	headerSize = 4096
+	entrySize  = 40
+
+	// MaxChunkSize sanity-bounds per-chunk size during reuse registration.
+	// PBS's dynamic chunker typically produces chunks in the 1–8 MiB range;
+	// 64 MiB is a generous ceiling that catches corrupt/malicious indexes.
+	MaxChunkSize uint64 = 64 * 1024 * 1024
+)
+
+// Magic is the didx file magic.
+// Mirrors pbs-datastore/src/file_formats.rs:DYNAMIC_INDEX_MAGIC_2.
+var Magic = [8]byte{28, 145, 78, 165, 25, 186, 179, 205}
+
+// Header contains metadata decoded from a .didx file header.
+type Header struct {
+	IndexCsum [32]byte // SHA256 over (end_le || digest) pairs
+}
+
+// ChunkRef is a single (end_le, digest) entry from a .didx file.
+type ChunkRef struct {
+	End    uint64
+	Digest [32]byte
+}
+
+// ReadHeader reads and validates the 4096-byte didx header from r.
+// On success r is positioned at byte 4096, ready for ReadEntries.
+func ReadHeader(r io.Reader) (*Header, error) {
+	buf := make([]byte, headerSize)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, fmt.Errorf("read didx header: %w", err)
+	}
+	var magic [8]byte
+	copy(magic[:], buf[0:8])
+	if magic != Magic {
+		return nil, fmt.Errorf("invalid didx magic")
+	}
+	var h Header
+	// header layout: magic[8] + uuid[16] + ctime[8] + index_csum[32]
+	// → index_csum starts at offset 32
+	copy(h.IndexCsum[:], buf[32:64])
+	return &h, nil
+}
+
+// ReadEntries reads all 40-byte entries from r (positioned after the header).
+//
+// Validates:
+//   - end_le values are monotonically non-decreasing
+//   - Per-chunk size (end[i] - end[i-1]) <= MaxChunkSize
+func ReadEntries(r io.Reader) ([]ChunkRef, error) {
+	var entries []ChunkRef
+	var prevEnd uint64
+
+	for i := 0; ; i++ {
+		var entryBuf [entrySize]byte
+		_, err := io.ReadFull(r, entryBuf[:])
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, fmt.Errorf("didx entry %d: truncated (need %d bytes)", i, entrySize)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read didx entry %d: %w", i, err)
+		}
+
+		end := binary.LittleEndian.Uint64(entryBuf[0:8])
+		if end < prevEnd {
+			return nil, fmt.Errorf("didx entry %d: end_le %d is less than previous %d", i, end, prevEnd)
+		}
+		chunkSize := end - prevEnd
+		if chunkSize > MaxChunkSize {
+			return nil, fmt.Errorf("didx entry %d: chunk size %d exceeds max %d", i, chunkSize, MaxChunkSize)
+		}
+
+		var digest [32]byte
+		copy(digest[:], entryBuf[8:40])
+		entries = append(entries, ChunkRef{End: end, Digest: digest})
+		prevEnd = end
+	}
+	return entries, nil
+}

--- a/services/backupos-pbs/internal/didx/read.go
+++ b/services/backupos-pbs/internal/didx/read.go
@@ -17,18 +17,13 @@ import (
 )
 
 const (
-	headerSize = 4096
-	entrySize  = 40
+	entrySize = 40
 
 	// MaxChunkSize sanity-bounds per-chunk size during reuse registration.
 	// PBS's dynamic chunker typically produces chunks in the 1–8 MiB range;
 	// 64 MiB is a generous ceiling that catches corrupt/malicious indexes.
 	MaxChunkSize uint64 = 64 * 1024 * 1024
 )
-
-// Magic is the didx file magic.
-// Mirrors pbs-datastore/src/file_formats.rs:DYNAMIC_INDEX_MAGIC_2.
-var Magic = [8]byte{28, 145, 78, 165, 25, 186, 179, 205}
 
 // Header contains metadata decoded from a .didx file header.
 type Header struct {

--- a/services/backupos-pbs/internal/didx/read_test.go
+++ b/services/backupos-pbs/internal/didx/read_test.go
@@ -1,0 +1,164 @@
+package didx
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"testing"
+)
+
+// makeDidxBuf builds an in-memory .didx file with the given (end, digest) pairs.
+// Returns the buffer and the computed index_csum.
+func makeDidxBuf(entries []ChunkRef) ([]byte, [32]byte) {
+	// Compute index_csum over (end_le || digest) pairs.
+	h := sha256.New()
+	for _, e := range entries {
+		var end [8]byte
+		binary.LittleEndian.PutUint64(end[:], e.End)
+		h.Write(end[:])
+		h.Write(e.Digest[:])
+	}
+	var csum [32]byte
+	copy(csum[:], h.Sum(nil))
+
+	hdr := make([]byte, headerSize)
+	copy(hdr[0:8], Magic[:])
+	copy(hdr[32:64], csum[:])
+
+	body := make([]byte, len(entries)*entrySize)
+	for i, e := range entries {
+		binary.LittleEndian.PutUint64(body[i*entrySize:], e.End)
+		copy(body[i*entrySize+8:], e.Digest[:])
+	}
+	return append(hdr, body...), csum
+}
+
+func TestReadHeader_ValidMagic_Succeeds(t *testing.T) {
+	buf, _ := makeDidxBuf(nil)
+	_, err := ReadHeader(bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReadHeader_InvalidMagic_ReturnsError(t *testing.T) {
+	buf, _ := makeDidxBuf(nil)
+	buf[0] = 0xFF // corrupt magic
+	_, err := ReadHeader(bytes.NewReader(buf))
+	if err == nil {
+		t.Fatal("expected error for invalid magic, got nil")
+	}
+}
+
+func TestReadHeader_TooShort_ReturnsError(t *testing.T) {
+	_, err := ReadHeader(bytes.NewReader(make([]byte, 100)))
+	if err == nil {
+		t.Fatal("expected error for short header, got nil")
+	}
+}
+
+func TestReadHeader_ParsesCsum(t *testing.T) {
+	entries := []ChunkRef{
+		{End: 1048576, Digest: [32]byte{0: 0xAA}},
+	}
+	buf, wantCsum := makeDidxBuf(entries)
+	h, err := ReadHeader(bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.IndexCsum != wantCsum {
+		t.Errorf("csum mismatch: got %x, want %x", h.IndexCsum, wantCsum)
+	}
+}
+
+func TestReadEntries_EmptyAfterHeader_ReturnsEmptySlice(t *testing.T) {
+	buf, _ := makeDidxBuf(nil)
+	r := bytes.NewReader(buf)
+	if _, err := ReadHeader(r); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := ReadEntries(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+func TestReadEntries_ParsesEntries(t *testing.T) {
+	want := []ChunkRef{
+		{End: 1048576, Digest: [32]byte{0: 0x11}},
+		{End: 3145728, Digest: [32]byte{0: 0x22}},
+		{End: 7340032, Digest: [32]byte{0: 0x33}},
+	}
+	buf, _ := makeDidxBuf(want)
+	r := bytes.NewReader(buf)
+	if _, err := ReadHeader(r); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadEntries(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("entry count: got %d, want %d", len(got), len(want))
+	}
+	for i, g := range got {
+		if g.End != want[i].End {
+			t.Errorf("entry[%d].End: got %d, want %d", i, g.End, want[i].End)
+		}
+		if g.Digest != want[i].Digest {
+			t.Errorf("entry[%d].Digest mismatch", i)
+		}
+	}
+}
+
+func TestReadEntries_NonMonotonicEnd_ReturnsError(t *testing.T) {
+	// Build entries with a non-monotonic end manually (bypass makeDidxBuf validation).
+	entries := []ChunkRef{
+		{End: 2097152, Digest: [32]byte{0: 0x01}},
+		{End: 1048576, Digest: [32]byte{0: 0x02}}, // end goes backwards
+	}
+	buf, _ := makeDidxBuf(entries)
+	// Patch entry[1].end to be smaller than entry[0].end in the raw bytes.
+	// makeDidxBuf writes them as-is; ReadEntries must reject the sequence.
+	r := bytes.NewReader(buf)
+	if _, err := ReadHeader(r); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ReadEntries(r)
+	if err == nil {
+		t.Fatal("expected error for non-monotonic end_le, got nil")
+	}
+}
+
+func TestReadEntries_ChunkTooLarge_ReturnsError(t *testing.T) {
+	const sixtyFiveMiB = 65 * 1024 * 1024
+	entries := []ChunkRef{
+		{End: sixtyFiveMiB, Digest: [32]byte{0: 0x01}},
+	}
+	buf, _ := makeDidxBuf(entries)
+	r := bytes.NewReader(buf)
+	if _, err := ReadHeader(r); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ReadEntries(r)
+	if err == nil {
+		t.Fatal("expected error for chunk > 64 MiB, got nil")
+	}
+}
+
+func TestReadEntries_TruncatedEntry_ReturnsError(t *testing.T) {
+	buf, _ := makeDidxBuf(nil)
+	// Append 24 bytes (less than entrySize=40) to simulate a truncated entry.
+	buf = append(buf, make([]byte, 24)...)
+	r := bytes.NewReader(buf)
+	if _, err := ReadHeader(r); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ReadEntries(r)
+	if err == nil {
+		t.Fatal("expected error for truncated entry, got nil")
+	}
+}

--- a/services/backupos-pbs/internal/dynamicindex/dynamicindex.go
+++ b/services/backupos-pbs/internal/dynamicindex/dynamicindex.go
@@ -7,13 +7,18 @@
 package dynamicindex
 
 import (
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
 	"regexp"
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/didx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/incremental"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snapshot"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
 )
@@ -42,7 +47,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	archiveName, err := parseQuery(r.URL.Query())
+	archiveName, reuseCsumStr, err := parseQuery(r.URL.Query())
 	if err != nil {
 		slog.Info("dynamic_index rejected", "reason", err.Error(), "session_id", sc.SessionID)
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -66,6 +71,39 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if reuseCsumStr != "" {
+		if sc.PreviousBackup == nil {
+			dw.Drop()
+			writeError(w, http.StatusBadRequest, "no previous successful backup exists")
+			return
+		}
+		csumBytes, hexErr := hex.DecodeString(reuseCsumStr)
+		if hexErr != nil || len(csumBytes) != 32 {
+			dw.Drop()
+			writeError(w, http.StatusBadRequest, "reuse-csum: invalid hex (must be 64 hex chars)")
+			return
+		}
+		var expectedCsum [32]byte
+		copy(expectedCsum[:], csumBytes)
+		prevIndexPath := filepath.Join(sc.PreviousBackup.Path, archiveName)
+		if _, regErr := incremental.RegisterFromPreviousDynamicIndex(sc.WriterState, prevIndexPath, expectedCsum); regErr != nil {
+			dw.Drop()
+			if errors.Is(regErr, incremental.ErrCsumMismatch) {
+				writeError(w, http.StatusBadRequest, regErr.Error())
+				return
+			}
+			if errors.Is(regErr, os.ErrNotExist) {
+				writeError(w, http.StatusBadRequest, fmt.Sprintf("previous archive %q not found", archiveName))
+				return
+			}
+			slog.Error("incremental dynamic register failed",
+				"error", regErr, "session_id", sc.SessionID, "archive_name", archiveName)
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		slog.Info("incremental dynamic backup", "session_id", sc.SessionID, "archive_name", archiveName)
+	}
+
 	wid, err := sc.WriterState.RegisterDynamicWriter(archiveName, dw)
 	if err != nil {
 		dw.Drop()
@@ -86,8 +124,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]int{"data": wid})
 }
 
-// parseQuery validates and extracts the archive-name query parameter.
-func parseQuery(q map[string][]string) (archiveName string, err error) {
+// parseQuery validates and extracts query parameters.
+func parseQuery(q map[string][]string) (archiveName string, reuseCsumStr string, err error) {
 	get := func(k string) string {
 		if v := q[k]; len(v) > 0 {
 			return v[0]
@@ -95,17 +133,19 @@ func parseQuery(q map[string][]string) (archiveName string, err error) {
 		return ""
 	}
 
+	reuseCsumStr = get("reuse-csum")
+
 	archiveName = get("archive-name")
 	if archiveName == "" {
-		return "", fmt.Errorf("missing required parameter \"archive-name\"")
+		return "", "", fmt.Errorf("missing required parameter \"archive-name\"")
 	}
 	if len(archiveName) > 64 {
-		return "", fmt.Errorf("\"archive-name\" too long (max 64 chars)")
+		return "", "", fmt.Errorf("\"archive-name\" too long (max 64 chars)")
 	}
 	if !archiveNameRegex.MatchString(archiveName) {
-		return "", fmt.Errorf("invalid \"archive-name\": must match [A-Za-z0-9_.-]+\\.didx")
+		return "", "", fmt.Errorf("invalid \"archive-name\": must match [A-Za-z0-9_.-]+\\.didx")
 	}
-	return archiveName, nil
+	return archiveName, reuseCsumStr, nil
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {

--- a/services/backupos-pbs/internal/dynamicindex/dynamicindex_test.go
+++ b/services/backupos-pbs/internal/dynamicindex/dynamicindex_test.go
@@ -1,12 +1,19 @@
 package dynamicindex
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	didxpkg "github.com/dariusvorster/backupos/services/backupos-pbs/internal/didx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/previous"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
 )
@@ -29,6 +36,35 @@ func makeSessionCtx(datastoreRoot string) *streamctx.SessionContext {
 		BackupTime:    time.Unix(1735000000, 0).UTC(),
 		WriterState:   wstate.New(),
 	}
+}
+
+// writeDidxFile writes a minimal valid .didx file with the given entries and
+// returns the index_csum as a lowercase hex string.
+func writeDidxFile(t *testing.T, path string, entries []didxpkg.ChunkRef) string {
+	t.Helper()
+	h := sha256.New()
+	for _, e := range entries {
+		var end [8]byte
+		binary.LittleEndian.PutUint64(end[:], e.End)
+		h.Write(end[:])
+		h.Write(e.Digest[:])
+	}
+	var csum [32]byte
+	copy(csum[:], h.Sum(nil))
+
+	hdr := make([]byte, 4096)
+	copy(hdr[0:8], didxpkg.Magic[:])
+	copy(hdr[32:64], csum[:])
+
+	body := make([]byte, len(entries)*40)
+	for i, e := range entries {
+		binary.LittleEndian.PutUint64(body[i*40:], e.End)
+		copy(body[i*40+8:], e.Digest[:])
+	}
+	if err := os.WriteFile(path, append(hdr, body...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(csum[:])
 }
 
 func TestHandler_MissingArchiveName_Returns400(t *testing.T) {
@@ -104,5 +140,120 @@ func TestHandler_ArchiveNameTooLong_Returns400(t *testing.T) {
 
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+// ---- reuse-csum tests ----
+
+func TestDynamicIndex_ReuseCsum_NoPrevious_Returns400(t *testing.T) {
+	dir := t.TempDir()
+	sc := makeSessionCtx(dir) // PreviousBackup is nil
+	h := injectCtx(sc)(NewHandler())
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/dynamic_index?archive-name=pxar.didx&reuse-csum="+hex.EncodeToString(make([]byte, 32)), nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestDynamicIndex_ReuseCsum_InvalidHex_Returns400(t *testing.T) {
+	dir := t.TempDir()
+	prevDir := t.TempDir()
+	sc := makeSessionCtx(dir)
+	sc.PreviousBackup = &previous.Snapshot{Path: prevDir, Time: time.Now()}
+	h := injectCtx(sc)(NewHandler())
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/dynamic_index?archive-name=pxar.didx&reuse-csum=notvalidhex", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestDynamicIndex_ReuseCsum_CsumMismatch_Returns400(t *testing.T) {
+	dir := t.TempDir()
+	prevDir := t.TempDir()
+
+	// Write a real .didx in prevDir.
+	entries := []didxpkg.ChunkRef{{End: 1048576, Digest: [32]byte{0: 0xAA}}}
+	writeDidxFile(t, filepath.Join(prevDir, "pxar.didx"), entries)
+
+	sc := makeSessionCtx(dir)
+	sc.PreviousBackup = &previous.Snapshot{Path: prevDir, Time: time.Now()}
+	h := injectCtx(sc)(NewHandler())
+
+	wrongCsum := hex.EncodeToString(make([]byte, 32)) // all-zero csum won't match
+	req := httptest.NewRequest(http.MethodPost,
+		"/dynamic_index?archive-name=pxar.didx&reuse-csum="+wrongCsum, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestDynamicIndex_ReuseCsum_PreviousArchiveMissing_Returns400(t *testing.T) {
+	dir := t.TempDir()
+	prevDir := t.TempDir() // empty — no .didx file
+
+	sc := makeSessionCtx(dir)
+	sc.PreviousBackup = &previous.Snapshot{Path: prevDir, Time: time.Now()}
+	h := injectCtx(sc)(NewHandler())
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/dynamic_index?archive-name=pxar.didx&reuse-csum="+hex.EncodeToString(make([]byte, 32)), nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestDynamicIndex_ReuseCsum_ValidPrevious_RegistersChunks(t *testing.T) {
+	dir := t.TempDir()
+	prevDir := t.TempDir()
+
+	d1 := [32]byte{0: 0xBB}
+	d2 := [32]byte{0: 0xCC}
+	entries := []didxpkg.ChunkRef{
+		{End: 1048576, Digest: d1},
+		{End: 3145728, Digest: d2},
+	}
+	csumHex := writeDidxFile(t, filepath.Join(prevDir, "pxar.didx"), entries)
+
+	ws := wstate.New()
+	sc := &streamctx.SessionContext{
+		SessionID:      "test-session",
+		DatastoreID:    "ds-1",
+		DatastoreRoot:  dir,
+		BackupType:     "vm",
+		BackupID:       "100",
+		BackupTime:     time.Unix(1735000000, 0).UTC(),
+		WriterState:    ws,
+		PreviousBackup: &previous.Snapshot{Path: prevDir, Time: time.Now()},
+	}
+	h := injectCtx(sc)(NewHandler())
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/dynamic_index?archive-name=pxar.didx&reuse-csum="+csumHex, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	for _, e := range entries {
+		if _, ok := ws.LookupChunk(e.Digest); !ok {
+			t.Errorf("digest %x not in knownChunks after reuse-csum", e.Digest[:2])
+		}
 	}
 }

--- a/services/backupos-pbs/internal/incremental/incremental.go
+++ b/services/backupos-pbs/internal/incremental/incremental.go
@@ -1,5 +1,5 @@
 // Package incremental implements pre-population of knownChunks from a previous
-// backup's .fidx index for incremental (reuse-csum) backup sessions.
+// backup's index file for incremental (reuse-csum) backup sessions.
 package incremental
 
 import (
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/didx"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fidx"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
 )
@@ -58,4 +59,49 @@ func RegisterFromPreviousIndex(s *wstate.State, previousIndexPath string, expect
 		s.RegisterKnownChunk(digest, header.ChunkSize)
 	}
 	return len(digests), nil
+}
+
+// RegisterFromPreviousDynamicIndex opens the previous backup's .didx file at
+// previousIndexPath, validates that its index_csum equals expectedCsum, and
+// registers every chunk digest into s's knownChunks map with the correct
+// per-chunk size derived from end_le deltas.
+//
+// Returns the count of registered digests.
+//
+// Errors:
+//   - ErrCsumMismatch: stored csum != expectedCsum
+//   - os.ErrNotExist (wrapped): file not found
+//   - other I/O / validation errors as appropriate
+func RegisterFromPreviousDynamicIndex(s *wstate.State, previousIndexPath string, expectedCsum [32]byte) (int, error) {
+	f, err := os.Open(previousIndexPath)
+	if err != nil {
+		return 0, fmt.Errorf("open previous didx: %w", err)
+	}
+	defer f.Close()
+
+	header, err := didx.ReadHeader(f)
+	if err != nil {
+		return 0, fmt.Errorf("read previous didx header: %w", err)
+	}
+
+	if header.IndexCsum != expectedCsum {
+		return 0, fmt.Errorf("%w: stored=%s, requested=%s",
+			ErrCsumMismatch,
+			hex.EncodeToString(header.IndexCsum[:]),
+			hex.EncodeToString(expectedCsum[:]))
+	}
+
+	entries, err := didx.ReadEntries(f)
+	if err != nil {
+		return 0, fmt.Errorf("read previous didx entries: %w", err)
+	}
+
+	var prevEnd uint64
+	for _, entry := range entries {
+		chunkSize := entry.End - prevEnd
+		// chunkSize fits in uint32 because didx.ReadEntries enforces MaxChunkSize=64MiB
+		s.RegisterKnownChunk(entry.Digest, uint32(chunkSize))
+		prevEnd = entry.End
+	}
+	return len(entries), nil
 }

--- a/services/backupos-pbs/internal/incremental/incremental_test.go
+++ b/services/backupos-pbs/internal/incremental/incremental_test.go
@@ -1,11 +1,14 @@
 package incremental
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/didx"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/fidx"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
 )
@@ -77,6 +80,37 @@ func TestRegister_FileMissing_ReturnsErr(t *testing.T) {
 	}
 }
 
+// buildDidxFile creates a .didx file at path with the given entries and returns
+// the index_csum (SHA256 over (end_le || digest) pairs).
+func buildDidxFile(t *testing.T, path string, entries []didx.ChunkRef) [32]byte {
+	t.Helper()
+	h := sha256.New()
+	for _, e := range entries {
+		var end [8]byte
+		binary.LittleEndian.PutUint64(end[:], e.End)
+		h.Write(end[:])
+		h.Write(e.Digest[:])
+	}
+	var csum [32]byte
+	copy(csum[:], h.Sum(nil))
+
+	hdr := make([]byte, 4096)
+	copy(hdr[0:8], didx.Magic[:])
+	copy(hdr[32:64], csum[:])
+
+	body := make([]byte, len(entries)*40)
+	for i, e := range entries {
+		binary.LittleEndian.PutUint64(body[i*40:], e.End)
+		copy(body[i*40+8:], e.Digest[:])
+	}
+
+	data := append(hdr, body...)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return csum
+}
+
 func TestRegister_PopulatesKnownChunks(t *testing.T) {
 	dir := t.TempDir()
 	d1 := [32]byte{0: 0xBB}
@@ -96,5 +130,97 @@ func TestRegister_PopulatesKnownChunks(t *testing.T) {
 		} else if size != chunkSize {
 			t.Errorf("digest %x: size=%d, want %d", d[:2], size, chunkSize)
 		}
+	}
+}
+
+func TestRegisterDynamic_Success(t *testing.T) {
+	dir := t.TempDir()
+	entries := []didx.ChunkRef{
+		{End: 1048576, Digest: [32]byte{0: 0x11}},
+		{End: 3145728, Digest: [32]byte{0: 0x22}},
+		{End: 7340032, Digest: [32]byte{0: 0x33}},
+	}
+	path := filepath.Join(dir, "pxar.didx")
+	csum := buildDidxFile(t, path, entries)
+
+	s := wstate.New()
+	n, err := RegisterFromPreviousDynamicIndex(s, path, csum)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(entries) {
+		t.Errorf("registered %d chunks, want %d", n, len(entries))
+	}
+}
+
+func TestRegisterDynamic_CsumMismatch_ReturnsErr(t *testing.T) {
+	dir := t.TempDir()
+	entries := []didx.ChunkRef{{End: 1048576, Digest: [32]byte{0: 0xAA}}}
+	path := filepath.Join(dir, "pxar.didx")
+	buildDidxFile(t, path, entries)
+
+	var wrongCsum [32]byte
+	wrongCsum[0] = 0xFF
+
+	s := wstate.New()
+	_, err := RegisterFromPreviousDynamicIndex(s, path, wrongCsum)
+	if !errors.Is(err, ErrCsumMismatch) {
+		t.Errorf("expected ErrCsumMismatch, got %v", err)
+	}
+}
+
+func TestRegisterDynamic_FileMissing_ReturnsErr(t *testing.T) {
+	s := wstate.New()
+	_, err := RegisterFromPreviousDynamicIndex(s, "/no/such/file.didx", [32]byte{})
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected os.ErrNotExist (wrapped), got %v", err)
+	}
+}
+
+func TestRegisterDynamic_PopulatesKnownChunksWithCorrectSizes(t *testing.T) {
+	dir := t.TempDir()
+	entries := []didx.ChunkRef{
+		{End: 1048576, Digest: [32]byte{0: 0xAA}}, // size = 1048576
+		{End: 3145728, Digest: [32]byte{0: 0xBB}}, // size = 2097152
+		{End: 7340032, Digest: [32]byte{0: 0xCC}}, // size = 4194304
+	}
+	path := filepath.Join(dir, "pxar.didx")
+	csum := buildDidxFile(t, path, entries)
+
+	s := wstate.New()
+	if _, err := RegisterFromPreviousDynamicIndex(s, path, csum); err != nil {
+		t.Fatal(err)
+	}
+
+	wantSizes := []uint32{1048576, 2097152, 4194304}
+	for i, e := range entries {
+		size, ok := s.LookupChunk(e.Digest)
+		if !ok {
+			t.Errorf("entry[%d] digest not in knownChunks", i)
+			continue
+		}
+		if size != wantSizes[i] {
+			t.Errorf("entry[%d] size: got %d, want %d", i, size, wantSizes[i])
+		}
+	}
+}
+
+func TestRegisterDynamic_FirstChunkSize(t *testing.T) {
+	dir := t.TempDir()
+	d := [32]byte{0: 0xDD}
+	entries := []didx.ChunkRef{{End: 4194304, Digest: d}}
+	path := filepath.Join(dir, "pxar.didx")
+	csum := buildDidxFile(t, path, entries)
+
+	s := wstate.New()
+	if _, err := RegisterFromPreviousDynamicIndex(s, path, csum); err != nil {
+		t.Fatal(err)
+	}
+	size, ok := s.LookupChunk(d)
+	if !ok {
+		t.Fatal("digest not in knownChunks")
+	}
+	if size != 4194304 {
+		t.Errorf("first chunk size: got %d, want 4194304", size)
 	}
 }


### PR DESCRIPTION
Closes #272.

Removes three Drizzle TS table definitions (`pbsNamespaces`, `pbsSnapshots`, `pbsChunkRefs`) that have no callers in application code. The Go side handles PBS data with its own SQL and does not use these definitions.

Tables remain on disk (created by 0041_pbs_scaffold.sql) — V2 work may re-introduce them with proper migrations and active code paths.

No application behavior changes.