### PR TITLE
fix(pbs): token UX — split credentials, unique constraint, permissions select, copy fallback

### DIFF
--- a/apps/web/app/(dashboard)/pbs/connect/client.tsx
+++ b/apps/web/app/(dashboard)/pbs/connect/client.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition }              from 'react'
 import { testPbsConnection, TestConnectionResult } from '@/app/actions/pbs-connect'
 import { Button }                                from '@/components/ui/button'
+import { CopyButton }                            from '@/components/copy-button'
 
 interface TokenOption     { id: string; authId: string; permissions: string }
 interface DatastoreOption { id: string; name: string }
@@ -43,28 +44,11 @@ const selectStyle: React.CSSProperties = {
   outline: 'none',
 }
 
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false)
-  return (
-    <button
-      type="button"
-      onClick={() => { navigator.clipboard.writeText(text).catch(() => {}); setCopied(true); setTimeout(() => setCopied(false), 1500) }}
-      style={{
-        fontSize: 11, padding: '2px 8px', cursor: 'pointer',
-        border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)',
-        backgroundColor: 'var(--surf2)', color: 'var(--fg-dim)',
-      }}
-    >
-      {copied ? 'Copied' : 'Copy'}
-    </button>
-  )
-}
-
 function InfoRow({ label: lbl, value }: { label: string; value: string }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8, minWidth: 0 }}>
       <span style={{ fontSize: 12, color: 'var(--fg-faint)', width: 100, flexShrink: 0 }}>{lbl}</span>
-      <span style={{ ...mono, color: 'var(--fg)', flex: 1, wordBreak: 'break-all' }}>{value}</span>
+      <span style={{ ...mono, color: 'var(--fg)', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{value}</span>
       <CopyButton text={value} />
     </div>
   )

--- a/apps/web/app/(dashboard)/pbs/tokens/client.tsx
+++ b/apps/web/app/(dashboard)/pbs/tokens/client.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from 'react'
 import { createPbsToken, revokePbsToken } from '@/app/actions/pbs-tokens'
+import { CopyButton } from '@/components/copy-button'
 
 interface Token {
   id:          string
@@ -14,21 +15,43 @@ interface Token {
   createdAt:   Date
 }
 
+const PERM_OPTIONS = [
+  { value: 'read',  label: 'Read — list snapshots, download chunks' },
+  { value: 'write', label: 'Write — create and upload backups' },
+  { value: 'full',  label: 'Full — read, write, and manage datastores' },
+] as const
+
+function permLabel(p: string): string {
+  return PERM_OPTIONS.find(o => o.value === p)?.label.split(' — ')[0] ?? p
+}
+
+interface CreatedSecret { authId: string; secret: string }
+
+function CredentialRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6, minWidth: 0 }}>
+      <span style={{ fontSize: 12, color: 'var(--fg-dim)', width: 80, flexShrink: 0 }}>{label}</span>
+      <code style={{ fontSize: 12, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--fg)' }}>{value}</code>
+      <CopyButton text={value} />
+    </div>
+  )
+}
+
 export function PbsTokensClient({ initial }: { initial: Token[] }) {
-  const [tokens, setTokens]     = useState(initial)
-  const [newToken, setNewToken] = useState<string | null>(null)
-  const [error, setError]       = useState('')
+  const [tokens, setTokens]       = useState(initial)
+  const [created, setCreated]     = useState<CreatedSecret | null>(null)
+  const [error, setError]         = useState('')
   const [pending, startTransition] = useTransition()
 
   async function handleCreate(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     setError('')
-    setNewToken(null)
+    setCreated(null)
     const fd = new FormData(e.currentTarget)
     const result = await createPbsToken(fd)
     if (result.error) { setError(result.error); return }
-    if (result.token && result.id) {
-      setNewToken(result.token)
+    if (result.authId && result.secret && result.id) {
+      setCreated({ authId: result.authId, secret: result.secret })
       setTokens(prev => [...prev, {
         id:          result.id!,
         user:        String(fd.get('user') ?? ''),
@@ -62,13 +85,19 @@ export function PbsTokensClient({ initial }: { initial: Token[] }) {
       <a href="/pbs" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--fg-dim)', textDecoration: 'none', marginBottom: 24 }}>← PBS</a>
       <h1 style={{ fontSize: 20, fontWeight: 700, color: 'var(--fg)', marginBottom: 4 }}>PBS API tokens</h1>
       <p style={{ fontSize: 13, color: 'var(--fg-dim)', marginBottom: 28 }}>
-        Tokens authenticate PVE hosts connecting to the PBS-compatible endpoint. Format: <code>user@realm!tokenname:secret</code>
+        Tokens authenticate PVE hosts connecting to the PBS-compatible endpoint.
       </p>
 
-      {newToken && (
+      {created && (
         <div style={{ marginBottom: 20, padding: '12px 16px', backgroundColor: 'var(--surf2)', border: '1px solid var(--success,#22c55e)', borderRadius: 'var(--radius-sm)' }}>
-          <p style={{ fontSize: 13, color: 'var(--fg)', marginBottom: 6, fontWeight: 600 }}>Token created — copy it now, it won&apos;t be shown again:</p>
-          <code style={{ fontSize: 12, wordBreak: 'break-all', color: 'var(--fg)' }}>{newToken}</code>
+          <p style={{ fontSize: 13, color: 'var(--fg)', marginBottom: 10, fontWeight: 600 }}>
+            Token created — copy the secret now, it won&apos;t be shown again:
+          </p>
+          <CredentialRow label="Username" value={created.authId} />
+          <CredentialRow label="Password" value={created.secret} />
+          <p style={{ fontSize: 11, color: 'var(--fg-faint)', marginTop: 8, marginBottom: 0 }}>
+            In PVE: paste <strong>Username</strong> into the Username field and <strong>Password</strong> into the Password field.
+          </p>
         </div>
       )}
 
@@ -89,7 +118,11 @@ export function PbsTokensClient({ initial }: { initial: Token[] }) {
           </div>
           <div>
             <label htmlFor="pbs-permissions" style={{ display: 'block', fontSize: 12, color: 'var(--fg-dim)', marginBottom: 4 }}>Permissions</label>
-            <input id="pbs-permissions" name="permissions" defaultValue="read" style={inputStyle} />
+            <select id="pbs-permissions" name="permissions" defaultValue="read" style={inputStyle}>
+              {PERM_OPTIONS.map(o => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
           </div>
           <div style={{ gridColumn: '1 / -1' }}>
             <label htmlFor="pbs-expires" style={{ display: 'block', fontSize: 12, color: 'var(--fg-dim)', marginBottom: 4 }}>Expires (optional)</label>
@@ -119,7 +152,7 @@ export function PbsTokensClient({ initial }: { initial: Token[] }) {
                 <td style={{ padding: '8px', color: 'var(--fg)' }}>
                   <code style={{ fontSize: 12 }}>{tk.user}@{tk.realm}!{tk.tokenName}</code>
                 </td>
-                <td style={{ padding: '8px', color: 'var(--fg-dim)' }}>{tk.permissions}</td>
+                <td style={{ padding: '8px', color: 'var(--fg-dim)' }}>{permLabel(tk.permissions)}</td>
                 <td style={{ padding: '8px', color: 'var(--fg-dim)' }}>{tk.expiresAt ? new Date(tk.expiresAt).toLocaleDateString() : '—'}</td>
                 <td style={{ padding: '8px', color: 'var(--fg-dim)' }}>{tk.lastUsedAt ? new Date(tk.lastUsedAt).toLocaleDateString() : '—'}</td>
                 <td style={{ padding: '8px' }}>

--- a/apps/web/app/actions/pbs-tokens.ts
+++ b/apps/web/app/actions/pbs-tokens.ts
@@ -2,17 +2,20 @@
 
 import { revalidatePath }                          from 'next/cache'
 import { randomBytes }                             from 'crypto'
-import { getDb, pbsTokens, eq }                    from '@backupos/db'
+import { getDb, pbsTokens, eq, and }               from '@backupos/db'
 import { requireAdmin }                            from '@/lib/user'
-import { generatePbsSecret, hashPbsSecret, formatPbsToken } from '@/lib/pbs-tokens'
+import { generatePbsSecret, hashPbsSecret }        from '@/lib/pbs-tokens'
 import { appendAuditEntry }                        from '@/lib/audit'
 import { headers }                                 from 'next/headers'
 import { auth }                                    from '@/lib/auth'
 
+const VALID_PERMISSIONS = new Set(['read', 'write', 'full'])
+
 export async function createPbsToken(formData: FormData): Promise<{
-  token?: string
-  id?: string
-  error?: string
+  authId?:  string
+  secret?:  string
+  id?:      string
+  error?:   string
 }> {
   await requireAdmin()
   const { api } = auth
@@ -28,12 +31,28 @@ export async function createPbsToken(formData: FormData): Promise<{
   if (!user)      return { error: 'User is required' }
   if (!realm)     return { error: 'Realm is required' }
   if (!tokenName) return { error: 'Token name is required' }
+  if (!VALID_PERMISSIONS.has(perms)) return { error: 'Permissions must be read, write, or full' }
+
+  const db = getDb()
+
+  const existing = await db
+    .select({ id: pbsTokens.id })
+    .from(pbsTokens)
+    .where(and(
+      eq(pbsTokens.user,      user),
+      eq(pbsTokens.realm,     realm),
+      eq(pbsTokens.tokenName, tokenName),
+    ))
+    .limit(1)
+  if (existing.length > 0) {
+    return { error: `Token ${user}@${realm}!${tokenName} already exists` }
+  }
 
   const secret = generatePbsSecret()
   const hash   = hashPbsSecret(secret)
   const id     = randomBytes(8).toString('hex')
+  const authId = `${user}@${realm}!${tokenName}`
 
-  const db = getDb()
   await db.insert(pbsTokens).values({
     id,
     user,
@@ -49,12 +68,12 @@ export async function createPbsToken(formData: FormData): Promise<{
     action:       'pbs_token.created',
     resourceType: 'pbs_token',
     resourceId:   id,
-    resourceName: `${user}@${realm}!${tokenName}`,
+    resourceName: authId,
     actor:        session.user.id,
   })
 
   revalidatePath('/pbs/tokens')
-  return { token: formatPbsToken({ user, realm, tokenName, secret }), id }
+  return { authId, secret, id }
 }
 
 export async function revokePbsToken(id: string): Promise<void> {

--- a/apps/web/components/copy-button.tsx
+++ b/apps/web/components/copy-button.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useState } from 'react'
+
+interface CopyButtonProps {
+  text: string
+  style?: React.CSSProperties
+}
+
+export function CopyButton({ text, style }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false)
+
+  function handleCopy() {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(text).then(
+        () => flash(),
+        () => fallback(),
+      )
+    } else {
+      fallback()
+    }
+  }
+
+  function fallback() {
+    const el = document.createElement('textarea')
+    el.value = text
+    el.style.position = 'fixed'
+    el.style.opacity = '0'
+    document.body.appendChild(el)
+    el.focus()
+    el.select()
+    try { document.execCommand('copy'); flash() } catch {}
+    document.body.removeChild(el)
+  }
+
+  function flash() {
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      style={{
+        fontSize: 11, padding: '2px 8px', cursor: 'pointer',
+        border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)',
+        backgroundColor: 'var(--surf2)', color: 'var(--fg-dim)',
+        flexShrink: 0,
+        ...style,
+      }}
+    >
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  )
+}

--- a/packages/db/migrations/0044_pbs_token_unique_identity.sql
+++ b/packages/db/migrations/0044_pbs_token_unique_identity.sql
@@ -1,0 +1,17 @@
+-- Migration: enforce unique (user, realm, token_name) on pbs_tokens
+--
+-- WARNING: if you have pre-existing duplicate identities from before this
+-- migration, the CREATE UNIQUE INDEX below will fail. Deduplicate first:
+--   DELETE FROM pbs_tokens WHERE rowid NOT IN (
+--     SELECT MIN(rowid) FROM pbs_tokens GROUP BY user, realm, token_name
+--   );
+
+-- Normalise legacy permissions values to the canonical set {read, write, full}
+-- before creating the index, so a future uniqueness check can't be confused by
+-- differing case or synonyms.
+UPDATE pbs_tokens SET permissions = 'read'  WHERE lower(permissions) IN ('read',  'readonly', 'ro');
+UPDATE pbs_tokens SET permissions = 'write' WHERE lower(permissions) IN ('write', 'readwrite', 'rw');
+UPDATE pbs_tokens SET permissions = 'full'  WHERE lower(permissions) IN ('full',  'admin', 'all');
+
+CREATE UNIQUE INDEX IF NOT EXISTS pbs_tokens_user_realm_token_name_uniq
+  ON pbs_tokens (user, realm, token_name);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, real, index } from 'drizzle-orm/sqlite-core'
+import { sqliteTable, text, integer, real, index, uniqueIndex } from 'drizzle-orm/sqlite-core'
 
 // ── Agents ────────────────────────────────────────────────────────────────
 // An agent is the backupos-agent binary running on a source host
@@ -655,7 +655,9 @@ export const pbsTokens = sqliteTable('pbs_tokens', {
   expiresAt:    integer('expires_at', { mode: 'timestamp_ms' }),
   createdAt:    integer('created_at', { mode: 'timestamp_ms' }).notNull(),
   lastUsedAt:   integer('last_used_at', { mode: 'timestamp_ms' }),
-})
+}, t => [
+  uniqueIndex('pbs_tokens_user_realm_token_name_uniq').on(t.user, t.realm, t.tokenName),
+])
 
 export const pbsActiveSessions = sqliteTable('pbs_active_sessions', {
   id:           text('id').primaryKey(),


### PR DESCRIPTION
## Summary

- **Split credentials display**: post-creation panel now shows separate **Username** (`user@realm!tokenname`) and **Password** (the secret) rows with PVE-matching labels — fixes the root cause of PVE 401s where operators were pasting the full combined string into the Password field
- **Unique constraint**: migration `0044` adds `UNIQUE INDEX (user, realm, token_name)` on `pbs_tokens`; server action pre-checks for duplicates and returns a friendly error before hitting the DB constraint; migration also normalises legacy `permissions` values to `{read, write, full}`
- **Permissions select**: replaces free-text input with a `<select>` showing human-readable descriptions; server-side validation rejects values outside the canonical set
- **Shared CopyButton** (`apps/web/components/copy-button.tsx`): `navigator.clipboard` with `document.execCommand` fallback — copy now works over plain HTTP on LAN-only PVE installs
- **Fingerprint overflow fix**: `InfoRow` in `connect/client` gets `minWidth: 0` + `overflow: hidden` on the flex value span so the 95-char fingerprint doesn't burst the card

## Test plan

- [ ] Create a token; confirm post-creation panel shows two separate rows labelled **Username** and **Password**
- [ ] Paste the **Username** value into PVE's Username field and **Password** into the Password field; verify PVE connects without 401
- [ ] Try creating a duplicate token identity; confirm error `Token user@realm!name already exists`
- [ ] Try submitting a bogus permissions value via curl; confirm 400-level error returned
- [ ] Load `/pbs/connect` over HTTP (not HTTPS); confirm copy buttons work via execCommand fallback
- [ ] Verify fingerprint row does not overflow on a narrow viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)