### PR TITLE
fix(sidebar): add PBS section linking to Tokens and Datastores

### DIFF
--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -6,6 +6,7 @@ import {
   LayoutDashboard, Activity, PlayCircle, Clock, Camera,
   Server, Database, Radar, RotateCcw, ListRestart,
   TriangleAlert, FileClock, Settings, BookOpen, FileTerminal, ShieldCheck,
+  KeyRound, HardDrive,
 } from 'lucide-react'
 import { ProfilePopover } from './profile-popover'
 
@@ -38,6 +39,13 @@ const NAV: NavGroup[] = [
       { href: '/agents',       label: 'Agents',       icon: <Server size={15} /> },
       { href: '/repositories', label: 'Repositories', icon: <Database size={15} /> },
       { href: '/monitors',     label: 'Monitors',     icon: <Radar size={15} /> },
+    ],
+  },
+  {
+    label: 'PBS',
+    items: [
+      { href: '/pbs/tokens',         label: 'Tokens',     icon: <KeyRound  size={15} /> },
+      { href: '/pbs/datastores/new', label: 'Datastores', icon: <HardDrive size={15} /> },
     ],
   },
   {


### PR DESCRIPTION
V1 ship-blocker item 2.5 of 14.

`/pbs/tokens` and `/pbs/datastores/new` were orphaned pages — reachable only by typing the URL directly. This PR adds a **PBS** nav group between Infrastructure and Restore so admins can reach them through the sidebar.

## Changes

- `apps/web/components/sidebar.tsx`: adds `KeyRound` and `HardDrive` to the lucide-react import; inserts a `PBS` group with two items: `Tokens → /pbs/tokens` and `Datastores → /pbs/datastores/new`.

## Follow-up

Datastores nav links to `/pbs/datastores/new` because the list page does not yet exist. Will be re-pointed to `/pbs/datastores` when M7 (Datastore management UI, item 8 of 14) ships.