### PR TITLE
feat(alerts): encrypt sensitive credentials in alert_channels.config (#157)

### DIFF
--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from 'next/cache'
 import { getDb, alerts, alertChannels, eq } from '@backupos/db'
 import { requireAdmin } from '@/lib/user'
 import { dispatchToChannel, ALL_ALERT_TYPES, type AlertType } from '@/lib/alerts'
+import { encryptChannelConfig } from '@/lib/alert-channel-crypto'
 
 const VALID_CHANNEL_TYPES = [
   'discord', 'slack', 'webhook',
@@ -84,7 +85,7 @@ export async function createAlertChannel(formData: FormData): Promise<void> {
     id: crypto.randomUUID(),
     name,
     type,
-    config: JSON.stringify(config),
+    config: JSON.stringify(encryptChannelConfig(type, config)),
     enabled: true,
     createdAt: new Date(),
   })
@@ -111,7 +112,7 @@ export async function createAlertChannelForType(integType: string, formData: For
     id: crypto.randomUUID(),
     name,
     type: integType,
-    config: JSON.stringify(config),
+    config: JSON.stringify(encryptChannelConfig(integType, config)),
     enabled: true,
     createdAt: new Date(),
   })
@@ -152,7 +153,7 @@ export async function testAlertChannel(input: TestAlertChannelInput): Promise<Te
     if (!input.config || Object.keys(input.config).length === 0) {
       return { ok: false, error: 'Missing configuration fields' }
     }
-    testChannel = { id: 'test', type: input.type, config: JSON.stringify(input.config) }
+    testChannel = { id: 'test', type: input.type, config: JSON.stringify(encryptChannelConfig(input.type, input.config)) }
   }
 
   const message = 'BackupOS test message — if you can read this, your channel is configured correctly.'

--- a/apps/web/lib/alert-channel-crypto.test.ts
+++ b/apps/web/lib/alert-channel-crypto.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { encryptChannelConfig, decryptChannelConfig } from './alert-channel-crypto'
+
+beforeAll(() => {
+  process.env.ENCRYPTION_KEY = '0'.repeat(64)
+})
+
+describe('encryptChannelConfig', () => {
+  it('discord — encrypts url', () => {
+    const out = encryptChannelConfig('discord', { url: 'https://discord.com/api/webhooks/123/secret' })
+    expect(out.url).toMatch(/^enc:v1:/)
+  })
+
+  it('zulip — encrypts apiKey only, leaves url/email/stream plaintext', () => {
+    const out = encryptChannelConfig('zulip', {
+      url:     'https://zulip.example.com',
+      email:   'bot@example.com',
+      apiKey:  'super-secret',
+      stream:  'ops',
+      topic:   'alerts',
+    })
+    expect(out.url).toBe('https://zulip.example.com')
+    expect(out.email).toBe('bot@example.com')
+    expect(out.stream).toBe('ops')
+    expect(out.topic).toBe('alerts')
+    expect(out.apiKey).toMatch(/^enc:v1:/)
+  })
+
+  it('pushover — encrypts both apiToken and userKey', () => {
+    const out = encryptChannelConfig('pushover', { apiToken: 'a', userKey: 'b' })
+    expect(out.apiToken).toMatch(/^enc:v1:/)
+    expect(out.userKey).toMatch(/^enc:v1:/)
+  })
+
+  it('idempotent — does not double-encrypt already-encrypted values', () => {
+    const once = encryptChannelConfig('discord', { url: 'https://example.com/secret' })
+    const twice = encryptChannelConfig('discord', once)
+    expect(twice.url).toBe(once.url)
+  })
+
+  it('unknown channel type — passes through unchanged', () => {
+    const cfg = { someField: 'value' }
+    const out = encryptChannelConfig('not-a-real-type', cfg)
+    expect(out).toEqual(cfg)
+  })
+
+  it('missing sensitive field — does not error', () => {
+    const out = encryptChannelConfig('discord', {})
+    expect(out).toEqual({})
+  })
+
+  it('non-string value in sensitive field — passes through', () => {
+    const out = encryptChannelConfig('discord', { url: 12345 as unknown as string })
+    expect(out.url).toBe(12345)
+  })
+})
+
+describe('decryptChannelConfig', () => {
+  it('round-trips encrypt then decrypt', () => {
+    const original = {
+      url:    'https://zulip.example.com',
+      email:  'bot@example.com',
+      apiKey: 'super-secret',
+      stream: 'ops',
+    }
+    const encrypted = encryptChannelConfig('zulip', original)
+    const decrypted = decryptChannelConfig('zulip', encrypted)
+    expect(decrypted).toEqual(original)
+  })
+
+  it('plaintext input — passes through (back-compat for un-migrated rows)', () => {
+    const out = decryptChannelConfig('discord', { url: 'https://example.com/plaintext' })
+    expect(out.url).toBe('https://example.com/plaintext')
+  })
+
+  it('unknown channel type — passes through', () => {
+    const out = decryptChannelConfig('mystery', { foo: 'bar' })
+    expect(out).toEqual({ foo: 'bar' })
+  })
+
+  it('corrupt ciphertext — throws (caller catches)', () => {
+    expect(() =>
+      decryptChannelConfig('discord', { url: 'enc:v1:not-real-base64' }),
+    ).toThrow()
+  })
+})

--- a/apps/web/lib/alert-channel-crypto.ts
+++ b/apps/web/lib/alert-channel-crypto.ts
@@ -1,0 +1,118 @@
+import { encryptField, decryptField } from './repo-crypto'
+
+const SENSITIVE_FIELDS: Record<string, readonly string[]> = {
+  discord:   ['url'],
+  slack:     ['url'],
+  webhook:   ['url'],
+  zulip:     ['apiKey'],
+  telegram:  ['botToken'],
+  pagerduty: ['integrationKey'],
+  ntfy:      ['auth'],
+  gotify:    ['appToken'],
+  pushover:  ['apiToken', 'userKey'],
+}
+
+/**
+ * Encrypt sensitive fields in an alert channel config object before serializing
+ * to the alert_channels.config JSON column.
+ *
+ * Idempotent: encryptField passes through values that already start with `enc:v1:`.
+ */
+export function encryptChannelConfig(
+  type: string,
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  const sensitive = SENSITIVE_FIELDS[type]
+  if (!sensitive) return config
+  const out: Record<string, unknown> = { ...config }
+  for (const field of sensitive) {
+    const value = out[field]
+    if (typeof value === 'string' && value.length > 0) {
+      out[field] = encryptField(value)
+    }
+  }
+  return out
+}
+
+/**
+ * Decrypt sensitive fields in an alert channel config object after parsing
+ * the alert_channels.config JSON column.
+ *
+ * decryptField returns the input unchanged if it is already plaintext, so
+ * mixed plaintext/ciphertext rows (during the migration window) work.
+ *
+ * Throws if any sensitive field has a corrupt ciphertext. The caller in
+ * dispatchToChannel catches this and skips that channel rather than failing
+ * the whole sendAlert.
+ */
+export function decryptChannelConfig(
+  type: string,
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  const sensitive = SENSITIVE_FIELDS[type]
+  if (!sensitive) return config
+  const out: Record<string, unknown> = { ...config }
+  for (const field of sensitive) {
+    const value = out[field]
+    if (typeof value === 'string' && value.length > 0) {
+      out[field] = decryptField(value)
+    }
+  }
+  return out
+}
+
+/**
+ * One-time migration. Reads every row in alert_channels, encrypts any
+ * sensitive fields that aren't already encrypted, and writes back.
+ *
+ * Idempotent: re-running is a no-op (encryptField passes through enc:v1:
+ * values). Safe to call on every server startup.
+ *
+ * Logs (not throws) per-row failures so a single corrupt row doesn't block
+ * boot.
+ */
+export async function migrateAlertChannelEncryption(): Promise<void> {
+  const { getDb, alertChannels, eq } = await import('@backupos/db')
+  const db = getDb()
+
+  const rows = await db.select().from(alertChannels).all()
+  let migrated = 0
+  let skipped = 0
+  let failed = 0
+
+  for (const row of rows) {
+    try {
+      const cfg = JSON.parse(row.config) as Record<string, unknown>
+      const sensitive = SENSITIVE_FIELDS[row.type]
+      if (!sensitive) {
+        skipped++
+        continue
+      }
+      const needsMigration = sensitive.some(field => {
+        const v = cfg[field]
+        return typeof v === 'string' && v.length > 0 && !v.startsWith('enc:v1:')
+      })
+      if (!needsMigration) {
+        skipped++
+        continue
+      }
+      const encrypted = encryptChannelConfig(row.type, cfg)
+      await db.update(alertChannels)
+        .set({ config: JSON.stringify(encrypted) })
+        .where(eq(alertChannels.id, row.id))
+      migrated++
+    } catch (err) {
+      console.error(
+        `[alert-channel-crypto] migration failed for channel ${row.id} (${row.type}):`,
+        err,
+      )
+      failed++
+    }
+  }
+
+  if (migrated > 0 || failed > 0) {
+    console.log(
+      `[alert-channel-crypto] migrated=${migrated} skipped=${skipped} failed=${failed}`,
+    )
+  }
+}

--- a/apps/web/lib/alerts.ts
+++ b/apps/web/lib/alerts.ts
@@ -1,6 +1,7 @@
 import nodemailer from 'nodemailer'
 import { getDb, alerts, alertChannels, smtpConfig, backupRuns, backupJobs, restoreRuns, restoreSpecs, eq } from '@backupos/db'
 import { decryptField } from './repo-crypto'
+import { decryptChannelConfig } from './alert-channel-crypto'
 
 export type AlertType =
   | 'backup_failed'
@@ -325,7 +326,17 @@ export async function dispatchToChannel(
   severity: string,
   payload: AlertPayload,
 ): Promise<void> {
-  const cfg = JSON.parse(channel.config) as Record<string, unknown>
+  let cfg: Record<string, unknown>
+  try {
+    const parsed = JSON.parse(channel.config) as Record<string, unknown>
+    cfg = decryptChannelConfig(channel.type, parsed)
+  } catch (err) {
+    console.error(
+      `[alerts] channel ${channel.id} (${channel.type}) config decrypt failed; skipping dispatch:`,
+      err,
+    )
+    return
+  }
   const url = (cfg.url as string | undefined) ?? ''
 
   if      (channel.type === 'discord')   await fireDiscord(url, type, message, severity)

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -15,6 +15,7 @@ import { ensureRepoMountedOnAgent } from './lib/repo-mount'
 import { loadOrCreateInternalToken } from './lib/internal-token'
 import { decryptField } from './lib/repo-crypto'
 import { sendAlert, fireBackupSucceeded, fireRestoreSucceeded, fireRestoreFailed } from './lib/alerts'
+import { migrateAlertChannelEncryption } from './lib/alert-channel-crypto'
 import { appendLog } from './lib/logger'
 import { auth } from './lib/auth'
 import type { AgentMessage, ServerMessage, MountConfig } from '@backupos/agent-protocol'
@@ -138,7 +139,9 @@ function getBundleHash(): string {
 const BUNDLE_HASH = getBundleHash()
 console.log('[server] bundle hash:', BUNDLE_HASH || '(not found)')
 
-void app.prepare().then(() => {
+void app.prepare().then(async () => {
+  await migrateAlertChannelEncryption()
+
   const server = createServer((req, res) => {
     const parsed = parse(req.url!, true)
 


### PR DESCRIPTION
## Summary

- Adds `apps/web/lib/alert-channel-crypto.ts` with `encryptChannelConfig`, `decryptChannelConfig`, and `migrateAlertChannelEncryption` using AES-256-GCM via the existing `repo-crypto` helpers
- Encrypts webhook URLs, bot tokens, API keys, and other secrets at all 3 write sites in `actions/alerts.ts`; decrypts transparently in `dispatchToChannel` in `lib/alerts.ts`
- Runs a one-time idempotent startup migration in `server.ts` (after `runMigrations()`) to back-encrypt existing plaintext rows

## Test plan

- [x] 11 unit tests in `alert-channel-crypto.test.ts` pass (round-trip, idempotency, back-compat plaintext, corrupt ciphertext throws, unknown type passthrough)
- [x] `pnpm --filter @backupos/web build` clean
- [ ] After deploy: `SELECT config FROM alert_channels` shows `enc:v1:` prefixed values for sensitive fields
- [ ] Existing channels continue to deliver alerts after migration (smoke test: trigger a backup, confirm channel receives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)