### PR TITLE
feat(security): ENCRYPTION_KEY_FILE support and SECURITY.md (#188 docs+keyfile)

### DIFF
--- a/apps/web/lib/repo-crypto.test.ts
+++ b/apps/web/lib/repo-crypto.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { encryptField, decryptField } from './repo-crypto'
+
+const VALID_HEX = '0'.repeat(64)
+let savedKey: string | undefined
+let savedKeyFile: string | undefined
+let tmpDir: string
+
+beforeEach(() => {
+  savedKey     = process.env.ENCRYPTION_KEY
+  savedKeyFile = process.env.ENCRYPTION_KEY_FILE
+  tmpDir       = mkdtempSync(join(tmpdir(), 'backupos-key-'))
+})
+
+afterEach(() => {
+  if (savedKey === undefined) delete process.env.ENCRYPTION_KEY
+  else process.env.ENCRYPTION_KEY = savedKey
+  if (savedKeyFile === undefined) delete process.env.ENCRYPTION_KEY_FILE
+  else process.env.ENCRYPTION_KEY_FILE = savedKeyFile
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('getKey via ENCRYPTION_KEY env', () => {
+  it('round-trips an encrypted value', () => {
+    delete process.env.ENCRYPTION_KEY_FILE
+    process.env.ENCRYPTION_KEY = VALID_HEX
+    const enc = encryptField('hello')
+    expect(decryptField(enc)).toBe('hello')
+  })
+
+  it('throws when env is too short', () => {
+    delete process.env.ENCRYPTION_KEY_FILE
+    process.env.ENCRYPTION_KEY = 'abcd'
+    expect(() => encryptField('x')).toThrow(/ENCRYPTION_KEY/)
+  })
+
+  it('throws when env is unset and file is unset', () => {
+    delete process.env.ENCRYPTION_KEY_FILE
+    delete process.env.ENCRYPTION_KEY
+    expect(() => encryptField('x')).toThrow(/ENCRYPTION_KEY/)
+  })
+})
+
+describe('getKey via ENCRYPTION_KEY_FILE', () => {
+  it('reads key from file path', () => {
+    const path = join(tmpDir, 'key.hex')
+    writeFileSync(path, VALID_HEX, 'utf8')
+    process.env.ENCRYPTION_KEY_FILE = path
+    delete process.env.ENCRYPTION_KEY
+    const enc = encryptField('hello')
+    expect(decryptField(enc)).toBe('hello')
+  })
+
+  it('trims trailing whitespace/newline (echo $KEY > path style)', () => {
+    const path = join(tmpDir, 'key.hex')
+    writeFileSync(path, VALID_HEX + '\n', 'utf8')
+    process.env.ENCRYPTION_KEY_FILE = path
+    delete process.env.ENCRYPTION_KEY
+    expect(decryptField(encryptField('hello'))).toBe('hello')
+  })
+
+  it('file path takes precedence over env when both are set', () => {
+    const path = join(tmpDir, 'key.hex')
+    writeFileSync(path, VALID_HEX, 'utf8')
+    process.env.ENCRYPTION_KEY_FILE = path
+    process.env.ENCRYPTION_KEY = 'f'.repeat(64)
+    const enc = encryptField('precedence')
+    expect(decryptField(enc)).toBe('precedence')
+  })
+
+  it('throws a clear error when file path does not exist', () => {
+    process.env.ENCRYPTION_KEY_FILE = join(tmpDir, 'does-not-exist')
+    delete process.env.ENCRYPTION_KEY
+    expect(() => encryptField('x')).toThrow(/Failed to read ENCRYPTION_KEY_FILE/)
+  })
+
+  it('throws when file contents are too short', () => {
+    const path = join(tmpDir, 'key.hex')
+    writeFileSync(path, 'abcd', 'utf8')
+    process.env.ENCRYPTION_KEY_FILE = path
+    delete process.env.ENCRYPTION_KEY
+    expect(() => encryptField('x')).toThrow(/ENCRYPTION_KEY_FILE/)
+  })
+})

--- a/apps/web/lib/repo-crypto.ts
+++ b/apps/web/lib/repo-crypto.ts
@@ -1,8 +1,39 @@
 import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
+import { readFileSync } from 'node:fs'
 
+/**
+ * Resolve the encryption key.
+ *
+ * Source order (first match wins):
+ *   1. ENCRYPTION_KEY_FILE — path to a file containing the hex key. Useful
+ *      with systemd LoadCredential= which exposes secrets at /run/credentials/...
+ *   2. ENCRYPTION_KEY — hex key directly in env.
+ *
+ * Either source must yield at least 64 hex chars (32 bytes). Whitespace
+ * around the value (newlines, etc.) is trimmed before validation so a file
+ * created with `echo "$KEY" > /path` works.
+ */
 function getKey(): Buffer {
-  const hex = process.env['ENCRYPTION_KEY'] ?? ''
-  if (hex.length < 64) throw new Error('ENCRYPTION_KEY must be at least 32 bytes (64 hex chars)')
+  const filePath = process.env['ENCRYPTION_KEY_FILE']
+  let hex: string
+
+  if (filePath && filePath.length > 0) {
+    try {
+      hex = readFileSync(filePath, 'utf8').trim()
+    } catch (err) {
+      throw new Error(
+        `Failed to read ENCRYPTION_KEY_FILE at ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+  } else {
+    hex = (process.env['ENCRYPTION_KEY'] ?? '').trim()
+  }
+
+  if (hex.length < 64) {
+    const source = filePath ? `ENCRYPTION_KEY_FILE (${filePath})` : 'ENCRYPTION_KEY'
+    throw new Error(`${source} must contain at least 32 bytes (64 hex chars)`)
+  }
+
   return Buffer.from(hex.slice(0, 64), 'hex')
 }
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,184 @@
+# BackupOS Security Model
+
+This document describes how BackupOS handles secrets at rest, what the
+encryption key protects, who can read what, and how to rotate the key.
+
+It does **not** describe transport security (TLS) or authentication
+(better-auth) — those are documented elsewhere.
+
+## What is encrypted
+
+BackupOS uses AES-256-GCM for field-level encryption with a single
+server-wide encryption key. The following fields are stored encrypted in
+the SQLite database:
+
+| Table             | Field             | What it holds                                      |
+| ----------------- | ----------------- | -------------------------------------------------- |
+| `repositories`    | `config`          | Backend credentials (S3/B2/Azure keys, NFS opts)   |
+| `repositories`    | `restic_password` | The Restic repository password                     |
+| `repositories`    | `escrowed_key`    | Optional escrowed copy of the Restic key           |
+| `smtp_config`     | `password`        | SMTP relay password                                 |
+| `alert_channels`  | `config` (parts)  | Per-channel webhook URLs and tokens (see below)    |
+| `verification`    | targets `sshKey`  | Inline-encrypted SSH key inside target JSON         |
+
+Encrypted values use the prefix `enc:v1:` followed by base64url-encoded
+ciphertext. Plaintext rows from before encryption was introduced are
+recognized by the absence of this prefix and migrated lazily on next
+write or by a one-time pass at server startup.
+
+### Alert channel field encryption
+
+`alert_channels.config` is a JSON column. Only sensitive fields inside
+that JSON are encrypted, not the whole blob — this keeps non-sensitive
+metadata (Zulip server URL, stream name, ntfy topic) readable for use
+in the channel-list UI subtitle.
+
+| Channel type | Encrypted fields              |
+| ------------ | ----------------------------- |
+| `discord`    | `url`                         |
+| `slack`      | `url`                         |
+| `webhook`    | `url`                         |
+| `zulip`      | `apiKey`                      |
+| `telegram`   | `botToken`                    |
+| `pagerduty`  | `integrationKey`              |
+| `ntfy`       | `auth`                        |
+| `gotify`     | `appToken`                    |
+| `pushover`   | `apiToken`, `userKey`         |
+
+Discord/Slack/generic webhook URLs encrypt the entire URL because the
+secret is embedded in the path (e.g. Discord webhook tokens).
+
+## What is NOT encrypted
+
+- **API token hashes** (`api_tokens.token_hash`, `integration_tokens.token_hash`)
+  are SHA-256 hashes, not encrypted plaintext. They cannot be reversed,
+  so encrypting them adds no value.
+- Schedules, file paths, hostnames, job names, and other operational
+  metadata are stored plaintext.
+- Backup data itself — Restic handles that. BackupOS never sees the
+  unencrypted contents of a backup.
+
+## The encryption key
+
+The key is a 32-byte (64-hex-char) value loaded at server startup. It
+is required for the server to start; without it, encrypted fields cannot
+be decrypted and most operations will fail.
+
+### Sources
+
+The key is loaded from one of two sources, in priority order:
+
+1. **`ENCRYPTION_KEY_FILE`** — path to a file containing the hex key.
+   Recommended for systemd-managed deployments using
+   [`LoadCredential=`][systemd-creds] to expose the key at
+   `/run/credentials/<service>/encryption-key` with strict permissions.
+
+2. **`ENCRYPTION_KEY`** — the hex key directly in an env var.
+
+Both sources are validated to contain at least 64 hex chars. Trailing
+whitespace is trimmed so `echo "$KEY" > /path/to/file` works.
+
+[systemd-creds]: https://www.freedesktop.org/software/systemd/man/systemd-creds.html
+
+### Default install
+
+The `server-install.sh` script generates a random key on first install
+and writes it to `/etc/backupos/server.env` as `ENCRYPTION_KEY=...`. The
+file is created with `chmod 600` and owned by the `backupos` user.
+
+## Threat model
+
+### What the key protects against
+
+- **DB exfiltration without server access.** An attacker with read-only
+  SQLite access (e.g. via a stolen backup of the BackupOS DB itself, an
+  IDOR bug exposing the file, etc.) cannot decrypt secrets without also
+  having the key.
+
+### What the key does NOT protect against
+
+- **Root access on the BackupOS server.** Root can read both
+  `/etc/backupos/server.env` and the SQLite DB. Encryption is meaningless
+  in this scenario; the threat model assumes root is trusted.
+- **Access as the `backupos` user.** Same as above — the user that runs
+  the service can read both. The mitigation here is to keep that user
+  shell-locked (`/usr/sbin/nologin`) and ensure the systemd unit is the
+  only thing that runs as it.
+- **Memory dump of the running process.** The key is in process memory
+  while the server runs. If an attacker can read process memory, they
+  have the key. No software-only mitigation exists.
+
+### V1 mitigations in place
+
+- `/etc/backupos/server.env` is created mode 600, owner `backupos`.
+- The `backupos` systemd unit drops privileges via `User=backupos`.
+- The `backupos` user has no shell.
+- `LoadCredential=` is supported (use `ENCRYPTION_KEY_FILE`) for
+  installations that prefer systemd-managed credentials.
+
+### Out of scope for V1 (enterprise-tier)
+
+- HSM-backed key storage
+- HashiCorp Vault / AWS KMS / GCP KMS integration
+- Per-tenant or per-repository keys
+- Hardware token unlock at boot
+
+## Operational guide
+
+### Where the key lives
+
+```bash
+# Default install
+/etc/backupos/server.env       # contains ENCRYPTION_KEY=<hex>
+
+# Systemd LoadCredential= setup
+/etc/backupos/encryption.key   # the file referenced by ENCRYPTION_KEY_FILE
+```
+
+### Backing up the key
+
+**Critical:** back up the encryption key separately from the BackupOS
+database. If the key is lost, encrypted fields become permanently
+unrecoverable. A common pattern:
+
+```bash
+# Print the key for safekeeping (e.g. password manager, sealed envelope)
+sudo cat /etc/backupos/server.env | grep ENCRYPTION_KEY
+```
+
+Or, for `LoadCredential=` deployments:
+
+```bash
+sudo cat /etc/backupos/encryption.key
+```
+
+### Switching from env var to file path
+
+```bash
+# 1. Extract the existing key
+sudo grep '^ENCRYPTION_KEY=' /etc/backupos/server.env | cut -d= -f2 \
+  | sudo tee /etc/backupos/encryption.key
+sudo chown backupos:backupos /etc/backupos/encryption.key
+sudo chmod 600 /etc/backupos/encryption.key
+
+# 2. Replace ENCRYPTION_KEY with ENCRYPTION_KEY_FILE in the env
+sudo sed -i \
+  '/^ENCRYPTION_KEY=/c\ENCRYPTION_KEY_FILE=/etc/backupos/encryption.key' \
+  /etc/backupos/server.env
+
+# 3. Restart
+sudo systemctl restart backupos backupos-pbs
+```
+
+### Rotating the key
+
+A key-rotation tool is planned (issue #188). Until then, rotation
+requires manually re-encrypting every encrypted column with the new key.
+**Do not change the key without re-encrypting** — existing encrypted
+data becomes unreadable.
+
+## Reporting security issues
+
+See [SECURITY.md in the repository root](../SECURITY.md) (if present) or
+contact the maintainers directly. Please do not file public GitHub
+issues for security bugs.

--- a/scripts/server-install.sh
+++ b/scripts/server-install.sh
@@ -311,6 +311,9 @@ RESTIC_BINARY_PATH=$(command -v restic)
 # Auth secrets — rotate these only if you want to invalidate all sessions
 BETTER_AUTH_SECRET=$(rand32)
 BETTER_AUTH_URL=$PUBLIC_URL
+# Encryption key for field-level secrets. Required.
+# Alternative: set ENCRYPTION_KEY_FILE=/path/to/keyfile to load from disk
+# (useful with systemd LoadCredential=). See docs/SECURITY.md for details.
 ENCRYPTION_KEY=$(rand32)
 ENVEOF
   chmod 600 "$ENV_FILE"


### PR DESCRIPTION
## Summary

- Extends `getKey()` in `repo-crypto.ts` to read from `ENCRYPTION_KEY_FILE` (file path) before falling back to `ENCRYPTION_KEY` env var — enables systemd `LoadCredential=` deployments where the key is exposed at `/run/credentials/...`
- Trailing whitespace/newlines trimmed so `echo "$KEY" > /path` works out of the box
- Adds `docs/SECURITY.md` with threat model, full encrypted-fields inventory (tables + alert channel map), key source docs, and operational runbook (backup, switch to file path, rotation note)
- Updates `scripts/server-install.sh` comment above `ENCRYPTION_KEY=` to mention the file-path alternative

## Test plan

- [x] 8 unit tests in `repo-crypto.test.ts` pass (env path, file path, trim, precedence, missing file, short contents)
- [x] `pnpm --filter @backupos/web build` clean
- [ ] After deploy: `sudo systemctl restart backupos` succeeds with existing `ENCRYPTION_KEY=` config (no regression)
- [ ] Optional: switch to `ENCRYPTION_KEY_FILE` per `docs/SECURITY.md`, restart, confirm all decryption works

🤖 Generated with [Claude Code](https://claude.com/claude-code)