### PR TITLE
feat(pbs): synthesize backup_jobs and backup_runs for PBS sessions

### DIFF
--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -111,6 +111,7 @@ func main() {
 	upgradeHandler := upgrade.NewHandler(
 		datastoreLookup,
 		sessionStore,
+		database,
 		blob.NewHandler(),
 		finish.NewHandler(sessionStore, database),
 		fixedindex.NewHandler(),

--- a/services/backupos-pbs/internal/finish/finish.go
+++ b/services/backupos-pbs/internal/finish/finish.go
@@ -80,7 +80,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Finalize the synthetic run row if one was created at upgrade time.
 	if sc.RunID != "" {
 		snapshotID := buildSnapshotID(sc.DatastoreID, sc.Namespace, sc.BackupType, sc.BackupID, sc.BackupTime)
-		if err := jobsync.FinishRun(h.db, sc.RunID, sc.JobID, "ok",
+		if err := jobsync.FinishRun(h.db, sc.RunID, sc.JobID, "success",
 			&snapshotID, nil, sc.SessionStartedAt, time.Now()); err != nil {
 			slog.Error("finish: FinishRun failed (backup still saved)",
 				"error", err, "run_id", sc.RunID)

--- a/services/backupos-pbs/internal/finish/finish.go
+++ b/services/backupos-pbs/internal/finish/finish.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/jobsync"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/session"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/snapshot"
@@ -75,6 +76,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Insert / upsert the pbs_snapshots row. This is best-effort: if the
 	// DB write fails the files are still on disk and can be re-indexed later.
 	h.insertSnapshot(sc)
+
+	// Finalize the synthetic run row if one was created at upgrade time.
+	if sc.RunID != "" {
+		snapshotID := buildSnapshotID(sc.DatastoreID, sc.Namespace, sc.BackupType, sc.BackupID, sc.BackupTime)
+		if err := jobsync.FinishRun(h.db, sc.RunID, sc.JobID, "ok",
+			&snapshotID, nil, sc.SessionStartedAt, time.Now()); err != nil {
+			slog.Error("finish: FinishRun failed (backup still saved)",
+				"error", err, "run_id", sc.RunID)
+		}
+	}
 
 	// Best-effort durability: fsync the snapshot directory.
 	snapDir, pathErr := snapshot.Path(sc.DatastoreRoot, sc.Namespace, sc.BackupType, sc.BackupID, sc.BackupTime)

--- a/services/backupos-pbs/internal/finish/finish_test.go
+++ b/services/backupos-pbs/internal/finish/finish_test.go
@@ -449,14 +449,14 @@ func TestFinish_FinalizesSyntheticRun(t *testing.T) {
 
 	var runStatus string
 	_ = snapDB.QueryRow(`SELECT status FROM backup_runs WHERE id = ?`, runID).Scan(&runStatus)
-	if runStatus != "ok" {
-		t.Errorf("run status: got %q, want 'ok'", runStatus)
+	if runStatus != "success" {
+		t.Errorf("run status: got %q, want 'success'", runStatus)
 	}
 
 	var lastRunStatus string
 	_ = snapDB.QueryRow(`SELECT last_run_status FROM backup_jobs WHERE id = ?`, jobID).Scan(&lastRunStatus)
-	if lastRunStatus != "ok" {
-		t.Errorf("job last_run_status: got %q, want 'ok'", lastRunStatus)
+	if lastRunStatus != "success" {
+		t.Errorf("job last_run_status: got %q, want 'success'", lastRunStatus)
 	}
 }
 

--- a/services/backupos-pbs/internal/finish/finish_test.go
+++ b/services/backupos-pbs/internal/finish/finish_test.go
@@ -71,6 +71,17 @@ func openTestDB(t *testing.T) *sql.DB {
 			datastore_id TEXT,
 			name TEXT
 		);
+		CREATE TABLE backup_jobs (
+			id TEXT PRIMARY KEY,
+			name TEXT, source_type TEXT, source_config TEXT,
+			schedule TEXT, enabled INTEGER, preflight_enabled INTEGER, created_at INTEGER,
+			last_run_at INTEGER, last_run_status TEXT
+		);
+		CREATE TABLE backup_runs (
+			id TEXT PRIMARY KEY, job_id TEXT, status TEXT, trigger TEXT,
+			started_at INTEGER, run_type TEXT,
+			completed_at INTEGER, duration INTEGER, snapshot_id TEXT, error_message TEXT
+		);
 	`)
 	if err != nil {
 		t.Fatal(err)
@@ -389,6 +400,63 @@ func TestFinish_DBInsertFailureStillReturns200(t *testing.T) {
 	}
 	if v, ok := resp["data"]; !ok || v != nil {
 		t.Errorf(`expected {"data":null}, got %v`, resp)
+	}
+}
+
+func TestFinish_FinalizesSyntheticRun(t *testing.T) {
+	tmp := t.TempDir()
+	_, snapDB, store := setupFull(t)
+	h := NewHandler(store, snapDB)
+
+	jobID := "pbs:ds-1::vm:100"
+	runID := "test-run-uuid"
+	startedAt := time.Unix(1735000000, 0)
+	backupTime := time.Unix(1735000100, 0)
+
+	if _, err := snapDB.Exec(
+		`INSERT INTO backup_jobs (id, name, source_type, source_config, schedule, enabled, preflight_enabled, created_at) VALUES (?, 'test', 'proxmox_vm', '{}', '', 0, 0, 1735000000000)`,
+		jobID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := snapDB.Exec(
+		`INSERT INTO backup_runs (id, job_id, status, trigger, started_at, run_type) VALUES (?, ?, 'running', 'api', 1735000000000, 'backup')`,
+		runID, jobID,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	id, err := store.Begin(session.BeginParams{
+		TokenID: "tok-1", DatastoreID: "ds-1",
+		BackupType: "vm", BackupID: "100",
+		BackupTime: backupTime, Kind: session.KindBackup,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sc := &streamctx.SessionContext{
+		SessionID: id, DatastoreID: "ds-1", DatastoreRoot: tmp,
+		BackupType: "vm", BackupID: "100", BackupTime: backupTime,
+		JobID: jobID, RunID: runID, SessionStartedAt: startedAt,
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, makeReq(t, sc))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var runStatus string
+	_ = snapDB.QueryRow(`SELECT status FROM backup_runs WHERE id = ?`, runID).Scan(&runStatus)
+	if runStatus != "ok" {
+		t.Errorf("run status: got %q, want 'ok'", runStatus)
+	}
+
+	var lastRunStatus string
+	_ = snapDB.QueryRow(`SELECT last_run_status FROM backup_jobs WHERE id = ?`, jobID).Scan(&lastRunStatus)
+	if lastRunStatus != "ok" {
+		t.Errorf("job last_run_status: got %q, want 'ok'", lastRunStatus)
 	}
 }
 

--- a/services/backupos-pbs/internal/jobsync/jobsync.go
+++ b/services/backupos-pbs/internal/jobsync/jobsync.go
@@ -1,0 +1,116 @@
+// Package jobsync synthesises backup_jobs and backup_runs rows for PBS sessions.
+//
+// PBS-protocol backups (PVE → backupos-pbs) don't go through the normal
+// backup-job scheduler, so they would be invisible in the web UI. This
+// package bridges that gap by creating a synthetic Job per unique backup tuple
+// and a Run per session. All operations are best-effort: callers log errors
+// but don't fail the backup on DB errors.
+package jobsync
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
+)
+
+// JobID returns the deterministic synthetic Job ID for a backup tuple.
+// Format: pbs:<datastoreID>:<namespace>:<backupType>:<backupID>
+// Root namespace produces an empty string between the two colons.
+func JobID(datastoreID string, ns namespace.Namespace, backupType, backupID string) string {
+	nsPart := ""
+	if !ns.IsRoot() {
+		nsPart = ns.String()
+	}
+	return fmt.Sprintf("pbs:%s:%s:%s:%s", datastoreID, nsPart, backupType, backupID)
+}
+
+// JobName returns the human-friendly display name.
+// Root namespace: "PVE: vm/100"
+// Non-root:       "PVE: tenant-a/vm/100"
+func JobName(ns namespace.Namespace, backupType, backupID string) string {
+	if ns.IsRoot() {
+		return fmt.Sprintf("PVE: %s/%s", backupType, backupID)
+	}
+	return fmt.Sprintf("PVE: %s/%s/%s", ns.String(), backupType, backupID)
+}
+
+// sourceTypeFor maps a PBS backup_type to the closest backup_jobs.source_type.
+func sourceTypeFor(backupType string) string {
+	if backupType == "vm" {
+		return "proxmox_vm"
+	}
+	return "proxmox_lxc"
+}
+
+// UpsertJob inserts the synthetic Job if it doesn't already exist.
+// On conflict the existing row is left unchanged (ON CONFLICT DO NOTHING).
+func UpsertJob(db *sql.DB, datastoreID string, ns namespace.Namespace, backupType, backupID string) error {
+	jobID := JobID(datastoreID, ns, backupType, backupID)
+	sourceConfig, _ := json.Marshal(map[string]string{
+		"datastore_id": datastoreID,
+		"namespace":    ns.String(),
+		"backup_id":    backupID,
+		"source":       "pbs_protocol",
+	})
+	const q = `
+		INSERT INTO backup_jobs
+			(id, name, source_type, source_config, schedule, enabled,
+			 preflight_enabled, created_at)
+		VALUES (?, ?, ?, ?, '', 0, 0, ?)
+		ON CONFLICT(id) DO NOTHING
+	`
+	_, err := db.Exec(q,
+		jobID, JobName(ns, backupType, backupID),
+		sourceTypeFor(backupType), string(sourceConfig),
+		time.Now().UnixMilli(),
+	)
+	return err
+}
+
+// InsertRunningRun inserts a backup_runs row in 'running' state and returns the new run ID.
+func InsertRunningRun(db *sql.DB, jobID string, startedAt time.Time) (string, error) {
+	runID := uuid.NewString()
+	const q = `
+		INSERT INTO backup_runs
+			(id, job_id, status, trigger, started_at, run_type)
+		VALUES (?, ?, 'running', 'api', ?, 'backup')
+	`
+	_, err := db.Exec(q, runID, jobID, startedAt.UnixMilli())
+	return runID, err
+}
+
+// FinishRun marks a run as completed (success or failed) and updates the parent Job.
+// snapshotID and errorMessage may be nil for the unused branch.
+func FinishRun(db *sql.DB, runID, jobID, status string, snapshotID, errorMessage *string, startedAt, completedAt time.Time) error {
+	durationSec := int64(completedAt.Sub(startedAt).Seconds())
+	const updateRun = `
+		UPDATE backup_runs
+		SET status = ?, completed_at = ?, duration = ?, snapshot_id = ?, error_message = ?
+		WHERE id = ?
+	`
+	if _, err := db.Exec(updateRun, status, completedAt.UnixMilli(), durationSec,
+		nullableString(snapshotID), nullableString(errorMessage), runID); err != nil {
+		return fmt.Errorf("update run: %w", err)
+	}
+	const updateJob = `
+		UPDATE backup_jobs
+		SET last_run_at = ?, last_run_status = ?
+		WHERE id = ?
+	`
+	if _, err := db.Exec(updateJob, completedAt.UnixMilli(), status, jobID); err != nil {
+		return fmt.Errorf("update job: %w", err)
+	}
+	return nil
+}
+
+func nullableString(s *string) sql.NullString {
+	if s == nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: *s, Valid: true}
+}

--- a/services/backupos-pbs/internal/jobsync/jobsync_test.go
+++ b/services/backupos-pbs/internal/jobsync/jobsync_test.go
@@ -159,7 +159,7 @@ func TestFinishRun_Success(t *testing.T) {
 
 	snapID := "snap-abc"
 	completedAt := time.Unix(1735000060, 0)
-	if err := FinishRun(db, runID, jobID, "ok", &snapID, nil, startedAt, completedAt); err != nil {
+	if err := FinishRun(db, runID, jobID, "success", &snapID, nil, startedAt, completedAt); err != nil {
 		t.Fatal(err)
 	}
 
@@ -167,7 +167,7 @@ func TestFinishRun_Success(t *testing.T) {
 	var snapshotID sql.NullString
 	_ = db.QueryRow(`SELECT status, snapshot_id FROM backup_runs WHERE id = ?`, runID).
 		Scan(&status, &snapshotID)
-	if status != "ok" {
+	if status != "success" {
 		t.Errorf("status: got %q", status)
 	}
 	if !snapshotID.Valid || snapshotID.String != "snap-abc" {
@@ -176,7 +176,7 @@ func TestFinishRun_Success(t *testing.T) {
 
 	var lastRunStatus string
 	_ = db.QueryRow(`SELECT last_run_status FROM backup_jobs WHERE id = ?`, jobID).Scan(&lastRunStatus)
-	if lastRunStatus != "ok" {
+	if lastRunStatus != "success" {
 		t.Errorf("last_run_status: got %q", lastRunStatus)
 	}
 }
@@ -218,7 +218,7 @@ func TestFinishRun_DurationCalculation(t *testing.T) {
 	completedAt := startedAt.Add(90 * time.Second)
 	runID, _ := InsertRunningRun(db, jobID, startedAt)
 
-	if err := FinishRun(db, runID, jobID, "ok", nil, nil, startedAt, completedAt); err != nil {
+	if err := FinishRun(db, runID, jobID, "success", nil, nil, startedAt, completedAt); err != nil {
 		t.Fatal(err)
 	}
 

--- a/services/backupos-pbs/internal/jobsync/jobsync_test.go
+++ b/services/backupos-pbs/internal/jobsync/jobsync_test.go
@@ -1,0 +1,230 @@
+package jobsync
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
+)
+
+func openDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE backup_jobs (
+			id TEXT PRIMARY KEY,
+			name TEXT, source_type TEXT, source_config TEXT,
+			schedule TEXT, enabled INTEGER, preflight_enabled INTEGER, created_at INTEGER,
+			last_run_at INTEGER, last_run_status TEXT
+		);
+		CREATE TABLE backup_runs (
+			id TEXT PRIMARY KEY, job_id TEXT, status TEXT, trigger TEXT,
+			started_at INTEGER, run_type TEXT,
+			completed_at INTEGER, duration INTEGER, snapshot_id TEXT, error_message TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestJobID_RootNamespace(t *testing.T) {
+	got := JobID("ds-1", namespace.Root(), "vm", "100")
+	want := "pbs:ds-1::vm:100"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestJobID_NonRootNamespace(t *testing.T) {
+	ns, err := namespace.Parse("tenant-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := JobID("ds-1", ns, "vm", "100")
+	want := "pbs:ds-1:tenant-a:vm:100"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestJobName_RootVsNonRoot(t *testing.T) {
+	if got := JobName(namespace.Root(), "vm", "100"); got != "PVE: vm/100" {
+		t.Errorf("root: got %q", got)
+	}
+	ns, _ := namespace.Parse("tenant-a")
+	if got := JobName(ns, "vm", "100"); got != "PVE: tenant-a/vm/100" {
+		t.Errorf("non-root: got %q", got)
+	}
+}
+
+func TestUpsertJob_InsertsRow(t *testing.T) {
+	db := openDB(t)
+	if err := UpsertJob(db, "ds-1", namespace.Root(), "vm", "100"); err != nil {
+		t.Fatal(err)
+	}
+
+	var id, name, sourceType string
+	err := db.QueryRow(`SELECT id, name, source_type FROM backup_jobs WHERE id = ?`, "pbs:ds-1::vm:100").
+		Scan(&id, &name, &sourceType)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if id != "pbs:ds-1::vm:100" {
+		t.Errorf("id: got %q", id)
+	}
+	if name != "PVE: vm/100" {
+		t.Errorf("name: got %q", name)
+	}
+	if sourceType != "proxmox_vm" {
+		t.Errorf("source_type: got %q", sourceType)
+	}
+}
+
+func TestUpsertJob_DoesNotUpdateExisting(t *testing.T) {
+	db := openDB(t)
+
+	if err := UpsertJob(db, "ds-1", namespace.Root(), "vm", "100"); err != nil {
+		t.Fatal(err)
+	}
+	// Manually tweak the row to verify it's left unchanged.
+	if _, err := db.Exec(`UPDATE backup_jobs SET name = 'custom' WHERE id = ?`, "pbs:ds-1::vm:100"); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpsertJob(db, "ds-1", namespace.Root(), "vm", "100"); err != nil {
+		t.Fatal(err)
+	}
+
+	var name string
+	_ = db.QueryRow(`SELECT name FROM backup_jobs WHERE id = ?`, "pbs:ds-1::vm:100").Scan(&name)
+	if name != "custom" {
+		t.Errorf("expected row unchanged (name='custom'), got %q", name)
+	}
+}
+
+func TestInsertRunningRun_InsertsRow(t *testing.T) {
+	db := openDB(t)
+	if err := UpsertJob(db, "ds-1", namespace.Root(), "vm", "100"); err != nil {
+		t.Fatal(err)
+	}
+
+	jobID := JobID("ds-1", namespace.Root(), "vm", "100")
+	startedAt := time.Unix(1735000000, 0)
+	runID, err := InsertRunningRun(db, jobID, startedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runID == "" {
+		t.Fatal("expected non-empty runID")
+	}
+
+	var status, trigger, runType string
+	var gotStartedAt int64
+	err = db.QueryRow(`SELECT status, trigger, started_at, run_type FROM backup_runs WHERE id = ?`, runID).
+		Scan(&status, &trigger, &gotStartedAt, &runType)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if status != "running" {
+		t.Errorf("status: got %q", status)
+	}
+	if trigger != "api" {
+		t.Errorf("trigger: got %q", trigger)
+	}
+	if runType != "backup" {
+		t.Errorf("run_type: got %q", runType)
+	}
+	if gotStartedAt != startedAt.UnixMilli() {
+		t.Errorf("started_at: got %d, want %d", gotStartedAt, startedAt.UnixMilli())
+	}
+}
+
+func TestFinishRun_Success(t *testing.T) {
+	db := openDB(t)
+	jobID := JobID("ds-1", namespace.Root(), "vm", "100")
+	if err := UpsertJob(db, "ds-1", namespace.Root(), "vm", "100"); err != nil {
+		t.Fatal(err)
+	}
+	startedAt := time.Unix(1735000000, 0)
+	runID, _ := InsertRunningRun(db, jobID, startedAt)
+
+	snapID := "snap-abc"
+	completedAt := time.Unix(1735000060, 0)
+	if err := FinishRun(db, runID, jobID, "ok", &snapID, nil, startedAt, completedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	var status string
+	var snapshotID sql.NullString
+	_ = db.QueryRow(`SELECT status, snapshot_id FROM backup_runs WHERE id = ?`, runID).
+		Scan(&status, &snapshotID)
+	if status != "ok" {
+		t.Errorf("status: got %q", status)
+	}
+	if !snapshotID.Valid || snapshotID.String != "snap-abc" {
+		t.Errorf("snapshot_id: got %v", snapshotID)
+	}
+
+	var lastRunStatus string
+	_ = db.QueryRow(`SELECT last_run_status FROM backup_jobs WHERE id = ?`, jobID).Scan(&lastRunStatus)
+	if lastRunStatus != "ok" {
+		t.Errorf("last_run_status: got %q", lastRunStatus)
+	}
+}
+
+func TestFinishRun_Failed(t *testing.T) {
+	db := openDB(t)
+	jobID := JobID("ds-1", namespace.Root(), "vm", "100")
+	if err := UpsertJob(db, "ds-1", namespace.Root(), "vm", "100"); err != nil {
+		t.Fatal(err)
+	}
+	startedAt := time.Unix(1735000000, 0)
+	runID, _ := InsertRunningRun(db, jobID, startedAt)
+
+	errMsg := "connection closed without /finish"
+	completedAt := time.Unix(1735000030, 0)
+	if err := FinishRun(db, runID, jobID, "failed", nil, &errMsg, startedAt, completedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	var status string
+	var errorMessage sql.NullString
+	_ = db.QueryRow(`SELECT status, error_message FROM backup_runs WHERE id = ?`, runID).
+		Scan(&status, &errorMessage)
+	if status != "failed" {
+		t.Errorf("status: got %q", status)
+	}
+	if !errorMessage.Valid || errorMessage.String != errMsg {
+		t.Errorf("error_message: got %v", errorMessage)
+	}
+}
+
+func TestFinishRun_DurationCalculation(t *testing.T) {
+	db := openDB(t)
+	jobID := JobID("ds-1", namespace.Root(), "vm", "100")
+	if err := UpsertJob(db, "ds-1", namespace.Root(), "vm", "100"); err != nil {
+		t.Fatal(err)
+	}
+	startedAt := time.Unix(1735000000, 0)
+	completedAt := startedAt.Add(90 * time.Second)
+	runID, _ := InsertRunningRun(db, jobID, startedAt)
+
+	if err := FinishRun(db, runID, jobID, "ok", nil, nil, startedAt, completedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	var duration int64
+	_ = db.QueryRow(`SELECT duration FROM backup_runs WHERE id = ?`, runID).Scan(&duration)
+	if duration != 90 {
+		t.Errorf("duration: got %d, want 90", duration)
+	}
+}

--- a/services/backupos-pbs/internal/streamctx/streamctx.go
+++ b/services/backupos-pbs/internal/streamctx/streamctx.go
@@ -34,6 +34,10 @@ type SessionContext struct {
 	WriterState    *wstate.State      // per-session writer state (fixed/dynamic index maps); nil for reader sessions
 	ReaderState    *rstate.State      // per-session reader state (allowed_chunks set); nil for backup sessions
 	PreviousBackup *previous.Snapshot // most recent prior snapshot for this group, nil if none
+	// Synthetic job/run IDs for the web UI. Empty string means no row was inserted.
+	JobID            string
+	RunID            string
+	SessionStartedAt time.Time
 }
 
 type ctxKey struct{}

--- a/services/backupos-pbs/internal/upgrade/handler.go
+++ b/services/backupos-pbs/internal/upgrade/handler.go
@@ -2,17 +2,20 @@ package upgrade
 
 import (
 	"bufio"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"golang.org/x/net/http2"
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/jobsync"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/owner"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/previous"
@@ -42,6 +45,7 @@ const UpgradeToken = "proxmox-backup-protocol-v1"
 type Handler struct {
 	datastores          *datastore.Lookup
 	sessions            *session.Store
+	db                  *sql.DB
 	blobHandler         http.Handler
 	finishHandler       http.Handler
 	fixedIndexHandler   http.Handler
@@ -66,6 +70,7 @@ type Handler struct {
 func NewHandler(
 	datastores *datastore.Lookup,
 	sessions *session.Store,
+	db *sql.DB,
 	blobHandler http.Handler,
 	finishHandler http.Handler,
 	fixedIndexHandler http.Handler,
@@ -83,6 +88,7 @@ func NewHandler(
 	return &Handler{
 		datastores:             datastores,
 		sessions:               sessions,
+		db:                     db,
 		blobHandler:            blobHandler,
 		finishHandler:          finishHandler,
 		fixedIndexHandler:      fixedIndexHandler,
@@ -265,16 +271,37 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer ws.Cleanup()
 
 	sessionCtx := &streamctx.SessionContext{
-		SessionID:      sessionID,
-		DatastoreID:    ds.ID,
-		DatastoreRoot:  ds.Path,
-		BackupType:     string(params.BackupType),
-		BackupID:       params.BackupID,
-		BackupTime:     params.BackupTime,
-		Namespace:      ns,
-		WriterState:    ws,
-		PreviousBackup: prev,
+		SessionID:        sessionID,
+		DatastoreID:      ds.ID,
+		DatastoreRoot:    ds.Path,
+		BackupType:       string(params.BackupType),
+		BackupID:         params.BackupID,
+		BackupTime:       params.BackupTime,
+		Namespace:        ns,
+		WriterState:      ws,
+		PreviousBackup:   prev,
+		SessionStartedAt: time.Now(),
 	}
+
+	// Insert synthetic job + run rows so this PBS backup appears in the web UI.
+	// Best-effort: failures are logged but do not abort the backup.
+	if h.db != nil && kind == session.KindBackup {
+		jobID := jobsync.JobID(ds.ID, ns, string(params.BackupType), params.BackupID)
+		if err := jobsync.UpsertJob(h.db, ds.ID, ns, string(params.BackupType), params.BackupID); err != nil {
+			slog.Error("upgrade: failed to upsert synthetic job",
+				"error", err, "session_id", sessionID, "job_id", jobID)
+		} else {
+			sessionCtx.JobID = jobID
+			runID, runErr := jobsync.InsertRunningRun(h.db, jobID, sessionCtx.SessionStartedAt)
+			if runErr != nil {
+				slog.Error("upgrade: failed to insert synthetic run",
+					"error", runErr, "session_id", sessionID, "job_id", jobID)
+			} else {
+				sessionCtx.RunID = runID
+			}
+		}
+	}
+
 	sessionRouter := buildSessionRouter(
 		h.blobHandler, h.finishHandler,
 		h.fixedIndexHandler, h.fixedChunkHandler,
@@ -297,6 +324,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	updated, finErr := h.sessions.Finalize(sessionID)
 	if finErr != nil {
 		slog.Error("session finalize failed", "error", finErr, "session_id", sessionID)
+	}
+	// If the session transitioned to aborted (no /finish received), mark the run failed.
+	if updated && sessionCtx.RunID != "" {
+		errMsg := "connection closed without /finish"
+		if err := jobsync.FinishRun(h.db, sessionCtx.RunID, sessionCtx.JobID, "failed",
+			nil, &errMsg, sessionCtx.SessionStartedAt, time.Now()); err != nil {
+			slog.Error("upgrade: abort path FinishRun failed",
+				"error", err, "run_id", sessionCtx.RunID)
+		}
 	}
 	slog.Info("upgrade connection closed",
 		"path", r.URL.Path,

--- a/services/backupos-pbs/internal/upgrade/handler_test.go
+++ b/services/backupos-pbs/internal/upgrade/handler_test.go
@@ -64,6 +64,18 @@ func setupTestDB(t *testing.T) *sql.DB {
 			scratch_path  TEXT,
 			namespace      TEXT NOT NULL DEFAULT ''
 		);
+
+		CREATE TABLE backup_jobs (
+			id TEXT PRIMARY KEY,
+			name TEXT, source_type TEXT, source_config TEXT,
+			schedule TEXT, enabled INTEGER, preflight_enabled INTEGER, created_at INTEGER,
+			last_run_at INTEGER, last_run_status TEXT
+		);
+		CREATE TABLE backup_runs (
+			id TEXT PRIMARY KEY, job_id TEXT, status TEXT, trigger TEXT,
+			started_at INTEGER, run_type TEXT,
+			completed_at INTEGER, duration INTEGER, snapshot_id TEXT, error_message TEXT
+		);
 	`)
 	if err != nil {
 		t.Fatal(err)
@@ -100,6 +112,18 @@ func setupTestDBAtPath(t *testing.T, dsPath string) *sql.DB {
 			state         TEXT NOT NULL,
 			scratch_path  TEXT,
 			namespace      TEXT NOT NULL DEFAULT ''
+		);
+
+		CREATE TABLE backup_jobs (
+			id TEXT PRIMARY KEY,
+			name TEXT, source_type TEXT, source_config TEXT,
+			schedule TEXT, enabled INTEGER, preflight_enabled INTEGER, created_at INTEGER,
+			last_run_at INTEGER, last_run_status TEXT
+		);
+		CREATE TABLE backup_runs (
+			id TEXT PRIMARY KEY, job_id TEXT, status TEXT, trigger TEXT,
+			started_at INTEGER, run_type TEXT,
+			completed_at INTEGER, duration INTEGER, snapshot_id TEXT, error_message TEXT
 		);
 	`)
 	if err != nil {
@@ -172,8 +196,9 @@ func newTestHandler(db *sql.DB) *Handler {
 	return NewHandler(
 		datastore.NewLookup(db),
 		session.NewStore(db),
+		db,
 		blob.NewHandler(),
-		finish.NewHandler(session.NewStore(db)),
+		finish.NewHandler(session.NewStore(db), db),
 		fixedindex.NewHandler(),
 		fixedchunk.NewHandler(),
 		fixedappend.NewHandler(),
@@ -539,5 +564,37 @@ func TestHandler_FullUpgradeDance(t *testing.T) {
 	_ = db.QueryRow(`SELECT state FROM pbs_active_sessions LIMIT 1`).Scan(&state)
 	if state != "aborted" {
 		t.Errorf("expected state='aborted' after connection close, got %q", state)
+	}
+}
+
+// TestUpgrade_InsertsSyntheticJobAndRun verifies that a successful upgrade
+// inserts backup_jobs and backup_runs rows before the H2 session starts.
+func TestUpgrade_InsertsSyntheticJobAndRun(t *testing.T) {
+	tmp := t.TempDir()
+	db := setupTestDBAtPath(t, tmp)
+	h := newTestHandler(db)
+
+	srv := httptest.NewServer(wrapWithTestIdentity(h))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	headers := do101(t, host, host, "/api2/json/backup?store=default&backup-type=vm&backup-id=100&backup-time=1735000000")
+
+	if !strings.HasPrefix(headers, "HTTP/1.1 101") {
+		t.Fatalf("expected 101, got:\n%s", headers)
+	}
+
+	// Job row must exist.
+	var jobCount int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM backup_jobs`).Scan(&jobCount)
+	if jobCount != 1 {
+		t.Errorf("expected 1 backup_jobs row, got %d", jobCount)
+	}
+
+	// Run row must exist with status='running'.
+	var runStatus string
+	_ = db.QueryRow(`SELECT status FROM backup_runs LIMIT 1`).Scan(&runStatus)
+	if runStatus != "running" {
+		t.Errorf("expected run status='running', got %q", runStatus)
 	}
 }


### PR DESCRIPTION
## Summary

- New `internal/jobsync` package with `UpsertJob`, `InsertRunningRun`, `FinishRun` for writing synthetic web-UI rows
- Upgrade handler inserts a `backup_jobs` row (ON CONFLICT DO NOTHING) and a `backup_runs` row (status=running) immediately after the 101 handshake
- `POST /finish` marks the run `ok` and records the snapshot ID; connection-close-without-finish marks it `failed`
- `SessionContext` gains `JobID`, `RunID`, `SessionStartedAt` fields to carry IDs across the H2 session

## Test plan

- [ ] `go test ./internal/jobsync/...` — 9 unit tests for all jobsync functions
- [ ] `go test ./internal/finish/...` — includes `TestFinish_FinalizesSyntheticRun`
- [ ] `go test ./internal/upgrade/...` — includes `TestUpgrade_InsertsSyntheticJobAndRun`
- [ ] `go build ./...` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)