### PR TITLE
fix(pbs): use underscore separator in synthetic JobID for URL safety

### DIFF
--- a/services/backupos-pbs/internal/finish/finish_test.go
+++ b/services/backupos-pbs/internal/finish/finish_test.go
@@ -408,7 +408,7 @@ func TestFinish_FinalizesSyntheticRun(t *testing.T) {
 	_, snapDB, store := setupFull(t)
 	h := NewHandler(store, snapDB)
 
-	jobID := "pbs:ds-1::vm:100"
+	jobID := "pbs_ds-1_root_vm_100"
 	runID := "test-run-uuid"
 	startedAt := time.Unix(1735000000, 0)
 	backupTime := time.Unix(1735000100, 0)

--- a/services/backupos-pbs/internal/jobsync/jobsync.go
+++ b/services/backupos-pbs/internal/jobsync/jobsync.go
@@ -19,14 +19,15 @@ import (
 )
 
 // JobID returns the deterministic synthetic Job ID for a backup tuple.
-// Format: pbs:<datastoreID>:<namespace>:<backupType>:<backupID>
-// Root namespace produces an empty string between the two colons.
+// Format: pbs_<datastoreID>_<namespace_or_root>_<backupType>_<backupID>
+// Uses underscore instead of colon to avoid URL-routing edge cases when
+// the ID becomes a dynamic route segment in the web UI.
 func JobID(datastoreID string, ns namespace.Namespace, backupType, backupID string) string {
-	nsPart := ""
+	nsPart := "root"
 	if !ns.IsRoot() {
 		nsPart = ns.String()
 	}
-	return fmt.Sprintf("pbs:%s:%s:%s:%s", datastoreID, nsPart, backupType, backupID)
+	return fmt.Sprintf("pbs_%s_%s_%s_%s", datastoreID, nsPart, backupType, backupID)
 }
 
 // JobName returns the human-friendly display name.

--- a/services/backupos-pbs/internal/jobsync/jobsync_test.go
+++ b/services/backupos-pbs/internal/jobsync/jobsync_test.go
@@ -39,7 +39,7 @@ func openDB(t *testing.T) *sql.DB {
 
 func TestJobID_RootNamespace(t *testing.T) {
 	got := JobID("ds-1", namespace.Root(), "vm", "100")
-	want := "pbs:ds-1::vm:100"
+	want := "pbs_ds-1_root_vm_100"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -51,7 +51,7 @@ func TestJobID_NonRootNamespace(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := JobID("ds-1", ns, "vm", "100")
-	want := "pbs:ds-1:tenant-a:vm:100"
+	want := "pbs_ds-1_tenant-a_vm_100"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -74,12 +74,12 @@ func TestUpsertJob_InsertsRow(t *testing.T) {
 	}
 
 	var id, name, sourceType string
-	err := db.QueryRow(`SELECT id, name, source_type FROM backup_jobs WHERE id = ?`, "pbs:ds-1::vm:100").
+	err := db.QueryRow(`SELECT id, name, source_type FROM backup_jobs WHERE id = ?`, "pbs_ds-1_root_vm_100").
 		Scan(&id, &name, &sourceType)
 	if err != nil {
 		t.Fatalf("query: %v", err)
 	}
-	if id != "pbs:ds-1::vm:100" {
+	if id != "pbs_ds-1_root_vm_100" {
 		t.Errorf("id: got %q", id)
 	}
 	if name != "PVE: vm/100" {
@@ -97,7 +97,7 @@ func TestUpsertJob_DoesNotUpdateExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Manually tweak the row to verify it's left unchanged.
-	if _, err := db.Exec(`UPDATE backup_jobs SET name = 'custom' WHERE id = ?`, "pbs:ds-1::vm:100"); err != nil {
+	if _, err := db.Exec(`UPDATE backup_jobs SET name = 'custom' WHERE id = ?`, "pbs_ds-1_root_vm_100"); err != nil {
 		t.Fatal(err)
 	}
 	if err := UpsertJob(db, "ds-1", namespace.Root(), "vm", "100"); err != nil {
@@ -105,7 +105,7 @@ func TestUpsertJob_DoesNotUpdateExisting(t *testing.T) {
 	}
 
 	var name string
-	_ = db.QueryRow(`SELECT name FROM backup_jobs WHERE id = ?`, "pbs:ds-1::vm:100").Scan(&name)
+	_ = db.QueryRow(`SELECT name FROM backup_jobs WHERE id = ?`, "pbs_ds-1_root_vm_100").Scan(&name)
 	if name != "custom" {
 		t.Errorf("expected row unchanged (name='custom'), got %q", name)
 	}


### PR DESCRIPTION
Colons in the synthetic JobID broke Next.js dynamic routing — `/jobs/[id]` rendered blank because the route segment was mangled (the empty namespace produced `::` which compounded the issue). Changes the separator from `:` to `_` and serializes the empty namespace as `root`.

Manual cleanup after deploy (existing rows have the old format and will be orphaned):
```sql
DELETE FROM backup_runs WHERE job_id LIKE 'pbs:%';
DELETE FROM backup_jobs WHERE id LIKE 'pbs:%';
```

Replaces #296 (which had a dirty merge state due to duplicate slice-1 commits on the branch). This branch is rebased onto current main, so the diff is just the actual fix.