### PR TITLE
feat(pbs): implement /api2/json/admin/datastore/<store>/status

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -56,6 +56,7 @@ import (
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/readerupgrade"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/speedtest"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastorelist"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastorestatus"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/selftest"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/sessionreaper"
@@ -156,8 +157,9 @@ func main() {
 	})
 	gcAdminHandler := gcadmin.NewHandler(datastoreLookup, gcTracker, oldestActiveWriter)
 	gcScheduler := gcsched.New(datastoreLookup, gcTracker, oldestActiveWriter, 0)
-	selfTestHandler      := selftest.NewHandler(database, datastoreLookup, versionString)
-	datastoreListHandler := datastorelist.NewHandler(database)
+	selfTestHandler        := selftest.NewHandler(database, datastoreLookup, versionString)
+	datastoreListHandler   := datastorelist.NewHandler(database)
+	datastoreStatusHandler := datastorestatus.NewHandler(datastoreLookup)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api2/json/version", versionHandler.ServeHTTP)
@@ -176,7 +178,12 @@ func main() {
 	))
 	mux.HandleFunc("/api2/json/admin/datastore/", requireAuth(validator,
 		func(w http.ResponseWriter, r *http.Request) {
-			if !strings.HasSuffix(r.URL.Path, "/gc") {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/gc"):
+				gcAdminHandler.ServeHTTP(w, r)
+			case strings.HasSuffix(r.URL.Path, "/status"):
+				datastoreStatusHandler.ServeHTTP(w, r)
+			default:
 				slog.Info("404 (admin/datastore subtree)",
 					"method", r.Method,
 					"path",   r.URL.Path,
@@ -184,9 +191,7 @@ func main() {
 					"remote", r.RemoteAddr,
 				)
 				http.NotFound(w, r)
-				return
 			}
-			gcAdminHandler.ServeHTTP(w, r)
 		},
 	))
 	mux.HandleFunc("/api2/json/admin/self-test/datastore/", selfTestHandler.ServeHTTP)

--- a/services/backupos-pbs/internal/datastorestatus/datastorestatus.go
+++ b/services/backupos-pbs/internal/datastorestatus/datastorestatus.go
@@ -1,0 +1,111 @@
+// Package datastorestatus implements GET /api2/json/admin/datastore/<store>/status.
+//
+// PVE polls this endpoint every 10 seconds to display storage health.
+// Required fields: total / used / avail (bytes). Other fields are
+// optional but populated with sensible defaults so PVE's UI renders fully.
+package datastorestatus
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"syscall"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+)
+
+type Handler struct {
+	datastores *datastore.Lookup
+}
+
+func NewHandler(ds *datastore.Lookup) *Handler {
+	return &Handler{datastores: ds}
+}
+
+type gcStatus struct {
+	UPID           string `json:"upid"`
+	LastRunEndtime int64  `json:"last-run-endtime"`
+	LastRunState   string `json:"last-run-state"`
+}
+
+type countEntry struct {
+	Snapshots int   `json:"snapshots"`
+	Size      int64 `json:"size"`
+}
+
+type counts struct {
+	CT   countEntry `json:"ct"`
+	Host countEntry `json:"host"`
+	VM   countEntry `json:"vm"`
+}
+
+type statusResponse struct {
+	Total    uint64   `json:"total"`
+	Used     uint64   `json:"used"`
+	Avail    uint64   `json:"avail"`
+	GCStatus gcStatus `json:"gc-status"`
+	Counts   counts   `json:"counts"`
+}
+
+// ServeHTTP returns disk usage and lightweight metadata for the datastore.
+//
+// Path:    /api2/json/admin/datastore/<store>/status
+// Method:  GET
+// Auth:    enforced by requireAuth wrapper at registration.
+//
+// total/used/avail come from statfs() on the datastore's root path.
+// gc-status and counts are populated with placeholder defaults — adequate
+// for PVE's storage-health indicator. A future PR can populate counts
+// from the snapshot index when that work lands.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Path format: /api2/json/admin/datastore/<store>/status
+	const prefix = "/api2/json/admin/datastore/"
+	rest := strings.TrimPrefix(r.URL.Path, prefix)
+	if !strings.HasSuffix(rest, "/status") {
+		http.NotFound(w, r)
+		return
+	}
+	store := strings.TrimSuffix(rest, "/status")
+	if store == "" || strings.Contains(store, "/") {
+		http.NotFound(w, r)
+		return
+	}
+
+	ds, err := h.datastores.ByName(store)
+	if errors.Is(err, datastore.ErrNotFound) || errors.Is(err, datastore.ErrInvalidName) {
+		http.Error(w, "datastore not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		http.Error(w, "datastore lookup failed", http.StatusInternalServerError)
+		return
+	}
+
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(ds.Path, &stat); err != nil {
+		http.Error(w, "statfs failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	bsize := uint64(stat.Bsize)
+	resp := statusResponse{
+		Total: stat.Blocks * bsize,
+		Used:  (stat.Blocks - stat.Bfree) * bsize,
+		Avail: stat.Bavail * bsize,
+		GCStatus: gcStatus{
+			UPID:           "",
+			LastRunEndtime: 0,
+			LastRunState:   "",
+		},
+		Counts: counts{},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"data": resp})
+}

--- a/services/backupos-pbs/internal/datastorestatus/datastorestatus_test.go
+++ b/services/backupos-pbs/internal/datastorestatus/datastorestatus_test.go
@@ -1,0 +1,135 @@
+package datastorestatus
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+)
+
+func setupDB(t *testing.T, name, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE pbs_datastores (
+			id                   TEXT PRIMARY KEY,
+			name                 TEXT NOT NULL UNIQUE,
+			path                 TEXT NOT NULL,
+			created_at           INTEGER NOT NULL,
+			gc_schedule_interval TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if name != "" {
+		_, err = db.Exec(
+			`INSERT INTO pbs_datastores (id, name, path, created_at) VALUES (?, ?, ?, ?)`,
+			"ds-1", name, path, 0,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return db
+}
+
+func TestDatastoreStatus_Success(t *testing.T) {
+	dir := t.TempDir()
+	db := setupDB(t, "default", dir)
+	h := NewHandler(datastore.NewLookup(db))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api2/json/admin/datastore/default/status", nil)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	data, ok := out["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected data object, got %T", out["data"])
+	}
+	total, _ := data["total"].(float64)
+	if total <= 0 {
+		t.Errorf("expected total > 0, got %v", total)
+	}
+	used, _ := data["used"].(float64)
+	if used < 0 {
+		t.Errorf("expected used >= 0, got %v", used)
+	}
+	avail, _ := data["avail"].(float64)
+	if avail < 0 {
+		t.Errorf("expected avail >= 0, got %v", avail)
+	}
+}
+
+func TestDatastoreStatus_WrongMethod(t *testing.T) {
+	dir := t.TempDir()
+	db := setupDB(t, "default", dir)
+	h := NewHandler(datastore.NewLookup(db))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api2/json/admin/datastore/default/status", nil)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestDatastoreStatus_UnknownStore(t *testing.T) {
+	db := setupDB(t, "", "")
+	h := NewHandler(datastore.NewLookup(db))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api2/json/admin/datastore/nonexistent/status", nil)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestDatastoreStatus_MalformedPath(t *testing.T) {
+	dir := t.TempDir()
+	db := setupDB(t, "foo", dir)
+	h := NewHandler(datastore.NewLookup(db))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api2/json/admin/datastore/foo/something", nil)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestDatastoreStatus_SlashInStoreName(t *testing.T) {
+	dir := t.TempDir()
+	db := setupDB(t, "foo", dir)
+	h := NewHandler(datastore.NewLookup(db))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api2/json/admin/datastore/foo/bar/status", nil)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary

PVE polls `GET /api2/json/admin/datastore/<store>/status` every 10 seconds for storage health. Until this endpoint returns a valid response, PVE marks the storage as broken and refuses to start backups.

## New package: `internal/datastorestatus`

- Parses the store name from the URL path (`/api2/json/admin/datastore/<store>/status`)
- Looks up the datastore by name via `datastore.Lookup.ByName`
- Calls `syscall.Statfs()` on the datastore root path to get real `total / used / avail` byte counts
- Returns `{"data": {"total": ..., "used": ..., "avail": ..., "gc-status": {...}, "counts": {...}}}` — the shape PVE's storage-status check expects
- `gc-status` and `counts` use zero-value placeholders (adequate for PVE's health indicator; snapshot counts are a follow-up)

## Route change in `main.go`

The existing `/api2/json/admin/datastore/` subtree handler was `if /gc → gcAdmin else → 404`. Changed to a `switch` dispatching on suffix:
- `/gc` → `gcAdminHandler`
- `/status` → `datastoreStatusHandler` (new)
- default → existing 404 log + `http.NotFound`

## Tests (5 cases)

| Case | Expected |
|---|---|
| Valid datastore + real `t.TempDir()` path | 200, `total > 0`, `used >= 0`, `avail >= 0` |
| POST method | 405 |
| Non-existent store name | 404 |
| Path without `/status` suffix | 404 |
| Slash in store name (`/foo/bar/status`) | 404 |

## Test plan

- [ ] CI `go test ./internal/datastorestatus/...` passes
- [ ] Deploy to dev; confirm PVE storage no longer shows as broken after polling `/status`
- [ ] `/gc` route still works (GC trigger unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)