### PR TITLE
chore(pbs): log unmatched 404 paths to surface missing endpoints

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -177,6 +177,12 @@ func main() {
 	mux.HandleFunc("/api2/json/admin/datastore/", requireAuth(validator,
 		func(w http.ResponseWriter, r *http.Request) {
 			if !strings.HasSuffix(r.URL.Path, "/gc") {
+				slog.Info("404 (admin/datastore subtree)",
+					"method", r.Method,
+					"path",   r.URL.Path,
+					"query",  r.URL.RawQuery,
+					"remote", r.RemoteAddr,
+				)
 				http.NotFound(w, r)
 				return
 			}
@@ -289,6 +295,12 @@ func writeAuthError(w http.ResponseWriter, reason string) {
 }
 
 func notFound(w http.ResponseWriter, r *http.Request) {
+	slog.Info("404",
+		"method", r.Method,
+		"path",   r.URL.Path,
+		"query",  r.URL.RawQuery,
+		"remote", r.RemoteAddr,
+	)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusNotFound)
 	resp := map[string]string{"error": "not found"}


### PR DESCRIPTION
## Summary

When `proxmox-backup-client` calls backupos-pbs endpoints we haven't implemented yet, the requests hit the `notFound` handler silently — we get a 404 in the client logs but nothing in the server logs. This makes it impossible to tell which PBS protocol paths are being called without running tcpdump.

## Change

Two `slog.Info` calls added to `services/backupos-pbs/cmd/backupos-pbs/main.go`:

1. **`notFound()`** — logs every request that falls through to the catch-all `"/"` handler
2. **`/api2/json/admin/datastore/` subtree handler** — logs requests to any path under that prefix that doesn't end in `/gc` (these previously called `http.NotFound` without logging)

Both log `method`, `path`, `query`, and `remote`. `slog` is already imported and in use in the same file.

## Test plan

- [ ] Make a request to an unimplemented path (e.g. `GET /api2/json/nodes`) — confirm JSON log line appears with `"msg":"404"` and the correct path
- [ ] Make a request to `/api2/json/admin/datastore/default/something` — confirm `"msg":"404 (admin/datastore subtree)"` appears
- [ ] `/api2/json/admin/datastore/default/gc` still routes to `gcAdminHandler` without logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)