### PR TITLE
fix(db): register migrations 0043-0045 in drizzle journal

### DIFF
--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -302,6 +302,27 @@
       "when": 1777680000000,
       "tag": "0042_pbs_gc_schedule_interval",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "6",
+      "when": 1777766400000,
+      "tag": "0043_pbs_session_namespace",
+      "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "6",
+      "when": 1777852800000,
+      "tag": "0044_pbs_token_unique_identity",
+      "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "6",
+      "when": 1777939200000,
+      "tag": "0045_pbs_token_permissions_backfill",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Three migration SQL files existed on disk but were never registered in `packages/db/migrations/meta/_journal.json`. The `runMigrations()` function in `packages/db/src/index.ts` reads the journal to determine which migrations to apply — files not listed there are silently skipped on every deploy.

| Migration | Landed in | What it does |
|---|---|---|
| `0043_pbs_session_namespace` | PR #271 | Adds `namespace` column to `pbs_active_sessions` |
| `0044_pbs_token_unique_identity` | PR #281 | Adds `UNIQUE INDEX (user, realm, token_name)` on `pbs_tokens`; normalises permissions values |
| `0045_pbs_token_permissions_backfill` | PR #282 | Backfills `'full access'` and other missed synonyms → canonical `{read, write, full}` |

**Current production state** (all three silently skipped since their PRs merged):
- `pbs_active_sessions.namespace` column does not exist → namespace multi-tenancy is broken
- `pbs_tokens` has no unique constraint → duplicate token identities can be created
- `pbs_tokens.permissions` still contains `'full access'` for pre-existing rows → dropdown enum mismatch

## Change

One file changed: `packages/db/migrations/meta/_journal.json` — three entries appended after `idx: 42`, in order, with monotonically-increasing `when` timestamps.

No SQL files modified. No runner code modified. No schema changes.

## Safety

- All three migrations are safe to apply against a production DB that has partially diverged
- 0043: `ALTER TABLE ... ADD COLUMN` — runner's "duplicate column" error handler marks it complete if already present
- 0044: `CREATE UNIQUE INDEX IF NOT EXISTS` — idempotent; `UPDATE` normalisation statements are also idempotent
- 0045: pure `UPDATE WHERE` statements — no-ops once values are already canonical

🤖 Generated with [Claude Code](https://claude.com/claude-code)