### PR TITLE
fix(pbs): register previous-backup .didx chunks into session known_chunks

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -121,7 +121,7 @@ func main() {
 		dynamicchunk.NewHandler(),
 		dynamicappend.NewHandler(),
 		dynamicclose.NewHandler(),
-		previousarchive.NewHandler(),
+		previousarchive.NewHandler(nil),
 		previoustime.NewHandler(),
 		upgrade.StubStreamHandler(),
 	)

--- a/services/backupos-pbs/internal/previousarchive/previousarchive.go
+++ b/services/backupos-pbs/internal/previousarchive/previousarchive.go
@@ -3,6 +3,14 @@
 // The client uses this endpoint to download an archive file from the previous
 // backup directory so it can compute its index_csum and pass it back as
 // ?reuse-csum= on POST /fixed_index.
+//
+// For .didx archives, the handler also registers every chunk from the previous
+// index into the session's known_chunks map before streaming the body. This
+// mirrors environment.rs:309 in real PBS: when the client downloads a previous
+// .didx it populates its local known_chunks set and will reference those
+// digests in /dynamic_index without re-uploading them. Without this
+// registration, DynamicWriterAppendChunk returns "chunk not uploaded in this
+// session".
 package previousarchive
 
 import (
@@ -10,23 +18,34 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/didx"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
 )
 
 // archiveNameRegex accepts .fidx, .didx, and .blob archive names.
 var archiveNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_.-]+\.(fidx|didx|blob)$`)
 
 // Handler serves GET /previous.
-type Handler struct{}
+//
+// state is an optional fallback used in tests when sc.WriterState is nil.
+// In production every backup session carries its own WriterState in the
+// session context, so main.go passes nil here.
+type Handler struct {
+	state *wstate.State
+}
 
 // NewHandler constructs a previousarchive Handler.
-func NewHandler() *Handler { return &Handler{} }
+func NewHandler(state *wstate.State) *Handler {
+	return &Handler{state: state}
+}
 
 // ServeHTTP handles GET /previous?archive-name=<name>.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -81,6 +100,34 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if filepath.Ext(archiveName) == ".didx" {
+		// Resolve per-session state: real sessions carry it in the context;
+		// tests inject it via the constructor.
+		ws := sc.WriterState
+		if ws == nil {
+			ws = h.state
+		}
+		if ws != nil {
+			if err := h.registerKnownChunks(ws, f, sc.SessionID, archiveName); err != nil {
+				slog.Error("previous .didx parse failed for known-chunk registration",
+					"error", err,
+					"session_id", sc.SessionID,
+					"archive_name", archiveName,
+				)
+				writeJSONError(w, http.StatusInternalServerError,
+					"failed to parse previous index for chunk registration")
+				return
+			}
+		}
+		// Rewind so the body stream starts at byte 0.
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			slog.Error("previous archive seek failed",
+				"error", err, "session_id", sc.SessionID, "archive_name", archiveName)
+			writeJSONError(w, http.StatusInternalServerError, "seek failed")
+			return
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Length", strconv.FormatInt(info.Size(), 10))
 	w.WriteHeader(http.StatusOK)
@@ -94,6 +141,36 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"error", err,
 		)
 	}
+}
+
+// registerKnownChunks parses a .didx file and pre-populates the session's
+// known_chunks map with every (digest, size) pair so the client can reuse
+// them without re-uploading. Mirrors environment.rs dynamic_writer flow:
+// every entry's size is computed from consecutive end-offsets.
+func (h *Handler) registerKnownChunks(ws *wstate.State, f *os.File, sessionID, archiveName string) error {
+	if _, err := didx.ReadHeader(f); err != nil {
+		return fmt.Errorf("read didx header: %w", err)
+	}
+	entries, err := didx.ReadEntries(f)
+	if err != nil {
+		return fmt.Errorf("read didx entries: %w", err)
+	}
+	var prevEnd uint64
+	for i, e := range entries {
+		size := e.End - prevEnd
+		// ReadEntries already enforces MaxChunkSize (64 MiB), so this fits in uint32.
+		if size > math.MaxUint32 {
+			return fmt.Errorf("didx entry %d size %d exceeds uint32", i, size)
+		}
+		ws.RegisterKnownChunk(e.Digest, uint32(size))
+		prevEnd = e.End
+	}
+	slog.Info("previous .didx chunks registered for reuse",
+		"session_id", sessionID,
+		"archive_name", archiveName,
+		"count", len(entries),
+	)
+	return nil
 }
 
 func writeJSONError(w http.ResponseWriter, status int, msg string) {

--- a/services/backupos-pbs/internal/previousarchive/previousarchive_test.go
+++ b/services/backupos-pbs/internal/previousarchive/previousarchive_test.go
@@ -1,6 +1,7 @@
 package previousarchive
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -8,8 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/didx"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/previous"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/wstate"
 )
 
 func makeRequest(method, archiveName string, sc *streamctx.SessionContext) *http.Request {
@@ -25,7 +28,7 @@ func makeRequest(method, archiveName string, sc *streamctx.SessionContext) *http
 }
 
 func TestPreviousArchive_MethodNotAllowed(t *testing.T) {
-	h := NewHandler()
+	h := NewHandler(wstate.New())
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, makeRequest(http.MethodPost, "drive-0.img.fidx", &streamctx.SessionContext{}))
 	if w.Code != http.StatusMethodNotAllowed {
@@ -34,7 +37,7 @@ func TestPreviousArchive_MethodNotAllowed(t *testing.T) {
 }
 
 func TestPreviousArchive_NoStreamCtx_Returns500(t *testing.T) {
-	h := NewHandler()
+	h := NewHandler(wstate.New())
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/previous?archive-name=drive-0.img.fidx", nil)
 	h.ServeHTTP(w, r)
@@ -44,7 +47,7 @@ func TestPreviousArchive_NoStreamCtx_Returns500(t *testing.T) {
 }
 
 func TestPreviousArchive_NoPreviousBackup_Returns404(t *testing.T) {
-	h := NewHandler()
+	h := NewHandler(wstate.New())
 	sc := &streamctx.SessionContext{PreviousBackup: nil}
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, makeRequest(http.MethodGet, "drive-0.img.fidx", sc))
@@ -54,7 +57,7 @@ func TestPreviousArchive_NoPreviousBackup_Returns404(t *testing.T) {
 }
 
 func TestPreviousArchive_MissingArchiveName_Returns400(t *testing.T) {
-	h := NewHandler()
+	h := NewHandler(wstate.New())
 	sc := &streamctx.SessionContext{PreviousBackup: &previous.Snapshot{}}
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, makeRequest(http.MethodGet, "", sc))
@@ -64,10 +67,9 @@ func TestPreviousArchive_MissingArchiveName_Returns400(t *testing.T) {
 }
 
 func TestPreviousArchive_InvalidArchiveName_Returns400(t *testing.T) {
-	h := NewHandler()
+	h := NewHandler(wstate.New())
 	sc := &streamctx.SessionContext{PreviousBackup: &previous.Snapshot{}}
 	w := httptest.NewRecorder()
-	// URL encoding of "../evil.fidx" — use raw path injection
 	r := httptest.NewRequest(http.MethodGet, "/previous?archive-name=..%2Fevil.fidx", nil)
 	r = r.WithContext(streamctx.WithSession(r.Context(), sc))
 	h.ServeHTTP(w, r)
@@ -77,7 +79,7 @@ func TestPreviousArchive_InvalidArchiveName_Returns400(t *testing.T) {
 }
 
 func TestPreviousArchive_ArchiveNotFound_Returns404(t *testing.T) {
-	h := NewHandler()
+	h := NewHandler(wstate.New())
 	sc := &streamctx.SessionContext{
 		PreviousBackup: &previous.Snapshot{Path: t.TempDir(), Time: time.Now()},
 	}
@@ -94,7 +96,7 @@ func TestPreviousArchive_StreamsFile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "drive-0.img.fidx"), content, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	h := NewHandler()
+	h := NewHandler(wstate.New())
 	sc := &streamctx.SessionContext{
 		PreviousBackup: &previous.Snapshot{Path: dir, Time: time.Now()},
 	}
@@ -108,5 +110,152 @@ func TestPreviousArchive_StreamsFile(t *testing.T) {
 	}
 	if ct := w.Header().Get("Content-Type"); ct != "application/octet-stream" {
 		t.Errorf("Content-Type: got %q, want application/octet-stream", ct)
+	}
+}
+
+// buildTestDidx creates a .didx file in dir with the given (digest, size) pairs.
+// end-offsets are cumulative sums of sizes (PBS convention).
+func buildTestDidx(t *testing.T, dir, name string, chunks []struct {
+	digest [32]byte
+	size   uint64
+}) string {
+	t.Helper()
+	finalPath := filepath.Join(dir, name)
+	w, err := didx.Create(finalPath)
+	if err != nil {
+		t.Fatalf("didx.Create: %v", err)
+	}
+	var offset uint64
+	for _, c := range chunks {
+		offset += c.size
+		if err := w.AddChunk(offset, c.digest); err != nil {
+			w.Drop()
+			t.Fatalf("AddChunk: %v", err)
+		}
+	}
+	if _, err := w.Close(); err != nil {
+		t.Fatalf("didx.Close: %v", err)
+	}
+	return finalPath
+}
+
+func TestServeHTTP_DidxRegistersChunks(t *testing.T) {
+	dir := t.TempDir()
+
+	var d1, d2 [32]byte
+	d1[0] = 0x01
+	d2[0] = 0x02
+
+	buildTestDidx(t, dir, "root.pxar.didx", []struct {
+		digest [32]byte
+		size   uint64
+	}{
+		{d1, 1000},
+		{d2, 2000},
+	})
+
+	ws := wstate.New()
+	h := NewHandler(ws)
+	sc := &streamctx.SessionContext{
+		SessionID:      "test",
+		PreviousBackup: &previous.Snapshot{Path: dir, Time: time.Now()},
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeRequest(http.MethodGet, "root.pxar.didx", sc))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify body is the full file content.
+	fileData, err := os.ReadFile(filepath.Join(dir, "root.pxar.didx"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(w.Body.Bytes(), fileData) {
+		t.Errorf("body does not match file on disk (len got=%d want=%d)", w.Body.Len(), len(fileData))
+	}
+
+	// Verify chunks registered with correct sizes.
+	size1, ok1 := ws.LookupChunk(d1)
+	if !ok1 || size1 != 1000 {
+		t.Errorf("d1: expected (1000, true), got (%d, %v)", size1, ok1)
+	}
+	size2, ok2 := ws.LookupChunk(d2)
+	if !ok2 || size2 != 2000 {
+		t.Errorf("d2: expected (2000, true), got (%d, %v)", size2, ok2)
+	}
+}
+
+func TestServeHTTP_FidxDoesNotRegister(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("fidx body bytes — not parsed")
+	if err := os.WriteFile(filepath.Join(dir, "drive-0.img.fidx"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws := wstate.New()
+	h := NewHandler(ws)
+	sc := &streamctx.SessionContext{
+		SessionID:      "test",
+		PreviousBackup: &previous.Snapshot{Path: dir, Time: time.Now()},
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeRequest(http.MethodGet, "drive-0.img.fidx", sc))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	// Body streamed unchanged.
+	if !bytes.Equal(w.Body.Bytes(), content) {
+		t.Errorf("body mismatch")
+	}
+
+	// No chunks should have been registered.
+	var anyDigest [32]byte
+	_, ok := ws.LookupChunk(anyDigest)
+	if ok {
+		t.Errorf("expected no chunks registered for .fidx, but found one")
+	}
+}
+
+func TestServeHTTP_DidxParseError(t *testing.T) {
+	dir := t.TempDir()
+	// Write a corrupt .didx: 100 bytes of garbage (less than the 4096-byte header).
+	garbage := make([]byte, 100)
+	for i := range garbage {
+		garbage[i] = 0xFF
+	}
+	if err := os.WriteFile(filepath.Join(dir, "corrupt.didx"), garbage, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws := wstate.New()
+	h := NewHandler(ws)
+	sc := &streamctx.SessionContext{
+		SessionID:      "test",
+		PreviousBackup: &previous.Snapshot{Path: dir, Time: time.Now()},
+	}
+	w := httptest.NewRecorder()
+
+	r := httptest.NewRequest(http.MethodGet, "/previous?archive-name=corrupt.didx", nil)
+	r = r.WithContext(streamctx.WithSession(r.Context(), sc))
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+
+	// No chunks should have been registered.
+	var anyDigest [32]byte
+	_, ok := ws.LookupChunk(anyDigest)
+	if ok {
+		t.Errorf("expected no chunks registered on parse error, but found one")
+	}
+
+	// Verify body is not the file content (it's the JSON error).
+	if bytes.Contains(w.Body.Bytes(), garbage) {
+		t.Errorf("corrupt file content leaked into error response")
 	}
 }


### PR DESCRIPTION
## Problem

PVE incremental backup of CT 202 failed with:

```
chunk <digest> not uploaded in this session
```

**Root cause**: `proxmox-backup-client` calls `GET /previous?archive-name=root.pxar.didx`, downloads the index, and uses those digests to populate its **client-side** `known_chunks` set (`pbs-client/src/backup_writer.rs:713-715`). It then sends `(digest, offset)` to `/dynamic_index` for those chunks **without ever calling `/dynamic_chunk`** — they're already in the datastore from the previous run.

Real PBS registers those chunks into the session's known_chunks map when the previous index is downloaded (`src/api2/backup/environment.rs:309`). Our `previousarchive` handler was streaming the file but never registering anything.

## Fix

Before streaming the `.didx` body, parse the header + entries and call `wstate.RegisterKnownChunk(digest, size)` for each entry. Per-chunk size = `end[i] - end[i-1]` (cumulative end-offsets, PBS convention). After parsing, `f.Seek(0, io.SeekStart)` rewinds so the client receives the full file unchanged.

`.fidx` and `.blob` paths are unaffected — only the `.didx` branch gets the new logic.

The handler struct gains a `state *wstate.State` field used as a fallback in tests (where `sc.WriterState` is nil). Production sessions carry their per-session state in `sc.WriterState` which takes precedence.

## Test plan

- [ ] `TestServeHTTP_DidxRegistersChunks` — builds a real 2-entry `.didx`, verifies 200 + full body streamed + both chunks registered with correct sizes
- [ ] `TestServeHTTP_FidxDoesNotRegister` — `.fidx` body streamed unchanged, no chunks registered
- [ ] `TestServeHTTP_DidxParseError` — 100-byte garbage `.didx` → 500, no chunks registered
- [ ] All existing tests updated to `NewHandler(wstate.New())` — all assertions unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)