### PR TITLE
feat(alerts): per-channel event subscriptions and new AlertTypes

### DIFF
--- a/apps/web/app/(dashboard)/settings/alerts/page.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/page.tsx
@@ -1,5 +1,6 @@
 import { getDb, alertChannels } from '@backupos/db'
-import { deleteAlertChannel } from '@/app/actions/alerts'
+import { deleteAlertChannel, saveChannelSubscriptions } from '@/app/actions/alerts'
+import { ALL_ALERT_TYPES, ALERT_TYPE_LABELS } from '@/lib/alerts'
 import { AddChannelForm } from './AddChannelForm'
 import { TestChannelButton } from './TestChannelButton'
 
@@ -40,41 +41,84 @@ export default async function AlertChannelsPage({ searchParams }: { searchParams
             Configured channels
           </div>
           {channels.map(ch => {
-            const deleteAction = deleteAlertChannel.bind(null, ch.id)
+            const deleteAction      = deleteAlertChannel.bind(null, ch.id)
+            const subscribeAction   = saveChannelSubscriptions.bind(null, ch.id)
             let subtitle = ''
             try {
               const cfg = JSON.parse(ch.config) as Record<string, string>
-              if (cfg.url)            { subtitle = cfg.url.slice(0, 48) + (cfg.url.length > 48 ? '…' : '') }
-              else if (cfg.chatId)    { subtitle = `chat ${cfg.chatId}` }
-              else if (cfg.integrationKey) { subtitle = cfg.integrationKey.slice(0, 20) + '…' }
-              else if (cfg.userKey)   { subtitle = `user ${cfg.userKey.slice(0, 16)}…` }
+              if (cfg.url)                  { subtitle = cfg.url.slice(0, 48) + (cfg.url.length > 48 ? '…' : '') }
+              else if (cfg.chatId)          { subtitle = `chat ${cfg.chatId}` }
+              else if (cfg.integrationKey)  { subtitle = cfg.integrationKey.slice(0, 20) + '…' }
+              else if (cfg.userKey)         { subtitle = `user ${cfg.userKey.slice(0, 16)}…` }
             } catch { /* ignore */ }
+
+            // null = subscribe to all (back-compat); explicit array = explicit selection
+            let subscribedSet: Set<string> | null = null
+            if (ch.subscribedEvents) {
+              try {
+                subscribedSet = new Set(JSON.parse(ch.subscribedEvents) as string[])
+              } catch { /* treat as all */ }
+            }
+            const isChecked = (t: string) => subscribedSet === null || subscribedSet.has(t)
+
             return (
-              <div key={ch.id} style={{
-                padding: '14px 20px', borderTop: '1px solid var(--border)',
-                display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-              }}>
-                <div>
-                  <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)' }}>{ch.name}</div>
-                  <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginTop: 2 }}>
-                    {TYPE_LABELS[ch.type] ?? ch.type}{subtitle ? ` · ${subtitle}` : ''}
+              <div key={ch.id} style={{ borderTop: '1px solid var(--border)' }}>
+                <div style={{
+                  padding: '14px 20px',
+                  display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                }}>
+                  <div>
+                    <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)' }}>{ch.name}</div>
+                    <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginTop: 2 }}>
+                      {TYPE_LABELS[ch.type] ?? ch.type}{subtitle ? ` · ${subtitle}` : ''}
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <TestChannelButton channelId={ch.id} />
+                    <form action={deleteAction}>
+                      <button
+                        type="submit"
+                        style={{
+                          padding: '4px 12px', fontSize: 12, cursor: 'pointer',
+                          borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+                          background: 'var(--surf2)', color: 'var(--err)',
+                        }}
+                      >
+                        Remove
+                      </button>
+                    </form>
                   </div>
                 </div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <TestChannelButton channelId={ch.id} />
-                  <form action={deleteAction}>
-                    <button
-                      type="submit"
-                      style={{
-                        padding: '4px 12px', fontSize: 12, cursor: 'pointer',
-                        borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
-                        background: 'var(--surf2)', color: 'var(--err)',
-                      }}
-                    >
-                      Remove
-                    </button>
-                  </form>
-                </div>
+
+                {/* Per-channel event subscriptions */}
+                <form action={subscribeAction} style={{ padding: '0 20px 14px' }}>
+                  <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-dim)', marginBottom: 8, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                    Notify on
+                  </div>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 20px', marginBottom: 10 }}>
+                    {ALL_ALERT_TYPES.map(t => (
+                      <label key={t} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: 'var(--fg)', cursor: 'pointer' }}>
+                        <input
+                          type="checkbox"
+                          name={`event_${t}`}
+                          defaultChecked={isChecked(t)}
+                          style={{ accentColor: 'var(--accent)' }}
+                        />
+                        {ALERT_TYPE_LABELS[t]}
+                      </label>
+                    ))}
+                  </div>
+                  <button
+                    type="submit"
+                    style={{
+                      padding: '4px 12px', fontSize: 12, cursor: 'pointer',
+                      borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+                      background: 'var(--surf2)', color: 'var(--fg)',
+                    }}
+                  >
+                    Save
+                  </button>
+                </form>
               </div>
             )
           })}

--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -4,7 +4,7 @@ import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { getDb, alerts, alertChannels, eq } from '@backupos/db'
 import { requireAdmin } from '@/lib/user'
-import { dispatchToChannel } from '@/lib/alerts'
+import { dispatchToChannel, ALL_ALERT_TYPES, type AlertType } from '@/lib/alerts'
 
 const VALID_CHANNEL_TYPES = [
   'discord', 'slack', 'webhook',
@@ -164,6 +164,21 @@ export async function testAlertChannel(input: TestAlertChannelInput): Promise<Te
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) }
   }
+}
+
+export async function updateChannelSubscriptions(channelId: string, events: AlertType[]): Promise<void> {
+  await requireAdmin()
+  if (!channelId) return
+  const db = getDb()
+  await db.update(alertChannels)
+    .set({ subscribedEvents: JSON.stringify(events) })
+    .where(eq(alertChannels.id, channelId))
+  revalidatePath('/settings/alerts')
+}
+
+export async function saveChannelSubscriptions(channelId: string, formData: FormData): Promise<void> {
+  const events = ALL_ALERT_TYPES.filter(t => formData.get(`event_${t}`) === 'on')
+  await updateChannelSubscriptions(channelId, events)
 }
 
 export async function sendTestAlert(channelId: string): Promise<{ ok: boolean; error?: string }> {

--- a/apps/web/lib/alerts.test.ts
+++ b/apps/web/lib/alerts.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildMessage,
+  channelReceivesEvent,
+  type AlertType,
+} from './alerts'
+
+// ── buildMessage ──────────────────────────────────────────────────────────────
+
+describe('buildMessage', () => {
+  it('backup_failed', () => {
+    const msg = buildMessage('backup_failed', { jobId: 'j1', jobName: 'Daily VM', error: 'disk full' })
+    expect(msg).toBe('Backup job "Daily VM" failed: disk full')
+  })
+
+  it('backup_missed', () => {
+    const msg = buildMessage('backup_missed', { jobId: 'j1', jobName: 'Daily VM' })
+    expect(msg).toBe('Scheduled backup job "Daily VM" did not run on time')
+  })
+
+  it('backup_succeeded — with duration and size', () => {
+    const msg = buildMessage('backup_succeeded', {
+      jobId: 'j1', jobName: 'Daily VM', durationSec: 90, totalSizeBytes: 1024 * 1024 * 512,
+    })
+    expect(msg).toContain('"Daily VM" completed successfully')
+    expect(msg).toContain('1m 30s')
+    expect(msg).toContain('512.0 MB')
+  })
+
+  it('backup_succeeded — no duration or size', () => {
+    const msg = buildMessage('backup_succeeded', {
+      jobId: 'j1', jobName: 'Daily VM', durationSec: null, totalSizeBytes: null,
+    })
+    expect(msg).toBe('Backup job "Daily VM" completed successfully')
+  })
+
+  it('restore_succeeded — with duration', () => {
+    const msg = buildMessage('restore_succeeded', { runId: 'r1', jobName: 'Daily VM', durationSec: 45 })
+    expect(msg).toContain('"Daily VM" completed successfully')
+    expect(msg).toContain('45s')
+  })
+
+  it('restore_succeeded — no duration', () => {
+    const msg = buildMessage('restore_succeeded', { runId: 'r1', jobName: 'Daily VM', durationSec: null })
+    expect(msg).toBe('Restore for "Daily VM" completed successfully')
+  })
+
+  it('restore_failed', () => {
+    const msg = buildMessage('restore_failed', { runId: 'r1', jobName: 'Daily VM', error: 'timeout' })
+    expect(msg).toBe('Restore for "Daily VM" failed: timeout')
+  })
+
+  it('restore_missed', () => {
+    const msg = buildMessage('restore_missed', { jobId: 'j1', jobName: 'Weekly CT' })
+    expect(msg).toBe('Scheduled restore for "Weekly CT" did not run on time')
+  })
+
+  it('agent_disconnected', () => {
+    const msg = buildMessage('agent_disconnected', { agentId: 'a1', agentName: 'prod-01' })
+    expect(msg).toBe('Agent "prod-01" (a1) has been unreachable for over 10 minutes')
+  })
+})
+
+// ── channelReceivesEvent ──────────────────────────────────────────────────────
+
+describe('channelReceivesEvent', () => {
+  it('null subscribedEvents → receives all events (back-compat)', () => {
+    expect(channelReceivesEvent(null, 'backup_failed')).toBe(true)
+    expect(channelReceivesEvent(null, 'backup_succeeded')).toBe(true)
+    expect(channelReceivesEvent(null, 'agent_disconnected')).toBe(true)
+  })
+
+  it('empty array → receives no events', () => {
+    const sub = JSON.stringify([])
+    const types: AlertType[] = ['backup_failed', 'backup_succeeded', 'restore_failed', 'agent_disconnected']
+    for (const t of types) {
+      expect(channelReceivesEvent(sub, t)).toBe(false)
+    }
+  })
+
+  it('single-type array → receives only that type', () => {
+    const sub = JSON.stringify(['backup_failed'])
+    expect(channelReceivesEvent(sub, 'backup_failed')).toBe(true)
+    expect(channelReceivesEvent(sub, 'backup_missed')).toBe(false)
+    expect(channelReceivesEvent(sub, 'agent_disconnected')).toBe(false)
+  })
+
+  it('multiple types → receives exactly those types', () => {
+    const sub = JSON.stringify(['backup_failed', 'restore_failed'])
+    expect(channelReceivesEvent(sub, 'backup_failed')).toBe(true)
+    expect(channelReceivesEvent(sub, 'restore_failed')).toBe(true)
+    expect(channelReceivesEvent(sub, 'backup_succeeded')).toBe(false)
+    expect(channelReceivesEvent(sub, 'agent_disconnected')).toBe(false)
+  })
+
+  it('malformed JSON → fail-safe: receives all events', () => {
+    expect(channelReceivesEvent('not-valid-json', 'backup_failed')).toBe(true)
+    expect(channelReceivesEvent('{broken', 'restore_succeeded')).toBe(true)
+  })
+
+  it('undefined subscribedEvents → receives all events', () => {
+    expect(channelReceivesEvent(undefined, 'backup_failed')).toBe(true)
+  })
+})

--- a/apps/web/lib/alerts.ts
+++ b/apps/web/lib/alerts.ts
@@ -2,17 +2,61 @@ import nodemailer from 'nodemailer'
 import { getDb, alerts, alertChannels, smtpConfig, eq } from '@backupos/db'
 import { decryptField } from './repo-crypto'
 
-export type AlertType = 'backup_failed' | 'backup_missed' | 'agent_disconnected'
+export type AlertType =
+  | 'backup_failed'
+  | 'backup_missed'
+  | 'backup_succeeded'
+  | 'restore_succeeded'
+  | 'restore_failed'
+  | 'restore_missed'
+  | 'agent_disconnected'
 
-export interface AlertBackupFailed  { jobId: string; jobName: string; error: string }
-export interface AlertBackupMissed  { jobId: string; jobName: string }
-export interface AlertAgentDisc     { agentId: string; agentName: string }
+// All AlertTypes for UI rendering. Order matters — UI shows them in this order.
+export const ALL_ALERT_TYPES: AlertType[] = [
+  'backup_succeeded',
+  'backup_failed',
+  'backup_missed',
+  'restore_succeeded',
+  'restore_failed',
+  'restore_missed',
+  'agent_disconnected',
+]
 
-export type AlertPayload = AlertBackupFailed | AlertBackupMissed | AlertAgentDisc
+// Human-friendly labels for the settings UI.
+export const ALERT_TYPE_LABELS: Record<AlertType, string> = {
+  backup_succeeded:   'Backup succeeded',
+  backup_failed:      'Backup failed',
+  backup_missed:      'Backup missed schedule',
+  restore_succeeded:  'Restore succeeded',
+  restore_failed:     'Restore failed',
+  restore_missed:     'Restore missed schedule',
+  agent_disconnected: 'Agent disconnected',
+}
+
+export interface AlertBackupFailed    { jobId: string; jobName: string; error: string }
+export interface AlertBackupMissed    { jobId: string; jobName: string }
+export interface AlertBackupSucceeded { jobId: string; jobName: string; durationSec: number | null; totalSizeBytes: number | null }
+export interface AlertRestoreSucceeded { runId: string; jobName: string; durationSec: number | null }
+export interface AlertRestoreFailed   { runId: string; jobName: string; error: string }
+export interface AlertRestoreMissed   { jobId: string; jobName: string }
+export interface AlertAgentDisc       { agentId: string; agentName: string }
+
+export type AlertPayload =
+  | AlertBackupFailed
+  | AlertBackupMissed
+  | AlertBackupSucceeded
+  | AlertRestoreSucceeded
+  | AlertRestoreFailed
+  | AlertRestoreMissed
+  | AlertAgentDisc
 
 const SEVERITY: Record<AlertType, string> = {
   backup_failed:       'error',
   backup_missed:       'warning',
+  backup_succeeded:    'info',
+  restore_failed:      'error',
+  restore_missed:      'warning',
+  restore_succeeded:   'info',
   agent_disconnected:  'warning',
 }
 
@@ -63,7 +107,21 @@ async function deliverOrThrow(
   }
 }
 
-function buildMessage(type: AlertType, payload: AlertPayload): string {
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return s === 0 ? `${m}m` : `${m}m ${s}s`
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(1)} MB`
+  return `${(bytes / 1024 ** 3).toFixed(2)} GB`
+}
+
+export function buildMessage(type: AlertType, payload: AlertPayload): string {
   if (type === 'backup_failed') {
     const p = payload as AlertBackupFailed
     return `Backup job "${p.jobName}" failed: ${p.error}`
@@ -72,8 +130,48 @@ function buildMessage(type: AlertType, payload: AlertPayload): string {
     const p = payload as AlertBackupMissed
     return `Scheduled backup job "${p.jobName}" did not run on time`
   }
+  if (type === 'backup_succeeded') {
+    const p = payload as AlertBackupSucceeded
+    const parts = [`Backup job "${p.jobName}" completed successfully`]
+    if (p.durationSec != null) parts.push(`in ${formatDuration(p.durationSec)}`)
+    if (p.totalSizeBytes != null) parts.push(`(${formatBytes(p.totalSizeBytes)})`)
+    return parts.join(' ')
+  }
+  if (type === 'restore_succeeded') {
+    const p = payload as AlertRestoreSucceeded
+    const parts = [`Restore for "${p.jobName}" completed successfully`]
+    if (p.durationSec != null) parts.push(`in ${formatDuration(p.durationSec)}`)
+    return parts.join(' ')
+  }
+  if (type === 'restore_failed') {
+    const p = payload as AlertRestoreFailed
+    return `Restore for "${p.jobName}" failed: ${p.error}`
+  }
+  if (type === 'restore_missed') {
+    const p = payload as AlertRestoreMissed
+    return `Scheduled restore for "${p.jobName}" did not run on time`
+  }
   const p = payload as AlertAgentDisc
   return `Agent "${p.agentName}" (${p.agentId}) has been unreachable for over 10 minutes`
+}
+
+/**
+ * Returns true if a channel with the given subscribedEvents value should
+ * receive an event of the given type.
+ *
+ * - null / missing → back-compat: receive all events
+ * - JSON array     → receive only listed types
+ * - malformed JSON → fail-safe: receive all events
+ */
+export function channelReceivesEvent(subscribedEvents: string | null | undefined, type: AlertType): boolean {
+  if (!subscribedEvents) return true
+  try {
+    const events = JSON.parse(subscribedEvents) as string[]
+    return events.includes(type)
+  } catch {
+    console.warn(`[alerts] malformed subscribed_events; treating as subscribe-to-all`)
+    return true
+  }
 }
 
 async function fireDiscord(url: string, type: AlertType, message: string, severity: string): Promise<void> {
@@ -258,8 +356,10 @@ export async function sendAlert(type: AlertType, payload: AlertPayload): Promise
   const channels = await db.select().from(alertChannels).all()
   const enabled  = channels.filter(c => c.enabled)
 
+  const subscribed = enabled.filter(channel => channelReceivesEvent(channel.subscribedEvents, type))
+
   await Promise.allSettled(
-    enabled.map(async channel => {
+    subscribed.map(async channel => {
       try {
         await dispatchToChannel(channel, type, message, severity, payload)
       } catch (err) {
@@ -268,6 +368,7 @@ export async function sendAlert(type: AlertType, payload: AlertPayload): Promise
     })
   )
 
+  // Email always receives every alert — no per-recipient filtering in V1.
   try {
     await fireEmail(type, message)
   } catch (err) {

--- a/packages/db/migrations/0046_alert_channel_subscriptions.sql
+++ b/packages/db/migrations/0046_alert_channel_subscriptions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE alert_channels ADD COLUMN subscribed_events TEXT;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1777939200000,
       "tag": "0045_pbs_token_permissions_backfill",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "6",
+      "when": 1778025600000,
+      "tag": "0046_alert_channel_subscriptions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -409,12 +409,13 @@ export const alerts = sqliteTable('alerts', {
 // Webhook destinations for alert delivery
 
 export const alertChannels = sqliteTable('alert_channels', {
-  id:        text('id').primaryKey(),
-  name:      text('name').notNull(),
-  type:      text('type').notNull(),
-  config:    text('config').notNull(),
-  enabled:   integer('enabled', { mode: 'boolean' }).notNull().default(true),
-  createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+  id:               text('id').primaryKey(),
+  name:             text('name').notNull(),
+  type:             text('type').notNull(),
+  config:           text('config').notNull(),
+  enabled:          integer('enabled', { mode: 'boolean' }).notNull().default(true),
+  subscribedEvents: text('subscribed_events'), // JSON string[] of AlertType; null = subscribe to all (back-compat)
+  createdAt:        integer('created_at', { mode: 'timestamp_ms' }).notNull(),
 })
 
 // ── Verification tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `subscribed_events` column to `alert_channels` (migration `0046`)
- Expands `AlertType` to 7 values: backup/restore succeeded/failed/missed + agent_disconnected
- Per-channel checkbox UI in `/settings/alerts` — save persists JSON array to DB
- `sendAlert` filters channels via `channelReceivesEvent`; null/missing = subscribe to all (back-compat); malformed JSON = fail-safe all
- Email delivery intentionally excluded from per-channel filtering (V1)
- 15 unit tests (vitest) covering `buildMessage` and `channelReceivesEvent`

## Test plan

- [ ] `cd apps/web && pnpm vitest run` — 15/15 pass
- [ ] `pnpm build` — clean
- [ ] Open `/settings/alerts`, check boxes per channel, save — verify DB updated
- [ ] Channel with empty subscription receives no alerts; null subscription receives all

🤖 Generated with [Claude Code](https://claude.com/claude-code)