### PR TITLE
feat(alerts): fire backup_succeeded/backup_failed for PBS sessions via internal webhook

### DIFF
--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -5,7 +5,7 @@ import { redirect } from 'next/navigation'
 import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, backupJobs, alertChannels, eq, desc } from '@backupos/db'
 import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult, type NotifyDelivery, type DatabaseRestoreDelivery } from '@backupos/restore'
 import { requireAdmin } from '@/lib/user'
-import { dispatchToChannel } from '@/lib/alerts'
+import { dispatchToChannel, fireRestoreSucceeded, fireRestoreFailed } from '@/lib/alerts'
 import type { AlertType, AlertPayload } from '@/lib/alerts'
 import { decryptField } from '@/lib/repo-crypto'
 import { connectedAgentIds, requestFilesystemRestore, requestDatabaseRestore, dispatch } from '@/lib/ws-state'
@@ -138,6 +138,17 @@ export async function runSpec(specId: string, snapshotId = 'latest'): Promise<vo
       .where(eq(restoreRuns.id, runId))
     try {
       if (result.success) {
+        await fireRestoreSucceeded(runId)
+      } else {
+        await fireRestoreFailed(runId, result.failedStep
+          ? `failed at step "${result.failedStep}"`
+          : 'restore failed')
+      }
+    } catch (err) {
+      console.error('[alerts] restore alert failed:', err)
+    }
+    try {
+      if (result.success) {
         appendLog({
           level: 'info',
           component: 'web',
@@ -161,6 +172,11 @@ export async function runSpec(specId: string, snapshotId = 'latest'): Promise<vo
     await db.update(restoreRuns).set({
       status: 'failed', completedAt: new Date(),
     }).where(eq(restoreRuns.id, runId))
+    try {
+      await fireRestoreFailed(runId, err instanceof Error ? err.message : String(err))
+    } catch (alertErr) {
+      console.error('[alerts] restore alert failed:', alertErr)
+    }
     console.error('[restore] executeRestoreSpec failed:', err)
     try {
       appendLog({

--- a/apps/web/app/api/internal/alerts/route.ts
+++ b/apps/web/app/api/internal/alerts/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { fireBackupSucceeded, fireBackupFailed } from '@/lib/alerts'
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const auth = req.headers.get('authorization')
+  const expected = process.env.BACKUPOS_INTERNAL_SECRET
+  if (!expected) {
+    console.error('[internal-alerts] BACKUPOS_INTERNAL_SECRET not set; rejecting')
+    return NextResponse.json({ error: 'internal auth not configured' }, { status: 503 })
+  }
+  if (auth !== `Bearer ${expected}`) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  let body: { event: string; runId?: string; error?: string }
+  try {
+    body = await req.json() as { event: string; runId?: string; error?: string }
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON' }, { status: 400 })
+  }
+
+  if (body.event === 'backup_succeeded' && body.runId) {
+    try {
+      await fireBackupSucceeded(body.runId)
+    } catch (err) {
+      console.error('[internal-alerts] fireBackupSucceeded failed:', err)
+      return NextResponse.json({ error: 'dispatch failed' }, { status: 500 })
+    }
+    return NextResponse.json({ ok: true })
+  }
+
+  if (body.event === 'backup_failed' && body.runId) {
+    try {
+      await fireBackupFailed(body.runId, body.error ?? 'PBS backup failed')
+    } catch (err) {
+      console.error('[internal-alerts] fireBackupFailed failed:', err)
+      return NextResponse.json({ error: 'dispatch failed' }, { status: 500 })
+    }
+    return NextResponse.json({ ok: true })
+  }
+
+  return NextResponse.json({ error: 'unknown event' }, { status: 400 })
+}

--- a/apps/web/lib/alerts.test.ts
+++ b/apps/web/lib/alerts.test.ts
@@ -102,3 +102,126 @@ describe('channelReceivesEvent', () => {
     expect(channelReceivesEvent(undefined, 'backup_failed')).toBe(true)
   })
 })
+
+// ── fire* helpers ─────────────────────────────────────────────────────────────
+// sendAlert is in the same ESM module, so we can't intercept the internal call
+// via vi.mock. Instead we fully stub getDb so sendAlert can run to completion,
+// then assert on what db.insert(alerts) received.
+
+import { vi, beforeEach } from 'vitest'
+
+vi.mock('@backupos/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@backupos/db')>()
+  return { ...actual, getDb: vi.fn() }
+})
+
+import { getDb } from '@backupos/db'
+import { fireBackupSucceeded, fireRestoreSucceeded, fireRestoreFailed } from './alerts'
+
+type InsertCall = { type: string; message: string; severity: string }
+
+function makeDb(selectRow: unknown) {
+  const insertedAlerts: InsertCall[] = []
+  const insertValues = vi.fn().mockImplementation((row: InsertCall) => {
+    insertedAlerts.push(row)
+    return Promise.resolve()
+  })
+
+  const selectQuery = {
+    from:     vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
+    where:    vi.fn().mockReturnThis(),
+    limit:    vi.fn().mockResolvedValue(selectRow === null ? [] : [selectRow]),
+    all:      vi.fn().mockResolvedValue([]), // channel list in sendAlert → empty = no dispatch
+  }
+
+  return {
+    db: {
+      select: vi.fn().mockReturnValue(selectQuery),
+      insert: vi.fn().mockReturnValue({ values: insertValues }),
+      update: vi.fn().mockReturnValue({ set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }) }),
+    },
+    insertedAlerts,
+  }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('fireBackupSucceeded', () => {
+  it('happy path — inserts backup_succeeded alert with correct message', async () => {
+    const { db, insertedAlerts } = makeDb({
+      jobId: 'j1', jobName: 'Daily VM', duration: 90000, totalSize: 536870912,
+    })
+    vi.mocked(getDb).mockReturnValue(db as never)
+    await fireBackupSucceeded('run-1')
+    expect(insertedAlerts).toHaveLength(1)
+    expect(insertedAlerts[0].type).toBe('backup_succeeded')
+    expect(insertedAlerts[0].message).toContain('"Daily VM" completed successfully')
+    expect(insertedAlerts[0].message).toContain('1m 30s')
+    expect(insertedAlerts[0].message).toContain('512.0 MB')
+  })
+
+  it('orphaned run (null jobId) — returns silently, no alert inserted', async () => {
+    const { db, insertedAlerts } = makeDb({ jobId: null, jobName: null, duration: null, totalSize: null })
+    vi.mocked(getDb).mockReturnValue(db as never)
+    await fireBackupSucceeded('run-orphan')
+    expect(insertedAlerts).toHaveLength(0)
+  })
+
+  it('missing row — returns silently, no alert inserted', async () => {
+    const { db, insertedAlerts } = makeDb(null)
+    vi.mocked(getDb).mockReturnValue(db as never)
+    await fireBackupSucceeded('run-missing')
+    expect(insertedAlerts).toHaveLength(0)
+  })
+})
+
+describe('fireRestoreSucceeded', () => {
+  it('happy path — inserts restore_succeeded alert with duration', async () => {
+    const startedAt   = new Date('2026-01-01T10:00:00Z')
+    const completedAt = new Date('2026-01-01T10:01:30Z')
+    const { db, insertedAlerts } = makeDb({ specId: 's1', specName: 'Weekly CT', startedAt, completedAt })
+    vi.mocked(getDb).mockReturnValue(db as never)
+    await fireRestoreSucceeded('rr-1')
+    expect(insertedAlerts).toHaveLength(1)
+    expect(insertedAlerts[0].type).toBe('restore_succeeded')
+    expect(insertedAlerts[0].message).toContain('"Weekly CT"')
+    expect(insertedAlerts[0].message).toContain('1m 30s')
+  })
+
+  it('no spec (ad-hoc) — uses fallback name', async () => {
+    const { db, insertedAlerts } = makeDb({ specId: null, specName: null, startedAt: null, completedAt: null })
+    vi.mocked(getDb).mockReturnValue(db as never)
+    await fireRestoreSucceeded('rr-2')
+    expect(insertedAlerts).toHaveLength(1)
+    expect(insertedAlerts[0].message).toContain('ad-hoc restore')
+  })
+
+  it('missing row — returns silently, no alert inserted', async () => {
+    const { db, insertedAlerts } = makeDb(null)
+    vi.mocked(getDb).mockReturnValue(db as never)
+    await fireRestoreSucceeded('rr-missing')
+    expect(insertedAlerts).toHaveLength(0)
+  })
+})
+
+describe('fireRestoreFailed', () => {
+  it('happy path — inserts restore_failed alert with error', async () => {
+    const { db, insertedAlerts } = makeDb({ specId: 's1', specName: 'Weekly CT' })
+    vi.mocked(getDb).mockReturnValue(db as never)
+    await fireRestoreFailed('rr-3', 'disk full')
+    expect(insertedAlerts).toHaveLength(1)
+    expect(insertedAlerts[0].type).toBe('restore_failed')
+    expect(insertedAlerts[0].message).toContain('"Weekly CT"')
+    expect(insertedAlerts[0].message).toContain('disk full')
+  })
+
+  it('missing row — uses fallback name, still fires alert', async () => {
+    const { db, insertedAlerts } = makeDb(null)
+    vi.mocked(getDb).mockReturnValue(db as never)
+    await fireRestoreFailed('rr-4', 'timeout')
+    expect(insertedAlerts).toHaveLength(1)
+    expect(insertedAlerts[0].message).toContain('ad-hoc restore')
+    expect(insertedAlerts[0].message).toContain('timeout')
+  })
+})

--- a/apps/web/lib/alerts.ts
+++ b/apps/web/lib/alerts.ts
@@ -1,5 +1,5 @@
 import nodemailer from 'nodemailer'
-import { getDb, alerts, alertChannels, smtpConfig, eq } from '@backupos/db'
+import { getDb, alerts, alertChannels, smtpConfig, backupRuns, backupJobs, restoreRuns, restoreSpecs, eq } from '@backupos/db'
 import { decryptField } from './repo-crypto'
 
 export type AlertType =
@@ -374,4 +374,65 @@ export async function sendAlert(type: AlertType, payload: AlertPayload): Promise
   } catch (err) {
     console.error('[alerts] email delivery failed:', err)
   }
+}
+
+export async function fireBackupSucceeded(runId: string): Promise<void> {
+  const db = getDb()
+  const [row] = await db.select({
+    jobId:     backupRuns.jobId,
+    jobName:   backupJobs.name,
+    duration:  backupRuns.duration,
+    totalSize: backupRuns.totalSize,
+  })
+    .from(backupRuns)
+    .leftJoin(backupJobs, eq(backupRuns.jobId, backupJobs.id))
+    .where(eq(backupRuns.id, runId))
+    .limit(1)
+  if (!row?.jobId) return
+  await sendAlert('backup_succeeded', {
+    jobId:          row.jobId,
+    jobName:        row.jobName ?? 'unknown',
+    durationSec:    row.duration != null ? Math.round(row.duration / 1000) : null,
+    totalSizeBytes: row.totalSize ?? null,
+  })
+}
+
+export async function fireRestoreSucceeded(runId: string): Promise<void> {
+  const db = getDb()
+  const [row] = await db.select({
+    specId:      restoreRuns.specId,
+    specName:    restoreSpecs.name,
+    startedAt:   restoreRuns.startedAt,
+    completedAt: restoreRuns.completedAt,
+  })
+    .from(restoreRuns)
+    .leftJoin(restoreSpecs, eq(restoreRuns.specId, restoreSpecs.id))
+    .where(eq(restoreRuns.id, runId))
+    .limit(1)
+  if (!row) return
+  const durationSec = (row.startedAt && row.completedAt)
+    ? Math.round((row.completedAt.getTime() - row.startedAt.getTime()) / 1000)
+    : null
+  await sendAlert('restore_succeeded', {
+    runId,
+    jobName:     row.specName ?? 'ad-hoc restore',
+    durationSec,
+  })
+}
+
+export async function fireRestoreFailed(runId: string, error: string): Promise<void> {
+  const db = getDb()
+  const [row] = await db.select({
+    specId:   restoreRuns.specId,
+    specName: restoreSpecs.name,
+  })
+    .from(restoreRuns)
+    .leftJoin(restoreSpecs, eq(restoreRuns.specId, restoreSpecs.id))
+    .where(eq(restoreRuns.id, runId))
+    .limit(1)
+  await sendAlert('restore_failed', {
+    runId,
+    jobName: row?.specName ?? 'ad-hoc restore',
+    error,
+  })
 }

--- a/apps/web/lib/alerts.ts
+++ b/apps/web/lib/alerts.ts
@@ -436,3 +436,21 @@ export async function fireRestoreFailed(runId: string, error: string): Promise<v
     error,
   })
 }
+
+export async function fireBackupFailed(runId: string, error: string): Promise<void> {
+  const db = getDb()
+  const [row] = await db.select({
+    jobId:   backupRuns.jobId,
+    jobName: backupJobs.name,
+  })
+    .from(backupRuns)
+    .leftJoin(backupJobs, eq(backupRuns.jobId, backupJobs.id))
+    .where(eq(backupRuns.id, runId))
+    .limit(1)
+  if (!row?.jobId) return
+  await sendAlert('backup_failed', {
+    jobId:   row.jobId,
+    jobName: row.jobName ?? 'unknown',
+    error,
+  })
+}

--- a/apps/web/lib/internal-alerts-route.test.ts
+++ b/apps/web/lib/internal-alerts-route.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@backupos/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@backupos/db')>()
+  return { ...actual, getDb: vi.fn() }
+})
+
+vi.mock('@/lib/alerts', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@/lib/alerts')>()
+  return {
+    ...mod,
+    fireBackupSucceeded: vi.fn().mockResolvedValue(undefined),
+    fireBackupFailed:    vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/internal/alerts/route'
+import { fireBackupSucceeded, fireBackupFailed } from '@/lib/alerts'
+
+const SECRET = 'test-secret-abc'
+
+function makeReq(body: unknown, authHeader?: string): NextRequest {
+  return new NextRequest('http://localhost/api/internal/alerts', {
+    method:  'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(authHeader !== undefined ? { Authorization: authHeader } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.BACKUPOS_INTERNAL_SECRET = SECRET
+})
+
+describe('POST /api/internal/alerts', () => {
+  it('503 when BACKUPOS_INTERNAL_SECRET not set', async () => {
+    delete process.env.BACKUPOS_INTERNAL_SECRET
+    const res = await POST(makeReq({ event: 'backup_succeeded', runId: 'r1' }, `Bearer ${SECRET}`))
+    expect(res.status).toBe(503)
+  })
+
+  it('401 when Authorization header missing', async () => {
+    const res = await POST(makeReq({ event: 'backup_succeeded', runId: 'r1' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('401 when Authorization header is wrong', async () => {
+    const res = await POST(makeReq({ event: 'backup_succeeded', runId: 'r1' }, 'Bearer wrong'))
+    expect(res.status).toBe(401)
+  })
+
+  it('dispatches backup_succeeded and returns 200', async () => {
+    const res = await POST(makeReq({ event: 'backup_succeeded', runId: 'r1' }, `Bearer ${SECRET}`))
+    expect(res.status).toBe(200)
+    expect(vi.mocked(fireBackupSucceeded)).toHaveBeenCalledWith('r1')
+  })
+
+  it('dispatches backup_failed with error and returns 200', async () => {
+    const res = await POST(makeReq({ event: 'backup_failed', runId: 'r2', error: 'disk full' }, `Bearer ${SECRET}`))
+    expect(res.status).toBe(200)
+    expect(vi.mocked(fireBackupFailed)).toHaveBeenCalledWith('r2', 'disk full')
+  })
+
+  it('backup_failed uses default error message when error field absent', async () => {
+    const res = await POST(makeReq({ event: 'backup_failed', runId: 'r3' }, `Bearer ${SECRET}`))
+    expect(res.status).toBe(200)
+    expect(vi.mocked(fireBackupFailed)).toHaveBeenCalledWith('r3', 'PBS backup failed')
+  })
+
+  it('400 for unknown event type', async () => {
+    const res = await POST(makeReq({ event: 'restore_succeeded', runId: 'r4' }, `Bearer ${SECRET}`))
+    expect(res.status).toBe(400)
+    expect(vi.mocked(fireBackupSucceeded)).not.toHaveBeenCalled()
+    expect(vi.mocked(fireBackupFailed)).not.toHaveBeenCalled()
+  })
+
+  it('400 for invalid JSON body', async () => {
+    const req = new NextRequest('http://localhost/api/internal/alerts', {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${SECRET}` },
+      body:    'not-json',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+})

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -14,7 +14,7 @@ import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTe
 import { ensureRepoMountedOnAgent } from './lib/repo-mount'
 import { loadOrCreateInternalToken } from './lib/internal-token'
 import { decryptField } from './lib/repo-crypto'
-import { sendAlert } from './lib/alerts'
+import { sendAlert, fireBackupSucceeded, fireRestoreSucceeded, fireRestoreFailed } from './lib/alerts'
 import { appendLog } from './lib/logger'
 import { auth } from './lib/auth'
 import type { AgentMessage, ServerMessage, MountConfig } from '@backupos/agent-protocol'
@@ -569,6 +569,11 @@ void app.prepare().then(() => {
             totalSize:       msg.stats.totalBytesProcessed,
             duration:        msg.stats.durationMs,
           }).where(eq(backupRuns.id, run.id))
+          try {
+            await fireBackupSucceeded(run.id)
+          } catch (err) {
+            console.error('[alerts] fireBackupSucceeded failed:', err)
+          }
           const [jobForNext] = await db.select({ schedule: backupJobs.schedule, name: backupJobs.name })
             .from(backupJobs).where(eq(backupJobs.id, msg.jobId)).limit(1)
           const jobLabel = jobForNext?.name ?? msg.jobId
@@ -781,6 +786,15 @@ void app.prepare().then(() => {
             resourceType: 'restore_run', resourceId: msg.restoreId,
             actor: agentId, createdAt: new Date(),
           })
+          try {
+            if (msg.success) {
+              await fireRestoreSucceeded(msg.restoreId)
+            } else {
+              await fireRestoreFailed(msg.restoreId, 'restore failed')
+            }
+          } catch (err) {
+            console.error('[alerts] restore alert failed:', err)
+          }
 
         } else if (msg.type === 'filesystem_restore_cancelled' && agentId) {
           console.log(`[restore] filesystem_restore_cancelled restoreId=${msg.restoreId} agentId=${agentId} reason=${msg.reason}`)
@@ -827,6 +841,15 @@ void app.prepare().then(() => {
             resourceType: 'restore_run', resourceId: msg.restoreId,
             actor: agentId, createdAt: new Date(),
           })
+          try {
+            if (msg.success) {
+              await fireRestoreSucceeded(msg.restoreId)
+            } else {
+              await fireRestoreFailed(msg.restoreId, msg.error ?? 'filesystem restore failed')
+            }
+          } catch (err) {
+            console.error('[alerts] restore alert failed:', err)
+          }
         }
       })()
     })

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, '.'),
+    },
+  },
   test: {
     include: ['lib/**/*.test.ts'],
   },

--- a/scripts/server-install.sh
+++ b/scripts/server-install.sh
@@ -319,6 +319,17 @@ else
   ok "Environment file already exists (keeping existing secrets)"
 fi
 
+# Generate internal API secret for cross-process auth (web ↔ pbs)
+if ! grep -q '^BACKUPOS_INTERNAL_SECRET=' "$ENV_FILE" 2>/dev/null; then
+  SECRET=$(openssl rand -hex 32)
+  echo "BACKUPOS_INTERNAL_SECRET=${SECRET}" >> "$ENV_FILE"
+  echo "[backupos] Generated BACKUPOS_INTERNAL_SECRET"
+fi
+if ! grep -q '^BACKUPOS_INTERNAL_URL=' "$ENV_FILE" 2>/dev/null; then
+  echo "BACKUPOS_INTERNAL_URL=http://127.0.0.1:3093" >> "$ENV_FILE"
+  echo "[backupos] Set BACKUPOS_INTERNAL_URL"
+fi
+
 # ── 7. Log rotation ───────────────────────────────────────────────────────────
 cat > /etc/logrotate.d/$SERVICE_NAME <<LREOF
 $LOG_DIR/*.log {
@@ -383,6 +394,7 @@ Wants=network-online.target
 Type=simple
 User=$SVC_USER
 Group=$SVC_USER
+EnvironmentFile=$ENV_FILE
 ExecStart=$INSTALL_DIR/bin/backupos-pbs \\
   --bind $PBS_BIND \\
   --cert $DATA_DIR/pbs/cert.pem \\

--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/blob"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/jobsync"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/db"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/dynamicappend"
@@ -95,6 +96,16 @@ func main() {
 		"release", releaseString,
 		"bind", *bind,
 	)
+
+	// Wire internal webhook for PBS → web alert delivery.
+	internalURL := os.Getenv("BACKUPOS_INTERNAL_URL")
+	internalSecret := os.Getenv("BACKUPOS_INTERNAL_SECRET")
+	if internalURL == "" || internalSecret == "" {
+		slog.Warn("BACKUPOS_INTERNAL_URL or BACKUPOS_INTERNAL_SECRET not set; PBS alerts will not fire")
+	} else {
+		jobsync.SetWebhookConfig(internalURL, internalSecret)
+		slog.Info("internal webhook configured", "url", internalURL)
+	}
 
 	// Open the SQLite database (read+write, WAL mode handled by Node side).
 	database, err := db.Open(*dbPath)

--- a/services/backupos-pbs/internal/jobsync/jobsync.go
+++ b/services/backupos-pbs/internal/jobsync/jobsync.go
@@ -8,15 +8,30 @@
 package jobsync
 
 import (
+	"bytes"
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/namespace"
 )
+
+var (
+	internalURL    string
+	internalSecret string
+)
+
+// SetWebhookConfig configures the internal webhook target.
+// Called once at startup from main.go. Empty url disables webhook.
+func SetWebhookConfig(url, secret string) {
+	internalURL = url
+	internalSecret = secret
+}
 
 // JobID returns the deterministic synthetic Job ID for a backup tuple.
 // Format: pbs_<datastoreID>_<namespace_or_root>_<backupType>_<backupID>
@@ -106,7 +121,64 @@ func FinishRun(db *sql.DB, runID, jobID, status string, snapshotID, errorMessage
 	if _, err := db.Exec(updateJob, completedAt.UnixMilli(), status, jobID); err != nil {
 		return fmt.Errorf("update job: %w", err)
 	}
+	fireWebhook(runID, status, errorMessage)
 	return nil
+}
+
+// fireWebhook is best-effort: never blocks the FinishRun success path,
+// even on network/auth errors. Logged loudly so deployment misconfigs
+// are visible. No retries — alerts are nice-to-have, not critical path.
+func fireWebhook(runID, status string, errMsg *string) {
+	if internalURL == "" || internalSecret == "" {
+		return // not configured; e.g. test environment
+	}
+
+	var event string
+	switch status {
+	case "success":
+		event = "backup_succeeded"
+	case "failed":
+		event = "backup_failed"
+	default:
+		return // running, cancelled, etc.
+	}
+
+	body := map[string]string{
+		"event": event,
+		"runId": runID,
+	}
+	if errMsg != nil {
+		body["error"] = *errMsg
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		slog.Error("jobsync: webhook marshal failed", "error", err)
+		return
+	}
+
+	req, err := http.NewRequest(http.MethodPost,
+		internalURL+"/api/internal/alerts",
+		bytes.NewReader(payload))
+	if err != nil {
+		slog.Error("jobsync: webhook request build failed", "error", err)
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+internalSecret)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Error("jobsync: webhook delivery failed", "error", err, "url", internalURL)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		slog.Error("jobsync: webhook returned non-2xx",
+			"status", resp.StatusCode, "run_id", runID)
+	}
 }
 
 func nullableString(s *string) sql.NullString {

--- a/services/backupos-pbs/internal/jobsync/jobsync_test.go
+++ b/services/backupos-pbs/internal/jobsync/jobsync_test.go
@@ -2,6 +2,11 @@ package jobsync
 
 import (
 	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -227,4 +232,107 @@ func TestFinishRun_DurationCalculation(t *testing.T) {
 	if duration != 90 {
 		t.Errorf("duration: got %d, want 90", duration)
 	}
+}
+
+// ── webhook tests ─────────────────────────────────────────────────────────────
+
+func resetWebhookConfig(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		internalURL = ""
+		internalSecret = ""
+	})
+}
+
+func TestFireWebhook_SuccessStatus(t *testing.T) {
+	resetWebhookConfig(t)
+
+	var received atomic.Int32
+	var gotBody map[string]string
+	var gotAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	SetWebhookConfig(srv.URL, "test-secret")
+	fireWebhook("run-1", "success", nil)
+
+	if received.Load() != 1 {
+		t.Fatalf("expected 1 request, got %d", received.Load())
+	}
+	if gotAuth != "Bearer test-secret" {
+		t.Errorf("auth header: got %q, want %q", gotAuth, "Bearer test-secret")
+	}
+	if gotBody["event"] != "backup_succeeded" {
+		t.Errorf("event: got %q, want backup_succeeded", gotBody["event"])
+	}
+	if gotBody["runId"] != "run-1" {
+		t.Errorf("runId: got %q, want run-1", gotBody["runId"])
+	}
+}
+
+func TestFireWebhook_FailedStatus(t *testing.T) {
+	resetWebhookConfig(t)
+
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	SetWebhookConfig(srv.URL, "test-secret")
+	errMsg := "disk full"
+	fireWebhook("run-2", "failed", &errMsg)
+
+	if gotBody["event"] != "backup_failed" {
+		t.Errorf("event: got %q, want backup_failed", gotBody["event"])
+	}
+	if gotBody["error"] != "disk full" {
+		t.Errorf("error: got %q, want disk full", gotBody["error"])
+	}
+}
+
+func TestFireWebhook_UnknownStatus_NoOp(t *testing.T) {
+	resetWebhookConfig(t)
+
+	var received atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	SetWebhookConfig(srv.URL, "test-secret")
+	fireWebhook("run-3", "cancelled", nil)
+
+	if received.Load() != 0 {
+		t.Errorf("expected 0 requests for cancelled status, got %d", received.Load())
+	}
+}
+
+func TestFireWebhook_NoConfig_NoOp(t *testing.T) {
+	resetWebhookConfig(t)
+	// internalURL and internalSecret are empty — must not panic
+	fireWebhook("run-4", "success", nil)
+}
+
+func TestFireWebhook_AuthFailure_LogsButDoesntPanic(t *testing.T) {
+	resetWebhookConfig(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	SetWebhookConfig(srv.URL, "wrong-secret")
+	// Must not panic; non-2xx is logged and swallowed
+	fireWebhook("run-5", "success", nil)
 }


### PR DESCRIPTION
## Summary

- **`scripts/server-install.sh`**: generates `BACKUPOS_INTERNAL_SECRET` (32-byte hex) and sets `BACKUPOS_INTERNAL_URL=http://127.0.0.1:3093` on first install; adds `EnvironmentFile` to the PBS systemd unit so it sources the shared env file alongside the web service
- **`apps/web/app/api/internal/alerts/route.ts`**: new `POST /api/internal/alerts` endpoint with Bearer auth; dispatches `backup_succeeded` / `backup_failed` via `fire*` helpers
- **`apps/web/lib/alerts.ts`**: adds `fireBackupFailed` helper (mirrors `fireBackupSucceeded` from PR B)
- **`services/backupos-pbs/internal/jobsync/jobsync.go`**: `SetWebhookConfig` + best-effort `fireWebhook` (5s timeout, logs non-2xx, never blocks `FinishRun`)
- **`services/backupos-pbs/cmd/backupos-pbs/main.go`**: reads env vars and calls `SetWebhookConfig`; warns at startup if vars are missing
- 5 new Go webhook tests (httptest.Server); 8 new TS route tests; 60 total TS tests pass
- `vitest.config.ts`: adds `@/` path alias so route handler tests can import from `app/`

## Depends on

PR #300 (merged) + PR #301 (open, cherry-picked onto this branch). Merge #301 first, then this.

## Go tests note

Go is not installed on the dev machine. Go tests (`TestFireWebhook_*`) are syntactically correct and must be verified in CI (`go test ./services/backupos-pbs/...`).

## End-to-end smoke test (after merge)

1. Configure a Discord/webhook channel in `/settings/alerts`
2. Subscribe it to `backup_succeeded`
3. Trigger a PVE backup of CT 202
4. Verify alert lands in Discord: `Backup job "PVE: ct/202" completed successfully in 19s`

## Cancelled path

`fireWebhook` returns early for any status other than `success` or `failed` — cancelled/running sessions produce no alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)