### PR TITLE
fix(settings): pending state and success toast for channel subscription save

### DIFF
--- a/apps/web/app/(dashboard)/settings/alerts/SaveSubscriptionsButton.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/SaveSubscriptionsButton.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useFormStatus } from 'react-dom'
+
+export function SaveSubscriptionsButton() {
+  const { pending } = useFormStatus()
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      style={{
+        padding: '4px 12px',
+        fontSize: 12,
+        cursor: pending ? 'not-allowed' : 'pointer',
+        borderRadius: 'var(--radius-sm)',
+        border: '1px solid var(--border)',
+        background: 'var(--surf2)',
+        color: pending ? 'var(--fg-mute)' : 'var(--fg)',
+        opacity: pending ? 0.7 : 1,
+        transition: 'opacity 0.15s ease',
+      }}
+    >
+      {pending ? 'Saving…' : 'Save'}
+    </button>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/alerts/page.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/page.tsx
@@ -3,6 +3,7 @@ import { deleteAlertChannel, saveChannelSubscriptions } from '@/app/actions/aler
 import { ALL_ALERT_TYPES, ALERT_TYPE_LABELS } from '@/lib/alerts'
 import { AddChannelForm } from './AddChannelForm'
 import { TestChannelButton } from './TestChannelButton'
+import { SaveSubscriptionsButton } from './SaveSubscriptionsButton'
 
 const TYPE_LABELS: Record<string, string> = {
   discord:   'Discord',
@@ -108,16 +109,7 @@ export default async function AlertChannelsPage({ searchParams }: { searchParams
                       </label>
                     ))}
                   </div>
-                  <button
-                    type="submit"
-                    style={{
-                      padding: '4px 12px', fontSize: 12, cursor: 'pointer',
-                      borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
-                      background: 'var(--surf2)', color: 'var(--fg)',
-                    }}
-                  >
-                    Save
-                  </button>
+                  <SaveSubscriptionsButton />
                 </form>
               </div>
             )

--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -173,7 +173,7 @@ export async function updateChannelSubscriptions(channelId: string, events: Aler
   await db.update(alertChannels)
     .set({ subscribedEvents: JSON.stringify(events) })
     .where(eq(alertChannels.id, channelId))
-  revalidatePath('/settings/alerts')
+  redirect('/settings/alerts?saved=1')
 }
 
 export async function saveChannelSubscriptions(channelId: string, formData: FormData): Promise<void> {


### PR DESCRIPTION
## Summary

- \`updateChannelSubscriptions\` now redirects to \`?saved=1\` instead of \`revalidatePath\` — triggers the existing "Channel saved." banner after clicking Save
- New \`SaveSubscriptionsButton\` client component using \`useFormStatus\`: disables the button and shows "Saving…" while the server action is in-flight; restores "Save" label on completion
- \`revalidatePath\` removed — \`redirect\` supersedes it (mirrors the existing \`deleteAlertChannel\` pattern)

## Test plan

- [ ] \`pnpm build\` — clean
- [ ] Open \`/settings/alerts\`, click Save on any channel — button shows "Saving…" briefly, then "Channel saved." toast appears
- [ ] No toast on hard-refresh (no \`?saved=1\` in URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)