### PR TITLE
fix(pbs): log path on every 401 response

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -246,13 +246,13 @@ func requireAuth(v *auth.Validator, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "" {
-			writeAuthError(w, "missing Authorization header")
+			writeAuthError(w, r, "missing Authorization header")
 			return
 		}
 
 		parsed, err := auth.ParseAuthHeader(authHeader)
 		if err != nil {
-			writeAuthError(w, "malformed Authorization header")
+			writeAuthError(w, r, "malformed Authorization header")
 			return
 		}
 
@@ -268,7 +268,7 @@ func requireAuth(v *auth.Validator, next http.HandlerFunc) http.HandlerFunc {
 				"token_name", parsed.TokenName,
 				"remote", r.RemoteAddr,
 			)
-			writeAuthError(w, "invalid credentials")
+			writeAuthError(w, r, "invalid credentials")
 			return
 		}
 
@@ -286,7 +286,14 @@ func requireAuth(v *auth.Validator, next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-func writeAuthError(w http.ResponseWriter, reason string) {
+func writeAuthError(w http.ResponseWriter, r *http.Request, reason string) {
+	slog.Info("401",
+		"reason", reason,
+		"method", r.Method,
+		"path",   r.URL.Path,
+		"query",  r.URL.RawQuery,
+		"remote", r.RemoteAddr,
+	)
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("WWW-Authenticate", `PBSAPIToken realm="backupos"`)
 	w.WriteHeader(http.StatusUnauthorized)


### PR DESCRIPTION
## Summary

`writeAuthError` was silent — we could see 401s in the client logs but had no server-side record of which path was hit or why. This made it impossible to diagnose PVE auth failures without tcpdump.

## Change

`writeAuthError` signature extended to accept `*http.Request`. It now emits `slog.Info("401")` with `reason`, `method`, `path`, `query`, and `remote` before writing the response. All three call sites in `requireAuth` updated.

The existing `slog.Info("auth failed")` log in the invalid-credentials branch is preserved — it logs the parsed token identity (user, realm, token_name). Together the two log lines give: what was presented, and where it was presented.

## Test plan

- [ ] Send a request with no `Authorization` header — confirm JSON log `{"msg":"401","reason":"missing Authorization header","path":"...","method":"..."}`
- [ ] Send a request with a malformed header — confirm `"reason":"malformed Authorization header"`
- [ ] Send a request with wrong credentials — confirm both `"auth failed"` and `"401"` log lines appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)