### PR TITLE
fix(pbs): normalise duplicate leading slashes in request paths

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -208,7 +208,7 @@ func main() {
 
 	server := &http.Server{
 		Addr:    *bind,
-		Handler: mux,
+		Handler: normalizeLeadingSlashes(mux),
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			MinVersion:   tls.VersionTLS12,
@@ -324,6 +324,35 @@ func writeAuthError(w http.ResponseWriter, r *http.Request, reason string) {
 	w.WriteHeader(http.StatusUnauthorized)
 	resp := map[string]string{"error": reason}
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// normalizeLeadingSlashes collapses runs of leading slashes in r.URL.Path
+// to a single slash before dispatching. proxmox-backup-client 4.1.5
+// constructs upgrade URLs as "//api2/json/backup?..." (a known quirk in
+// its build_uri helper). Without this normalisation, Go's net/http.ServeMux
+// 307-redirects to the canonical "/api2/json/backup" form and the client
+// — which does not follow redirects on the upgrade endpoint — bails with
+// the redirect HTML body as its error message.
+func normalizeLeadingSlashes(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(r.URL.Path) >= 2 && r.URL.Path[0] == '/' && r.URL.Path[1] == '/' {
+			// Collapse leading run of '/' to a single '/'.
+			i := 0
+			for i < len(r.URL.Path) && r.URL.Path[i] == '/' {
+				i++
+			}
+			cleaned := "/" + r.URL.Path[i:]
+			slog.Info("normalised duplicate leading slashes",
+				"original_path", r.URL.Path,
+				"cleaned_path",  cleaned,
+				"method",        r.Method,
+				"remote",        r.RemoteAddr,
+			)
+			r.URL.Path = cleaned
+			r.URL.RawPath = "" // force re-encode on read
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func notFound(w http.ResponseWriter, r *http.Request) {

--- a/services/backupos-pbs/cmd/backupos-pbs/normalize_test.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/normalize_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNormalizeLeadingSlashes(t *testing.T) {
+	cases := []struct {
+		name     string
+		inPath   string
+		wantPath string
+	}{
+		{"single slash unchanged", "/api2/json/backup", "/api2/json/backup"},
+		{"double slash collapsed", "//api2/json/backup", "/api2/json/backup"},
+		{"triple slash collapsed", "///api2/json/backup", "/api2/json/backup"},
+		{"single slash root", "/", "/"},
+		{"double slash root", "//", "/"},
+		{"empty stays empty", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seen string
+			inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				seen = r.URL.Path
+			})
+			h := normalizeLeadingSlashes(inner)
+
+			r := httptest.NewRequest(http.MethodGet, "http://example.com"+tc.inPath, nil)
+			// httptest.NewRequest cleans paths; force the raw value:
+			r.URL.Path = tc.inPath
+
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+
+			if seen != tc.wantPath {
+				t.Errorf("path: got %q, want %q", seen, tc.wantPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the root cause of PVE backup failures where `proxmox-backup-client` received a "Temporary Redirect" response instead of the PBS protocol upgrade handshake.

### Root cause

`proxmox-backup-client` 4.1.5 builds upgrade-endpoint URLs with a double leading slash: `//api2/json/backup?...`. This is a known quirk of its `build_uri` helper. Real PBS tolerates this at the reverse-proxy layer (pbsproxy normalises the path before forwarding).

Go's `net/http.ServeMux` does not tolerate double-slash paths — it issues a 307 redirect to the canonical single-slash form. The PBS upgrade client does not follow redirects; when it receives a non-101 response it reads the body and prints it as an error. That body is Go's stdlib redirect HTML:

```
<a href="/api2/json/backup?...">Temporary Redirect</a>.
```

This explained the full debugging arc: polling endpoints (`/api2/json/admin/datastore`) are built without the double-slash quirk and worked fine; the upgrade endpoint (`/api2/json/backup`) was always redirected.

## Fix

`normalizeLeadingSlashes` middleware wraps `http.Server.Handler`. For any path starting with `//`, it collapses the leading run of `/` characters to a single `/` before dispatching to the mux. A `slog.Info` line logs the normalisation so the path distortion is visible in production logs.

## Tests

Six cases in `normalize_test.go` (package `main`): single slash unchanged, double and triple slash collapsed, root path variants, empty path passthrough.

## Verification

After deploy: `curl -k -i 'https://127.0.0.1:8007//api2/json/version'` should return 200 with version JSON instead of 307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)