### PR TITLE
fix(pbs/auth): accept space-separated PBSAPIToken header (pveproxy format)

### DIFF
--- a/services/backupos-pbs/internal/auth/auth.go
+++ b/services/backupos-pbs/internal/auth/auth.go
@@ -1,6 +1,7 @@
 // Package auth implements PBS token validation.
 //
-// Wire format: Authorization: PBSAPIToken=user@realm!tokenname:secret
+// Wire formats: "PBSAPIToken=user@realm!tokenname:secret" (proxmox-backup-client)
+//               "PBSAPIToken user@realm!tokenname:secret" (pveproxy / RFC 7235)
 //
 // Hash format: sha256(secret) as lowercase hex. No salt. Matches the
 // M3b Node implementation exactly so existing tokens validate.
@@ -53,13 +54,23 @@ var ErrTokenExpired = errors.New("token expired")
 // Authorization header value. Returns ErrMalformed if the header doesn't
 // match the expected format.
 //
-// Format: PBSAPIToken=user@realm!tokenname:secret
+// Accepts both formats real PBS accepts:
+//
+//	"PBSAPIToken=user@realm!tokenname:secret"  (proxmox-backup-client)
+//	"PBSAPIToken user@realm!tokenname:secret"  (RFC 7235, pveproxy)
 func ParseAuthHeader(header string) (*ParsedHeader, error) {
-	const prefix = "PBSAPIToken="
-	if !strings.HasPrefix(header, prefix) {
+	const scheme = "PBSAPIToken"
+	if !strings.HasPrefix(header, scheme) {
 		return nil, ErrMalformed
 	}
-	raw := header[len(prefix):]
+	if len(header) <= len(scheme) {
+		return nil, ErrMalformed
+	}
+	sep := header[len(scheme)]
+	if sep != '=' && sep != ' ' {
+		return nil, ErrMalformed
+	}
+	raw := header[len(scheme)+1:]
 
 	colonIdx := strings.Index(raw, ":")
 	if colonIdx == -1 {

--- a/services/backupos-pbs/internal/auth/auth_test.go
+++ b/services/backupos-pbs/internal/auth/auth_test.go
@@ -36,6 +36,25 @@ func TestParseAuthHeader_SecretWithSpecialChars(t *testing.T) {
 	}
 }
 
+func TestParseAuthHeader_SpaceSeparated(t *testing.T) {
+	h, err := ParseAuthHeader("PBSAPIToken root@pbs!test1:abcdef")
+	if err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+	if h.User != "root" {
+		t.Errorf("user: got %q, want %q", h.User, "root")
+	}
+	if h.Realm != "pbs" {
+		t.Errorf("realm: got %q, want %q", h.Realm, "pbs")
+	}
+	if h.TokenName != "test1" {
+		t.Errorf("tokenName: got %q, want %q", h.TokenName, "test1")
+	}
+	if h.Secret != "abcdef" {
+		t.Errorf("secret: got %q, want %q", h.Secret, "abcdef")
+	}
+}
+
 func TestParseAuthHeader_Malformed(t *testing.T) {
 	cases := []string{
 		"",                               // empty
@@ -49,6 +68,8 @@ func TestParseAuthHeader_Malformed(t *testing.T) {
 		"PBSAPIToken=user@!name:secret",  // empty realm
 		"PBSAPIToken=user@realm!:secret", // empty token name
 		"PBSAPIToken=user!name:secret",   // missing @realm
+		"PBSAPIToken:root@pbs!test1:x",   // unrecognised separator
+		"PBSAPIToken",                    // scheme only, no separator
 	}
 	for _, c := range cases {
 		t.Run(c, func(t *testing.T) {


### PR DESCRIPTION
## Summary

PVE sends two distinct `Authorization` header formats to backupos-pbs:

| Caller | Format | Status |
|---|---|---|
| `proxmox-backup-client` | `PBSAPIToken=<authid>:<secret>` | ✅ accepted |
| pveproxy (storage-status, datastore checks) | `PBSAPIToken <authid>:<secret>` | ❌ rejected → 401 |

The space-separated form is the RFC 7235 standard auth-scheme syntax. Real PBS accepts both. Our parser hardcoded `PBSAPIToken=` and rejected the space form, causing pveproxy calls to 401, PVE to mark the storage broken, and backups to refuse to start.

## Change

`ParseAuthHeader` now checks the byte immediately after `"PBSAPIToken"` and accepts either `=` or ` ` (single space) as the separator. Any other character (including bare scheme, colon, tab, multiple spaces) returns `ErrMalformed`.

No changes to `ParsedHeader`, `Validator`, or any middleware.

## Tests added

- `TestParseAuthHeader_SpaceSeparated` — verifies the space form parses all fields correctly
- Two new cases in `TestParseAuthHeader_Malformed`: `"PBSAPIToken:..."` (colon separator) and `"PBSAPIToken"` (scheme only, no separator)

## Test plan

- [ ] CI `go test ./internal/auth/...` passes (all existing + 3 new cases)
- [ ] Deploy to dev; confirm PVE storage-status no longer 401s after the malformed-auth log shows `"PBSAPIToken <authid>"` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)