### PR TITLE
fix(pbs): insert pbs_snapshots row on POST /finish

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -112,7 +112,7 @@ func main() {
 		datastoreLookup,
 		sessionStore,
 		blob.NewHandler(),
-		finish.NewHandler(sessionStore),
+		finish.NewHandler(sessionStore, database),
 		fixedindex.NewHandler(),
 		fixedchunk.NewHandler(),
 		fixedappend.NewHandler(),

--- a/services/backupos-pbs/internal/finish/finish.go
+++ b/services/backupos-pbs/internal/finish/finish.go
@@ -11,12 +11,16 @@
 package finish
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snapshot"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
@@ -25,11 +29,12 @@ import (
 // Handler implements POST /finish.
 type Handler struct {
 	sessions *session.Store
+	db       *sql.DB
 }
 
 // NewHandler constructs a finish handler.
-func NewHandler(sessions *session.Store) *Handler {
-	return &Handler{sessions: sessions}
+func NewHandler(sessions *session.Store, db *sql.DB) *Handler {
+	return &Handler{sessions: sessions, db: db}
 }
 
 // ServeHTTP routes POST /finish → mark session finished, fsync snapshot dir, 200.
@@ -67,6 +72,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Insert / upsert the pbs_snapshots row. This is best-effort: if the
+	// DB write fails the files are still on disk and can be re-indexed later.
+	h.insertSnapshot(sc)
+
 	// Best-effort durability: fsync the snapshot directory.
 	snapDir, pathErr := snapshot.Path(sc.DatastoreRoot, sc.Namespace, sc.BackupType, sc.BackupID, sc.BackupTime)
 	if pathErr != nil {
@@ -96,6 +105,78 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(`{"data":null}`))
+}
+
+// insertSnapshot upserts a pbs_snapshots row for the completed backup.
+// Errors are logged but do not affect the HTTP response — disk is the
+// source of truth and the row can be re-inserted later.
+func (h *Handler) insertSnapshot(sc *streamctx.SessionContext) {
+	snapshotID := buildSnapshotID(sc.DatastoreID, sc.Namespace, sc.BackupType, sc.BackupID, sc.BackupTime)
+	namespaceID := h.resolveNamespaceID(sc.DatastoreID, sc.Namespace)
+
+	// Future: decode index.json.blob (magic + zstd) and store the JSON.
+	// For now leave NULL; the snapshot row is what /notes and listing need.
+	var manifest sql.NullString
+
+	const insert = `
+		INSERT INTO pbs_snapshots
+			(id, datastore_id, namespace_id, backup_type, backup_id, backup_time,
+			 finished_at, manifest, total_size_bytes, unique_size_bytes, protected, notes)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)
+		ON CONFLICT(id) DO UPDATE SET
+			finished_at = excluded.finished_at,
+			manifest = excluded.manifest,
+			total_size_bytes = excluded.total_size_bytes,
+			unique_size_bytes = excluded.unique_size_bytes
+	`
+	_, err := h.db.Exec(insert,
+		snapshotID, sc.DatastoreID, namespaceID,
+		sc.BackupType, sc.BackupID, sc.BackupTime.UnixMilli(),
+		time.Now().UnixMilli(), manifest,
+		nil, nil, // total_size_bytes, unique_size_bytes — TODO when stats land
+	)
+	if err != nil {
+		slog.Error("finish: pbs_snapshots insert failed (snapshot still on disk)",
+			"error", err,
+			"session_id", sc.SessionID,
+			"snapshot_id", snapshotID,
+		)
+		return
+	}
+	slog.Info("snapshot row inserted",
+		"snapshot_id", snapshotID,
+		"session_id", sc.SessionID,
+	)
+}
+
+// buildSnapshotID constructs a deterministic primary key for a snapshot.
+// Format: <datastoreID>:<namespace>:<backupType>/<backupID>/<iso8601>
+// Matches the on-disk directory name format for easy cross-reference.
+func buildSnapshotID(datastoreID string, ns namespace.Namespace, backupType, backupID string, t time.Time) string {
+	nsPart := ""
+	if !ns.IsRoot() {
+		nsPart = ns.String()
+	}
+	return fmt.Sprintf("%s:%s:%s/%s/%s",
+		datastoreID, nsPart, backupType, backupID,
+		t.UTC().Format("2006-01-02T15:04:05Z"))
+}
+
+// resolveNamespaceID returns the row id of the matching namespace, or NULL
+// if root namespace, missing, or on lookup error.
+func (h *Handler) resolveNamespaceID(datastoreID string, ns namespace.Namespace) sql.NullString {
+	if ns.IsRoot() {
+		return sql.NullString{}
+	}
+	const q = `SELECT id FROM pbs_namespaces WHERE datastore_id = ? AND name = ? LIMIT 1`
+	var id string
+	err := h.db.QueryRow(q, datastoreID, ns.String()).Scan(&id)
+	if err != nil {
+		slog.Warn("finish: namespace lookup failed; inserting NULL",
+			"error", err, "datastore_id", datastoreID, "namespace", ns.String())
+		return sql.NullString{}
+	}
+	return sql.NullString{String: id, Valid: true}
 }
 
 // fsyncDir fsyncs a directory inode for durability of recent renames.

--- a/services/backupos-pbs/internal/finish/finish_test.go
+++ b/services/backupos-pbs/internal/finish/finish_test.go
@@ -12,6 +12,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/streamctx"
 )
@@ -44,6 +45,49 @@ func setupTestStore(t *testing.T) (*sql.DB, *session.Store) {
 	return db, session.NewStore(db)
 }
 
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`
+		CREATE TABLE pbs_snapshots (
+			id TEXT PRIMARY KEY,
+			datastore_id TEXT,
+			namespace_id TEXT,
+			backup_type TEXT,
+			backup_id TEXT,
+			backup_time INTEGER,
+			finished_at INTEGER,
+			manifest TEXT,
+			total_size_bytes INTEGER,
+			unique_size_bytes INTEGER,
+			protected INTEGER DEFAULT 0,
+			notes TEXT
+		);
+		CREATE TABLE pbs_namespaces (
+			id TEXT PRIMARY KEY,
+			datastore_id TEXT,
+			name TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// setupFull returns a session DB, a snapshot DB, and a session store.
+// Used by tests that need both DB handles.
+func setupFull(t *testing.T) (*sql.DB, *sql.DB, *session.Store) {
+	t.Helper()
+	sessDB, store := setupTestStore(t)
+	snapDB := openTestDB(t)
+	return sessDB, snapDB, store
+}
+
 func makeReq(t *testing.T, sc *streamctx.SessionContext) *http.Request {
 	t.Helper()
 	r := httptest.NewRequest(http.MethodPost, "/finish", nil)
@@ -55,8 +99,8 @@ func makeReq(t *testing.T, sc *streamctx.SessionContext) *http.Request {
 
 func TestHandler_HappyPath(t *testing.T) {
 	tmp := t.TempDir()
-	db, store := setupTestStore(t)
-	h := NewHandler(store)
+	sessDB, snapDB, store := setupFull(t)
+	h := NewHandler(store, snapDB)
 
 	id, err := store.Begin(session.BeginParams{
 		TokenID: "tok-1", DatastoreID: "ds-1",
@@ -87,7 +131,7 @@ func TestHandler_HappyPath(t *testing.T) {
 	}
 
 	var gotState string
-	_ = db.QueryRow(`SELECT state FROM pbs_active_sessions WHERE id = ?`, id).Scan(&gotState)
+	_ = sessDB.QueryRow(`SELECT state FROM pbs_active_sessions WHERE id = ?`, id).Scan(&gotState)
 	if gotState != "finished" {
 		t.Errorf("state: got %q, want finished", gotState)
 	}
@@ -95,7 +139,7 @@ func TestHandler_HappyPath(t *testing.T) {
 
 func TestHandler_GETReturns405(t *testing.T) {
 	_, store := setupTestStore(t)
-	h := NewHandler(store)
+	h := NewHandler(store, openTestDB(t))
 	r := httptest.NewRequest(http.MethodGet, "/finish", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, r)
@@ -106,7 +150,7 @@ func TestHandler_GETReturns405(t *testing.T) {
 
 func TestHandler_MissingStreamCtx(t *testing.T) {
 	_, store := setupTestStore(t)
-	h := NewHandler(store)
+	h := NewHandler(store, openTestDB(t))
 	r := httptest.NewRequest(http.MethodPost, "/finish", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, r)
@@ -117,8 +161,8 @@ func TestHandler_MissingStreamCtx(t *testing.T) {
 
 func TestHandler_DoubleFinishRejected(t *testing.T) {
 	tmp := t.TempDir()
-	_, store := setupTestStore(t)
-	h := NewHandler(store)
+	_, snapDB, store := setupFull(t)
+	h := NewHandler(store, snapDB)
 
 	id, _ := store.Begin(session.BeginParams{
 		TokenID: "tok-1", DatastoreID: "ds-1",
@@ -148,8 +192,8 @@ func TestHandler_DoubleFinishRejected(t *testing.T) {
 
 func TestHandler_FinishOnAbortedSessionRejected(t *testing.T) {
 	tmp := t.TempDir()
-	_, store := setupTestStore(t)
-	h := NewHandler(store)
+	_, snapDB, store := setupFull(t)
+	h := NewHandler(store, snapDB)
 
 	id, _ := store.Begin(session.BeginParams{
 		TokenID: "tok-1", DatastoreID: "ds-1",
@@ -173,8 +217,8 @@ func TestHandler_FinishOnAbortedSessionRejected(t *testing.T) {
 
 func TestHandler_NoSnapshotDirIsOK(t *testing.T) {
 	tmp := t.TempDir()
-	_, store := setupTestStore(t)
-	h := NewHandler(store)
+	_, snapDB, store := setupFull(t)
+	h := NewHandler(store, snapDB)
 
 	id, _ := store.Begin(session.BeginParams{
 		TokenID: "tok-1", DatastoreID: "ds-1",
@@ -190,5 +234,199 @@ func TestHandler_NoSnapshotDirIsOK(t *testing.T) {
 	h.ServeHTTP(w, makeReq(t, sc))
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200 even without snapshot dir, got %d. Body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestFinish_InsertsPbsSnapshotsRow(t *testing.T) {
+	tmp := t.TempDir()
+	_, snapDB, store := setupFull(t)
+	h := NewHandler(store, snapDB)
+
+	backupTime := time.Unix(1735000000, 0)
+	id, err := store.Begin(session.BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: backupTime, Kind: session.KindBackup,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sc := &streamctx.SessionContext{
+		SessionID: id, DatastoreID: "ds-1", DatastoreRoot: tmp,
+		BackupType: "vm", BackupID: "100", BackupTime: backupTime,
+	}
+	before := time.Now().UnixMilli()
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeReq(t, sc))
+	after := time.Now().UnixMilli()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var (
+		gotDatastoreID string
+		gotBackupType  string
+		gotBackupID    string
+		gotBackupTime  int64
+		gotFinishedAt  int64
+		gotNotes       sql.NullString
+		gotProtected   int
+	)
+	err = snapDB.QueryRow(`
+		SELECT datastore_id, backup_type, backup_id, backup_time, finished_at, notes, protected
+		FROM pbs_snapshots
+		WHERE datastore_id = 'ds-1'
+	`).Scan(&gotDatastoreID, &gotBackupType, &gotBackupID, &gotBackupTime, &gotFinishedAt, &gotNotes, &gotProtected)
+	if err != nil {
+		t.Fatalf("pbs_snapshots query: %v", err)
+	}
+
+	if gotDatastoreID != "ds-1" {
+		t.Errorf("datastore_id: got %q", gotDatastoreID)
+	}
+	if gotBackupType != "vm" {
+		t.Errorf("backup_type: got %q", gotBackupType)
+	}
+	if gotBackupID != "100" {
+		t.Errorf("backup_id: got %q", gotBackupID)
+	}
+	if gotBackupTime != backupTime.UnixMilli() {
+		t.Errorf("backup_time: got %d, want %d", gotBackupTime, backupTime.UnixMilli())
+	}
+	if gotFinishedAt < before || gotFinishedAt > after {
+		t.Errorf("finished_at %d not in [%d, %d]", gotFinishedAt, before, after)
+	}
+	if gotNotes.Valid {
+		t.Errorf("notes should be NULL")
+	}
+	if gotProtected != 0 {
+		t.Errorf("protected should be 0, got %d", gotProtected)
+	}
+}
+
+func TestFinish_DuplicateInsertIsIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+	_, snapDB, store := setupFull(t)
+	h := NewHandler(store, snapDB)
+
+	backupTime := time.Unix(1735000000, 0)
+	snapshotID := buildSnapshotID("ds-1", namespace.Root(), "vm", "100", backupTime)
+
+	// Pre-insert a row with the same id and an old finished_at.
+	_, err := snapDB.Exec(`
+		INSERT INTO pbs_snapshots (id, datastore_id, backup_type, backup_id, backup_time, finished_at, protected)
+		VALUES (?, 'ds-1', 'vm', '100', ?, 1000, 0)
+	`, snapshotID, backupTime.UnixMilli())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id, _ := store.Begin(session.BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: backupTime, Kind: session.KindBackup,
+	})
+	sc := &streamctx.SessionContext{
+		SessionID: id, DatastoreID: "ds-1", DatastoreRoot: tmp,
+		BackupType: "vm", BackupID: "100", BackupTime: backupTime,
+	}
+
+	before := time.Now().UnixMilli()
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeReq(t, sc))
+	after := time.Now().UnixMilli()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var count int
+	_ = snapDB.QueryRow(`SELECT COUNT(*) FROM pbs_snapshots`).Scan(&count)
+	if count != 1 {
+		t.Errorf("expected 1 row, got %d", count)
+	}
+
+	// finished_at should have been updated from 1000 to now.
+	var finishedAt int64
+	_ = snapDB.QueryRow(`SELECT finished_at FROM pbs_snapshots WHERE id = ?`, snapshotID).Scan(&finishedAt)
+	if finishedAt < before || finishedAt > after {
+		t.Errorf("finished_at not updated: got %d, want in [%d, %d]", finishedAt, before, after)
+	}
+}
+
+func TestFinish_DBInsertFailureStillReturns200(t *testing.T) {
+	tmp := t.TempDir()
+	_, snapDB, store := setupFull(t)
+
+	// Drop the snapshots table so the insert will fail.
+	if _, err := snapDB.Exec(`DROP TABLE pbs_snapshots`); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewHandler(store, snapDB)
+
+	id, _ := store.Begin(session.BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: time.Unix(1735000000, 0), Kind: session.KindBackup,
+	})
+	sc := &streamctx.SessionContext{
+		SessionID: id, DatastoreID: "ds-1", DatastoreRoot: tmp,
+		BackupType: "vm", BackupID: "100", BackupTime: time.Unix(1735000000, 0),
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeReq(t, sc))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 even on DB failure, got %d", w.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if v, ok := resp["data"]; !ok || v != nil {
+		t.Errorf(`expected {"data":null}, got %v`, resp)
+	}
+}
+
+func TestFinish_NamespaceLookupReturnsNullOnMiss(t *testing.T) {
+	tmp := t.TempDir()
+	_, snapDB, store := setupFull(t)
+	h := NewHandler(store, snapDB)
+
+	backupTime := time.Unix(1735000000, 0)
+	ns, err := namespace.Parse("tenant-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id, _ := store.Begin(session.BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "ct", BackupID: "200",
+		BackupTime: backupTime, Kind: session.KindBackup,
+		Namespace: ns.String(),
+	})
+	sc := &streamctx.SessionContext{
+		SessionID: id, DatastoreID: "ds-1", DatastoreRoot: tmp,
+		BackupType: "ct", BackupID: "200", BackupTime: backupTime,
+		Namespace: ns,
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeReq(t, sc))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var namespaceID sql.NullString
+	err = snapDB.QueryRow(`SELECT namespace_id FROM pbs_snapshots WHERE backup_type = 'ct'`).Scan(&namespaceID)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if namespaceID.Valid {
+		t.Errorf("expected namespace_id to be NULL when namespace row missing, got %q", namespaceID.String)
 	}
 }


### PR DESCRIPTION
## Problem

`SELECT COUNT(*) FROM pbs_snapshots` returns 0 after every backup. `finish.Handler` marks the session as 'finished' and fsyncs the snapshot directory but never inserts a database row.

Observed consequences:
- `PUT /notes` returns **"snapshot not found in database"** — the row doesn't exist
- Web UI snapshot listings see nothing
- Future GC / verify / prune code paths can't enumerate snapshots via DB

## Fix

After `sessions.Finish` succeeds, insert (or upsert via `ON CONFLICT(id) DO UPDATE`) a `pbs_snapshots` row. The row captures the core snapshot identity tuple; `manifest`, `total_size_bytes`, and `unique_size_bytes` are NULL for now with TODO comments.

- `backup_time` and `finished_at` stored as **milliseconds** (`.UnixMilli()`)
- `namespace_id` resolved by `(datastore_id, name)` lookup against `pbs_namespaces`; NULL on root namespace or lookup miss
- Snapshot `id` is deterministic: `<datastoreID>:<ns>:<type>/<id>/<iso8601>`
- **DB insert failure does NOT fail `/finish`** — logged at ERROR, client still gets 200. Disk is the source of truth.

## Test plan

- [ ] `TestFinish_InsertsPbsSnapshotsRow` — full flow, verifies row exists with correct tuple + `finished_at` within last 5s, `notes` NULL, `protected` 0
- [ ] `TestFinish_DuplicateInsertIsIdempotent` — pre-insert row with old `finished_at`, run /finish, verify count=1 and `finished_at` updated
- [ ] `TestFinish_DBInsertFailureStillReturns200` — drop `pbs_snapshots` table, run /finish, assert 200 + `{"data":null}`
- [ ] `TestFinish_NamespaceLookupReturnsNullOnMiss` — non-root namespace, no row in `pbs_namespaces`, assert inserted row has `namespace_id = NULL`
- [ ] All existing tests updated to `NewHandler(store, snapDB)` — all assertions unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)