### PR TITLE
fix(pbs/connect): wrap fingerprint in PVE Web UI tab table

### DIFF
--- a/apps/web/app/(dashboard)/pbs/connect/client.tsx
+++ b/apps/web/app/(dashboard)/pbs/connect/client.tsx
@@ -244,7 +244,11 @@ export function ConnectClient({ tokens, datastores, server, serverError }: Props
               </li>
               <li style={{ marginTop: 8 }}>
                 Fill in the fields:
-                <table style={{ fontSize: 12, marginTop: 8, borderCollapse: 'collapse', width: '100%' }}>
+                <table style={{ fontSize: 12, marginTop: 8, borderCollapse: 'collapse', width: '100%', tableLayout: 'fixed' }}>
+                  <colgroup>
+                    <col style={{ width: 90 }} />
+                    <col />
+                  </colgroup>
                   <tbody>
                     {[
                       ['ID',          'backupos (or any name)'],
@@ -255,12 +259,14 @@ export function ConnectClient({ tokens, datastores, server, serverError }: Props
                       ['Fingerprint', fp         || '—'],
                     ].map(([k, v]) => (
                       <tr key={k}>
-                        <td style={{ padding: '3px 12px 3px 0', color: 'var(--fg-faint)', whiteSpace: 'nowrap' }}>{k}</td>
-                        <td>
-                          <span style={{ ...mono, color: 'var(--fg)' }}>{v}</span>
-                          {['Server', 'Username', 'Datastore', 'Fingerprint'].includes(k ?? '') && v && v !== '—' && (
-                            <span style={{ marginLeft: 8 }}><CopyButton text={v ?? ''} /></span>
-                          )}
+                        <td style={{ padding: '4px 12px 4px 0', color: 'var(--fg-faint)', whiteSpace: 'nowrap', verticalAlign: 'top' }}>{k}</td>
+                        <td style={{ verticalAlign: 'top' }}>
+                          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, minWidth: 0 }}>
+                            <span style={{ ...mono, color: 'var(--fg)', flex: 1, minWidth: 0, wordBreak: 'break-all' }}>{v}</span>
+                            {['Server', 'Username', 'Datastore', 'Fingerprint'].includes(k ?? '') && v && v !== '—' && (
+                              <CopyButton text={v ?? ''} />
+                            )}
+                          </div>
                         </td>
                       </tr>
                     ))}


### PR DESCRIPTION
## Summary

PR #282 fixed `InfoRow` in the Server info card to use `wordBreak: break-all`. The PVE Web UI tab contains a separate `<table>` that renders the same fingerprint string — that table had no column-width constraints, so the 95-char fingerprint forced it wider than the card boundary.

## Changes (single file: `apps/web/app/(dashboard)/pbs/connect/client.tsx`)

- `<table>` gains `tableLayout: 'fixed'` and a `<colgroup>` with an explicit 90px label column; the value column takes the remaining space
- Each value `<td>` now wraps its content in a flex container (`alignItems: flex-start`, `minWidth: 0`) with the value `<span>` using `flex: 1 + minWidth: 0 + wordBreak: break-all`
- `CopyButton` moves out of the `<span style={{ marginLeft: 8 }}>` wrapper and directly into the flex row
- Both `<td>` cells get `verticalAlign: top` so labels stay pinned to the start of multi-line values

## Test plan

- [ ] Open `/pbs/connect`, switch to PVE Web UI tab with a token and datastore selected
- [ ] Fingerprint row wraps within the card boundary — no horizontal overflow
- [ ] Copy button on Fingerprint row is top-aligned with the first line of the wrapped text
- [ ] All other rows (ID, Server, Username, Password, Datastore) render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)