### PR TITLE
fix(pbs): correct dynamic writer offset accounting (start vs end)

### DIFF
--- a/services/backupos-pbs/internal/dynamicappend/dynamicappend_test.go
+++ b/services/backupos-pbs/internal/dynamicappend/dynamicappend_test.go
@@ -125,7 +125,7 @@ func TestHandler_HappyPath_Returns200(t *testing.T) {
 	body := appendRequest{
 		Wid:        wid,
 		DigestList: []string{"dead" + "000000000000000000000000000000000000000000000000000000000000"},
-		OffsetList: []uint64{65536},
+		OffsetList: []uint64{0}, // start offset 0 (first chunk)
 	}
 	// Fix digest hex to be exactly 64 chars matching the registered digest.
 	hexStr := make([]byte, 64)

--- a/services/backupos-pbs/internal/dynamicclose/dynamicclose_test.go
+++ b/services/backupos-pbs/internal/dynamicclose/dynamicclose_test.go
@@ -115,11 +115,17 @@ func TestHandler_HappyPath_Returns200(t *testing.T) {
 func TestHandler_ChunkCountMismatch_Returns400(t *testing.T) {
 	ws, wid, _ := makeState(t)
 	var d [32]byte
-	_ = ws.RegisterDynamicChunk(wid, d, 4096, false)
-	_ = ws.DynamicWriterAppendChunk(wid, 4096, d)
+	if err := ws.RegisterDynamicChunk(wid, d, 4096, false); err != nil {
+		t.Fatal(err)
+	}
+	// Start offset 0; after append running offset becomes 4096.
+	if err := ws.DynamicWriterAppendChunk(wid, 0, d); err != nil {
+		t.Fatal(err)
+	}
 	h := injectCtx(makeSessionCtx(ws))(NewHandler())
 
 	csumHex := strings.Repeat("00", 32)
+	// Server has 1 chunk; client claims 0 → count mismatch.
 	url := "/dynamic_close?wid=1&chunk-count=0&size=4096&csum=" + csumHex
 	req := httptest.NewRequest(http.MethodPost, url, nil)
 	rr := httptest.NewRecorder()

--- a/services/backupos-pbs/internal/wstate/wstate.go
+++ b/services/backupos-pbs/internal/wstate/wstate.go
@@ -267,8 +267,13 @@ func (s *State) RegisterDynamicChunk(wid int, digest [32]byte, size uint32, isDu
 }
 
 // DynamicWriterAppendChunk associates an uploaded chunk with a position in the
-// .didx index. The digest must already be in known_chunks (checked by caller).
-// No size is passed — dynamic index entries carry only (offset, digest).
+// .didx index. The digest must already be in known_chunks.
+//
+// offset is the START offset of this chunk (cumulative total BEFORE this chunk),
+// matching what proxmox-backup-client sends (fetch_add pre-increment return value).
+// We validate it matches our running counter, look up the chunk size from
+// knownChunks, bump the counter by that size, then write the END offset into the
+// index — matching environment.rs dynamic_writer_append_chunk in real PBS.
 func (s *State) DynamicWriterAppendChunk(wid int, offset uint64, digest [32]byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -282,11 +287,30 @@ func (s *State) DynamicWriterAppendChunk(wid int, offset uint64, digest [32]byte
 	if w.Closed {
 		return fmt.Errorf("dynamic writer %q already closed", w.Name)
 	}
-	if err := w.Index.AddChunk(offset, digest); err != nil {
+
+	// The client sends the START offset of this chunk (cumulative total before
+	// adding this chunk's length). Validate it matches our running counter.
+	if w.Offset != offset {
+		return fmt.Errorf("dynamic writer %q append: got strange chunk offset (%d != %d)",
+			w.Name, w.Offset, offset)
+	}
+
+	// Look up chunk size from knownChunks (populated when /dynamic_chunk uploaded it).
+	size, ok := s.knownChunks[digest]
+	if !ok {
+		return fmt.Errorf("dynamic writer %q append: chunk not found in known_chunks",
+			w.Name)
+	}
+
+	// Bump running offset by chunk size, then write the END offset into the index.
+	// This matches environment.rs dynamic_writer_append_chunk in real PBS:
+	//   data.offset += size as u64;
+	//   data.index.add_chunk(data.offset, digest)?;
+	w.Offset += uint64(size)
+	if err := w.Index.AddChunk(w.Offset, digest); err != nil {
 		return fmt.Errorf("dynamic writer %q add_chunk failed: %w", w.Name, err)
 	}
 	w.ChunkCount++
-	w.Offset = offset
 	return nil
 }
 

--- a/services/backupos-pbs/internal/wstate/wstate_test.go
+++ b/services/backupos-pbs/internal/wstate/wstate_test.go
@@ -366,12 +366,18 @@ func TestDynamicWriterAppendChunk_IncrementsChunkCount(t *testing.T) {
 	wid, _ := ws.RegisterDynamicWriter("a.didx", fi)
 
 	var digest [32]byte
-	if err := ws.DynamicWriterAppendChunk(wid, 65536, digest); err != nil {
+	// Pre-register chunk so knownChunks has the size lookup.
+	if err := ws.RegisterDynamicChunk(wid, digest, 65536, false); err != nil {
+		t.Fatal(err)
+	}
+	// Start offset is 0 (first chunk); after append running offset becomes 65536.
+	if err := ws.DynamicWriterAppendChunk(wid, 0, digest); err != nil {
 		t.Fatal(err)
 	}
 	if len(fi.chunks) != 1 {
 		t.Errorf("expected 1 chunk in fakeDynIdx, got %d", len(fi.chunks))
 	}
+	// Index receives the END offset (65536), not the start offset.
 	if fi.chunks[0].offset != 65536 {
 		t.Errorf("offset: got %d, want 65536", fi.chunks[0].offset)
 	}
@@ -387,7 +393,13 @@ func TestDynamicWriterClose_HappyPath(t *testing.T) {
 	wid, _ := ws.RegisterDynamicWriter("a.didx", fi)
 
 	var d [32]byte
-	_ = ws.DynamicWriterAppendChunk(wid, 65536, d)
+	if err := ws.RegisterDynamicChunk(wid, d, 65536, false); err != nil {
+		t.Fatal(err)
+	}
+	// Start offset 0; after append running offset becomes 65536.
+	if err := ws.DynamicWriterAppendChunk(wid, 0, d); err != nil {
+		t.Fatal(err)
+	}
 
 	got, err := ws.DynamicWriterClose(wid, 1, 65536, expectedCsum)
 	if err != nil {
@@ -415,7 +427,13 @@ func TestDynamicWriterClose_SizeMismatch_ReturnsError(t *testing.T) {
 	wid, _ := ws.RegisterDynamicWriter("a.didx", fi)
 
 	var d [32]byte
-	_ = ws.DynamicWriterAppendChunk(wid, 65536, d) // Offset becomes 65536
+	if err := ws.RegisterDynamicChunk(wid, d, 65536, false); err != nil {
+		t.Fatal(err)
+	}
+	// Start offset 0; after append running offset becomes 65536.
+	if err := ws.DynamicWriterAppendChunk(wid, 0, d); err != nil {
+		t.Fatal(err)
+	}
 
 	// client claims size=99999, server tracked 65536
 	_, err := ws.DynamicWriterClose(wid, 1, 99999, [32]byte{})
@@ -462,5 +480,46 @@ func TestCleanup_SkipsClosedDynamicWriters(t *testing.T) {
 	ws.Cleanup()
 	if fi.dropCalled {
 		t.Error("Drop called on already-closed dynamic writer during Cleanup")
+	}
+}
+
+func TestDynamicWriterAppendChunk_RejectsWrongStartOffset(t *testing.T) {
+	s := New()
+	idx := &fakeDynIdx{}
+	wid, err := s.RegisterDynamicWriter("test.didx", idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var d1, d2 [32]byte
+	d1[0] = 0x01
+	d2[0] = 0x02
+	if err := s.RegisterDynamicChunk(wid, d1, 100, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterDynamicChunk(wid, d2, 200, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// First chunk: start offset 0, size 100 → running offset becomes 100.
+	if err := s.DynamicWriterAppendChunk(wid, 0, d1); err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+	// Second chunk: start offset MUST be 100, not 50 or 200.
+	if err := s.DynamicWriterAppendChunk(wid, 50, d2); err == nil {
+		t.Fatal("expected error for wrong start offset, got nil")
+	}
+	if err := s.DynamicWriterAppendChunk(wid, 100, d2); err != nil {
+		t.Fatalf("correct second append: %v", err)
+	}
+
+	// Final running offset should equal 100 + 200 = 300.
+	// Close with size=300, chunk_count=2; csum mismatch is expected (zero csum vs zero closeReturn).
+	var csum [32]byte
+	if _, err := s.DynamicWriterClose(wid, 2, 300, csum); err != nil {
+		// Csum mismatch is fine — verify the failure is csum-only, not offset-related.
+		if !strings.Contains(err.Error(), "csum") {
+			t.Fatalf("unexpected close error (should be csum): %v", err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the root cause of the `data offset != size` close failure that surfaced after PR #290 unblocked the PBS upgrade path and PVE started successfully completing backup streams.

### Two bugs in `DynamicWriterAppendChunk`

**Bug 1 — wrong offset stored in `w.Offset`**

`w.Offset` was set to the *start* offset of the last appended chunk:
```go
w.Offset = offset   // BUG: start offset, not end offset
```

`DynamicWriterClose` checks `w.Offset != size` (total stream bytes). Since `w.Offset` held the start of the last chunk, not the end, the check always failed by exactly the last chunk's size. Observed: `4241873515 - 4241308783 = 564732` = exact size of the last `dynamic_chunk` upload.

**Bug 2 — wrong offset written to the index**

`Index.AddChunk` was called with the start offset instead of the end offset, producing a corrupt `.didx` where every chunk's entry is off by its own size. Restores would read wrong positions.

### Fix

Mirrors `environment.rs dynamic_writer_append_chunk` in real PBS:
1. Validate client's start offset matches server's running counter (`w.Offset != offset → error`)
2. Look up chunk size from `knownChunks` (populated at `/dynamic_chunk` time)
3. Bump counter by size (`w.Offset += size`)
4. Write **end** offset to the index (`Index.AddChunk(w.Offset, digest)`)

The client (`proxmox-backup-client` `backup_writer.rs` ~line 817) sends the pre-increment `fetch_add` return value — i.e., cumulative total *before* adding this chunk. This is the start offset.

### Test changes

- `TestDynamicWriterAppendChunk_IncrementsChunkCount` — pre-register chunk, use start offset 0
- `TestDynamicWriterClose_HappyPath` — pre-register chunk, use start offset 0
- `TestDynamicWriterClose_SizeMismatch_ReturnsError` — pre-register chunk, use start offset 0
- `TestHandler_ChunkCountMismatch_Returns400` (dynamicclose) — use start offset 0 so chunk is actually appended before close
- `TestHandler_HappyPath_Returns200` (dynamicappend) — change `OffsetList: {65536}` to `{0}`
- **New:** `TestDynamicWriterAppendChunk_RejectsWrongStartOffset` — covers the exact sequence that triggered the original failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)