### PR TITLE
feat(pbs): add /api2/json/admin/datastore list endpoint

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/readchunk"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/readerupgrade"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/speedtest"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastorelist"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/selftest"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/sessionreaper"
@@ -155,12 +156,24 @@ func main() {
 	})
 	gcAdminHandler := gcadmin.NewHandler(datastoreLookup, gcTracker, oldestActiveWriter)
 	gcScheduler := gcsched.New(datastoreLookup, gcTracker, oldestActiveWriter, 0)
-	selfTestHandler := selftest.NewHandler(database, datastoreLookup, versionString)
+	selfTestHandler      := selftest.NewHandler(database, datastoreLookup, versionString)
+	datastoreListHandler := datastorelist.NewHandler(database)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api2/json/version", versionHandler.ServeHTTP)
 	mux.HandleFunc("/api2/json/backup", requireAuth(validator, upgradeHandler.ServeHTTP))
 	mux.HandleFunc("/api2/json/reader", readerHandler.ServeHTTP)
+	// Route precedence note:
+	//   /api2/json/admin/datastore     → exact match, list endpoint (PVE enumeration)
+	//   /api2/json/admin/datastore/    → subtree match, per-datastore subroutes
+	// Go's net/http mux serves the more specific exact match first, so the
+	// list endpoint wins for the bare path and the subtree handles everything
+	// from /api2/json/admin/datastore/<name>/... onward.
+	mux.HandleFunc("/api2/json/admin/datastore", requireAuth(validator,
+		func(w http.ResponseWriter, r *http.Request) {
+			datastoreListHandler.ServeHTTP(w, r)
+		},
+	))
 	mux.HandleFunc("/api2/json/admin/datastore/", requireAuth(validator,
 		func(w http.ResponseWriter, r *http.Request) {
 			if !strings.HasSuffix(r.URL.Path, "/gc") {

--- a/services/backupos-pbs/internal/datastorelist/datastorelist.go
+++ b/services/backupos-pbs/internal/datastorelist/datastorelist.go
@@ -1,0 +1,73 @@
+// Package datastorelist implements GET /api2/json/admin/datastore.
+//
+// PVE's "Add Proxmox Backup Server" UI calls this endpoint to enumerate
+// available datastores after the operator submits the storage-add dialog.
+// Real PBS returns:
+//
+//	{"data":[{"store":"default", "comment":"..."}, ...]}
+//
+// We return the same shape with the "store" field populated. "comment" is
+// included as an empty string for compatibility; populate it when the
+// pbs_datastores schema gains a comment column.
+package datastorelist
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+)
+
+// Handler serves GET /api2/json/admin/datastore.
+type Handler struct {
+	db *sql.DB
+}
+
+// NewHandler constructs a Handler.
+func NewHandler(db *sql.DB) *Handler {
+	return &Handler{db: db}
+}
+
+type datastoreEntry struct {
+	Store   string `json:"store"`
+	Comment string `json:"comment"`
+}
+
+// ServeHTTP returns the list of datastores in the format expected by PVE.
+//
+// Auth is enforced by the requireAuth wrapper at registration time; this
+// handler runs only after the caller has presented a valid token.
+//
+// Authorization: any authenticated token can list datastores. Real PBS
+// scopes this by Datastore.Audit privilege; we do not yet implement
+// per-datastore ACLs in the protocol layer, so all tokens see all
+// datastores. Track as a follow-up when the privilege model lands.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	rows, err := h.db.Query(`SELECT name FROM pbs_datastores ORDER BY name ASC`)
+	if err != nil {
+		http.Error(w, "database error", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	entries := []datastoreEntry{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			http.Error(w, "database error", http.StatusInternalServerError)
+			return
+		}
+		entries = append(entries, datastoreEntry{Store: name, Comment: ""})
+	}
+	if err := rows.Err(); err != nil {
+		http.Error(w, "database error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"data": entries})
+}

--- a/services/backupos-pbs/internal/datastorelist/datastorelist_test.go
+++ b/services/backupos-pbs/internal/datastorelist/datastorelist_test.go
@@ -1,0 +1,137 @@
+package datastorelist
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupDB(t *testing.T, names ...string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE pbs_datastores (
+			id         TEXT PRIMARY KEY,
+			name       TEXT NOT NULL UNIQUE,
+			path       TEXT NOT NULL,
+			created_at INTEGER NOT NULL
+		);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, name := range names {
+		_, err = db.Exec(
+			`INSERT INTO pbs_datastores (id, name, path, created_at) VALUES (?, ?, ?, ?)`,
+			fmt.Sprintf("ds-%d", i), name, "/tmp/"+name, 0,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return db
+}
+
+func getJSON(t *testing.T, db *sql.DB, method string) (int, map[string]any) {
+	t.Helper()
+	h := NewHandler(db)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(method, "/api2/json/admin/datastore", nil)
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		return w.Code, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v — body: %s", err, w.Body.String())
+	}
+	return w.Code, out
+}
+
+func TestDatastoreList_Empty(t *testing.T) {
+	db := setupDB(t)
+	code, body := getJSON(t, db, http.MethodGet)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	data, _ := body["data"].([]any)
+	if len(data) != 0 {
+		t.Errorf("expected empty data array, got %v", data)
+	}
+}
+
+func TestDatastoreList_Single(t *testing.T) {
+	db := setupDB(t, "default")
+	code, body := getJSON(t, db, http.MethodGet)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	data, _ := body["data"].([]any)
+	if len(data) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(data))
+	}
+	entry, _ := data[0].(map[string]any)
+	if entry["store"] != "default" {
+		t.Errorf("expected store=default, got %v", entry["store"])
+	}
+	if entry["comment"] != "" {
+		t.Errorf("expected comment empty, got %v", entry["comment"])
+	}
+}
+
+func TestDatastoreList_MultipleAlphabetical(t *testing.T) {
+	// Insert in non-alphabetical order; expect sorted output.
+	db := setupDB(t, "zebra", "alpha", "middle")
+	code, body := getJSON(t, db, http.MethodGet)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	data, _ := body["data"].([]any)
+	if len(data) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(data))
+	}
+	want := []string{"alpha", "middle", "zebra"}
+	for i, w := range want {
+		entry, _ := data[i].(map[string]any)
+		if entry["store"] != w {
+			t.Errorf("entry[%d]: expected %q, got %v", i, w, entry["store"])
+		}
+	}
+}
+
+func TestDatastoreList_WrongMethod(t *testing.T) {
+	db := setupDB(t)
+	h := NewHandler(db)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api2/json/admin/datastore", strings.NewReader(""))
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestDatastoreList_DBError(t *testing.T) {
+	db := setupDB(t)
+	// Close DB before the call to simulate a database error.
+	_ = db.Close()
+
+	h := NewHandler(db)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api2/json/admin/datastore", nil)
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Why

PVE's "Add Proxmox Backup Server" storage dialog calls `GET /api2/json/admin/datastore` (bare path, no trailing slash) to enumerate datastores after the operator submits the form. backupos-pbs had no handler at that exact path — only the `/api2/json/admin/datastore/` subtree route for per-datastore subroutes. PVE received a 404 which its UI surfaces as `401 Unauthorized`, blocking the connect flow.

Confirmed by testing against real PBS at `192.168.69.21` with the same token model: real PBS returns `{"data":[{"store":"default","comment":""},...]}` from the bare path.

## What

- **`internal/datastorelist`** — new package with a single `ServeHTTP` handler that queries `pbs_datastores` and returns `{"data":[{"store":"<name>","comment":""},...]}` sorted alphabetically, matching the real PBS wire format.
- **`main.go`** — registers the handler at the exact path `/api2/json/admin/datastore` (behind `requireAuth`) alongside a route-precedence comment explaining why the exact and subtree routes coexist without conflict in Go's `net/http` mux.
- **Tests** — 5 cases: empty list, single, multiple (sorted), wrong method → 405, closed DB → 500.

## Route precedence

Go's `net/http` mux gives priority to exact matches over subtree patterns. `/api2/json/admin/datastore` (exact) wins for the bare path; `/api2/json/admin/datastore/` (subtree) continues to handle all per-datastore subroutes. The existing subtree route is unchanged.

## Not done (by spec)

- No `comment` column added to schema — `""` is sufficient for PVE compatibility today.
- No per-token ACL filtering — any authenticated token sees all datastores, matching the rest of the auth model.