### PR TITLE
fix(pbs): backfill permissions + replace overflow ellipsis with wrap

### DIFF
--- a/apps/web/app/(dashboard)/pbs/connect/client.tsx
+++ b/apps/web/app/(dashboard)/pbs/connect/client.tsx
@@ -46,9 +46,9 @@ const selectStyle: React.CSSProperties = {
 
 function InfoRow({ label: lbl, value }: { label: string; value: string }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8, minWidth: 0 }}>
-      <span style={{ fontSize: 12, color: 'var(--fg-faint)', width: 100, flexShrink: 0 }}>{lbl}</span>
-      <span style={{ ...mono, color: 'var(--fg)', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{value}</span>
+    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, marginBottom: 8, minWidth: 0 }}>
+      <span style={{ fontSize: 12, color: 'var(--fg-faint)', width: 100, flexShrink: 0, paddingTop: 2 }}>{lbl}</span>
+      <span style={{ ...mono, color: 'var(--fg)', flex: 1, minWidth: 0, wordBreak: 'break-all' }}>{value}</span>
       <CopyButton text={value} />
     </div>
   )

--- a/apps/web/app/(dashboard)/pbs/tokens/client.tsx
+++ b/apps/web/app/(dashboard)/pbs/tokens/client.tsx
@@ -29,9 +29,9 @@ interface CreatedSecret { authId: string; secret: string }
 
 function CredentialRow({ label, value }: { label: string; value: string }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6, minWidth: 0 }}>
-      <span style={{ fontSize: 12, color: 'var(--fg-dim)', width: 80, flexShrink: 0 }}>{label}</span>
-      <code style={{ fontSize: 12, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--fg)' }}>{value}</code>
+    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: 6, minWidth: 0 }}>
+      <span style={{ fontSize: 12, color: 'var(--fg-dim)', width: 80, flexShrink: 0, paddingTop: 2 }}>{label}</span>
+      <code style={{ fontSize: 12, flex: 1, minWidth: 0, wordBreak: 'break-all', fontFamily: 'IBM Plex Mono, monospace', color: 'var(--fg)' }}>{value}</code>
       <CopyButton text={value} />
     </div>
   )

--- a/packages/db/migrations/0045_pbs_token_permissions_backfill.sql
+++ b/packages/db/migrations/0045_pbs_token_permissions_backfill.sql
@@ -1,0 +1,17 @@
+-- Backfill: normalise pbs_tokens.permissions values that 0044 missed.
+--
+-- 0044 normalised {full, admin, all} → 'full', but missed the literal
+-- 'full access' string used by older UI versions. It also missed
+-- 'read+write' and similar synonyms. This migration cleans up anything
+-- that didn't match the canonical set, with a final catch-all that
+-- collapses unknowns to 'read' (safe default).
+
+UPDATE pbs_tokens SET permissions = 'full'
+  WHERE lower(permissions) IN ('full access', 'fullaccess', 'full_access');
+
+UPDATE pbs_tokens SET permissions = 'write'
+  WHERE lower(permissions) IN ('read+write', 'read write', 'read_write');
+
+-- Catch-all: anything that isn't already in {read, write, full} becomes 'read'.
+UPDATE pbs_tokens SET permissions = 'read'
+  WHERE permissions NOT IN ('read', 'write', 'full');


### PR DESCRIPTION
## Summary

- **Migration 0045** — backfills `pbs_tokens.permissions` values that migration 0044 missed. 0044 handled `{full, admin, all}` → `'full'` but not the literal string `'full access'` that the older UI wrote (e.g. the live `smoke@pbs!smoke1` row). Also catches `'fullaccess'`, `'full_access'`, `'read+write'` synonyms. A final catch-all UPDATE collapses any remaining non-canonical value to `'read'` (safe default), so the column is guaranteed to contain only `{read, write, full}` after this runs.
- **InfoRow** (`pbs/connect/client.tsx`) — replaced `overflow:hidden + textOverflow:ellipsis + whiteSpace:nowrap` with `wordBreak:break-all`; parent flex changed to `alignItems:flex-start` with `paddingTop:2` on the label so the Copy button anchors to the top of wrapped text. The 95-char fingerprint is now fully readable.
- **CredentialRow** (`pbs/tokens/client.tsx`) — same fix: the token secret wraps fully instead of truncating. Added explicit `fontFamily: IBM Plex Mono` to the `<code>` element since the `mono` constant isn't in scope here.

## Why 0044 missed `'full access'`

0044 was written against the schema's canonical values (`full`, `admin`, `all`). The live database had a token whose permissions were set by an older version of the UI that rendered the dropdown label `'full access'` as the stored value rather than the underlying key `'full'`. 0045 is the explicit cleanup pass.

## Test plan

- [ ] Apply 0045 against a DB containing `permissions = 'full access'`; confirm row updates to `'full'`
- [ ] Apply 0045 against a clean DB with only canonical values; confirm no rows affected (idempotent)
- [ ] Load `/pbs/connect` — fingerprint row wraps without truncation; Copy button stays top-aligned
- [ ] Load `/pbs/tokens`, create a token — post-creation Password row wraps the full secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)