### PR TITLE
feat(web): surface restores and upcoming jobs in activity feed

### DIFF
--- a/apps/web/app/(dashboard)/activity/page.tsx
+++ b/apps/web/app/(dashboard)/activity/page.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
-import { getDb, backupRuns, backupJobs, alerts, eq } from '@backupos/db'
-import { desc } from '@backupos/db'
+import { getDb, backupRuns, backupJobs, alerts, eq, desc, gte, and } from '@backupos/db'
 import { PageHeader } from '@/components/ui/page-header'
 import { AutoRefresh } from '@/components/ui/auto-refresh'
 
@@ -8,6 +7,15 @@ function fmtDate(d: Date | null): string {
   if (!d) return '—'
   return d.toISOString().slice(0, 16).replace('T', ' ')
 }
+
+function fmtIn(d: Date): string {
+  const ms = d.getTime() - Date.now()
+  if (ms < 60_000) return 'soon'
+  if (ms < 3_600_000) return `in ${Math.floor(ms / 60_000)}m`
+  if (ms < 86_400_000) return `in ${Math.floor(ms / 3_600_000)}h`
+  return `in ${Math.floor(ms / 86_400_000)}d`
+}
+
 
 const STATUS_COLOR: Record<string, string> = {
   success: 'var(--ok)',
@@ -37,7 +45,7 @@ type FeedItem = {
 export default async function ActivityPage() {
   const db = getDb()
 
-  const [runs, fired] = await Promise.all([
+  const [runs, fired, upcoming] = await Promise.all([
     db
       .select({
         id:        backupRuns.id,
@@ -46,6 +54,7 @@ export default async function ActivityPage() {
         status:    backupRuns.status,
         trigger:   backupRuns.trigger,
         startedAt: backupRuns.startedAt,
+        runType:   backupRuns.runType,
       })
       .from(backupRuns)
       .leftJoin(backupJobs, eq(backupRuns.jobId, backupJobs.id))
@@ -59,6 +68,22 @@ export default async function ActivityPage() {
       .orderBy(desc(alerts.firedAt))
       .limit(75)
       .all(),
+
+    db
+      .select({
+        id:         backupJobs.id,
+        name:       backupJobs.name,
+        nextRunAt:  backupJobs.nextRunAt,
+        sourceType: backupJobs.sourceType,
+      })
+      .from(backupJobs)
+      .where(and(
+        eq(backupJobs.enabled, true),
+        gte(backupJobs.nextRunAt, new Date()),
+      ))
+      .orderBy(backupJobs.nextRunAt)
+      .limit(10)
+      .all(),
   ])
 
   const feed: FeedItem[] = [
@@ -67,7 +92,7 @@ export default async function ActivityPage() {
       date:   r.startedAt,
       kind:   'run' as const,
       status: r.status,
-      title:  `Backup run ${r.status} — ${r.jobName ?? 'unknown job'}${r.trigger === 'manual' ? ' (manual)' : ''}`,
+      title:  `${r.runType === 'restore' ? 'Restore' : 'Backup'} run ${r.status} — ${r.jobName ?? 'unknown job'}${r.trigger === 'manual' ? ' (manual)' : ''}`,
       href:   r.jobId ? `/jobs/${r.jobId}` : undefined,
     })),
     ...fired.map(a => ({
@@ -85,7 +110,7 @@ export default async function ActivityPage() {
   return (
     <div>
       <AutoRefresh intervalMs={10_000} />
-      <PageHeader title="Activity" description="Backup runs and alerts from the last 30 days." />
+      <PageHeader title="Activity" description="Backup and restore activity from the last 30 days, plus upcoming scheduled jobs." />
 
       <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)' }}>
         {recent.length === 0 ? (
@@ -126,6 +151,55 @@ export default async function ActivityPage() {
             ))}
           </div>
         )}
+      </div>
+
+      {/* Upcoming scheduled jobs */}
+      <div style={{ marginTop: 24 }}>
+        <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg)', marginBottom: 8 }}>Upcoming</div>
+        <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)' }}>
+          {upcoming.length === 0 ? (
+            <div style={{ padding: 40, textAlign: 'center', color: 'var(--fg-mute)', fontSize: 13 }}>
+              No scheduled jobs queued.
+            </div>
+          ) : (
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+              {upcoming.map((job, i) => (
+                <div
+                  key={job.id}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 12,
+                    padding: '10px 20px',
+                    borderTop: i > 0 ? '1px solid var(--border)' : 'none',
+                  }}
+                >
+                  <span style={{
+                    display: 'inline-block', width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
+                    backgroundColor: 'var(--accent)',
+                  }} />
+                  <span style={{ color: 'var(--fg-dim)', flexShrink: 0, width: 130 }}>
+                    {fmtDate(job.nextRunAt)}
+                  </span>
+                  <span style={{
+                    fontSize: 10, padding: '1px 6px', borderRadius: 10, flexShrink: 0,
+                    border: '1px solid var(--border)',
+                    color: 'var(--accent)',
+                    backgroundColor: 'var(--surf2)',
+                  }}>
+                    scheduled
+                  </span>
+                  <Link href={`/jobs/${job.id}`} style={{ color: 'var(--fg)', textDecoration: 'none', flex: 1 }}>
+                    {job.name}
+                  </Link>
+                  {job.nextRunAt && (
+                    <span style={{ color: 'var(--fg-dim)', flexShrink: 0 }}>
+                      {fmtIn(job.nextRunAt)}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -51,6 +51,14 @@ function fmtAge(d: Date | null): string {
   return `${Math.floor(s / 86400)}d ago`
 }
 
+function fmtIn(d: Date): string {
+  const ms = d.getTime() - Date.now()
+  if (ms < 60_000) return 'soon'
+  if (ms < 3_600_000) return `in ${Math.floor(ms / 60_000)}m`
+  if (ms < 86_400_000) return `in ${Math.floor(ms / 3_600_000)}h`
+  return `in ${Math.floor(ms / 86_400_000)}d`
+}
+
 export default async function DashboardPage() {
   const db      = getDb()
   const now     = Date.now()
@@ -58,7 +66,7 @@ export default async function DashboardPage() {
   const since7d   = new Date(now -  7  * 24 * 60 * 60 * 1000)
   const since30d  = new Date(now - 30  * 24 * 60 * 60 * 1000)
 
-  const [jobs, recentRuns, allAgents, repos, successRuns24h, openAlerts, runs30d, passedVerifications7d, allServices] =
+  const [jobs, recentRuns, allAgents, repos, successRuns24h, openAlerts, runs30d, passedVerifications7d, allServices, upcomingJobs] =
     await Promise.all([
       db.select().from(backupJobs).all(),
       db.select({
@@ -105,6 +113,20 @@ export default async function DashboardPage() {
         host:        infraOsServices.host,
         description: infraOsServices.description,
       }).from(infraOsServices).all(),
+
+      db.select({
+        id:        backupJobs.id,
+        name:      backupJobs.name,
+        nextRunAt: backupJobs.nextRunAt,
+      })
+        .from(backupJobs)
+        .where(and(
+          eq(backupJobs.enabled, true),
+          gte(backupJobs.nextRunAt, new Date()),
+        ))
+        .orderBy(backupJobs.nextRunAt)
+        .limit(5)
+        .all(),
     ])
 
   const runs24h      = recentRuns.filter(r => r.startedAt && r.startedAt >= since24h)
@@ -338,6 +360,42 @@ export default async function DashboardPage() {
                       </div>
                     </div>
                     <Badge status={toBadge(agent.status ?? 'disconnected')} />
+                  </div>
+                ))}
+              </CardBody>
+            )}
+          </Card>
+
+          {/* Coming up card */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Coming up</CardTitle>
+              <CardLink href="/activity">View all →</CardLink>
+            </CardHeader>
+            {upcomingJobs.length === 0 ? (
+              <CardBody>
+                <div style={{ padding: '20px 0', textAlign: 'center', color: 'var(--fg-faint)', fontSize: 13 }}>
+                  No scheduled jobs queued.
+                </div>
+              </CardBody>
+            ) : (
+              <CardBody style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {upcomingJobs.map(job => (
+                  <div key={job.id} style={{
+                    display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8,
+                  }}>
+                    <a href={`/jobs/${job.id}`} style={{
+                      fontSize: 13, fontWeight: 500, color: 'var(--fg)',
+                      textDecoration: 'none', flex: 1, overflow: 'hidden',
+                      textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                    }}>
+                      {job.name}
+                    </a>
+                    {job.nextRunAt && (
+                      <span style={{ fontSize: 11, color: 'var(--accent)', flexShrink: 0, fontFamily: 'var(--font-mono)' }}>
+                        {fmtIn(job.nextRunAt)}
+                      </span>
+                    )}
                   </div>
                 ))}
               </CardBody>


### PR DESCRIPTION
## Summary

- **Restore labels**: `/activity` feed now reads `Restore run <status>` for `runType='restore'` runs instead of always `Backup run`. Added `runType` to the SELECT.
- **Upcoming panel on `/activity`**: new "Upcoming" section below the feed lists the next 10 enabled jobs with `nextRunAt` in the future. Shows relative time (`in 2h`, `in 3d`). Empty state: "No scheduled jobs queued."
- **Coming up card on `/dashboard`**: new card in the right column showing the next 5 scheduled jobs with relative time, linking to `/jobs/[id]`. Empty state: "No scheduled jobs queued."
- **Page header updated**: `/activity` description now reads "Backup and restore activity from the last 30 days, plus upcoming scheduled jobs."

## Notes

- PBS jobs have `nextRunAt = NULL` — they are excluded by the `gte(nextRunAt, new Date())` filter and will never appear in the upcoming lists.
- Both pages render without errors on a fresh DB with zero scheduled jobs.
- No new tables, migrations, or additional files modified.

## Test plan

- [ ] `/activity` shows "Restore run …" label for restore runs
- [ ] `/activity` "Upcoming" panel appears below feed with scheduled jobs
- [ ] `/activity` "Upcoming" shows empty state when no jobs are scheduled
- [ ] `/dashboard` "Coming up" card appears in right column
- [ ] `/dashboard` "Coming up" shows empty state when no jobs are scheduled
- [ ] Build passes: `pnpm --filter @backupos/web build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)