### PR TITLE
feat(repos): Initialize repository button + add missing test_repo agent handler (closes #313, #314)

### DIFF
--- a/apps/web/app/(dashboard)/repositories/[id]/InitRepositoryButton.tsx
+++ b/apps/web/app/(dashboard)/repositories/[id]/InitRepositoryButton.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+
+interface Props {
+  repoId: string
+}
+
+export function InitRepositoryButton({ repoId }: Props) {
+  const [pending, startTransition] = useTransition()
+  const [confirming, setConfirming] = useState(false)
+  const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null)
+
+  const onConfirm = () => {
+    setConfirming(false)
+    startTransition(async () => {
+      try {
+        const res = await fetch(`/api/repos/${repoId}/init`, { method: 'POST' })
+        const data = await res.json() as { ok?: boolean; error?: string }
+        if (res.ok && data.ok) {
+          setResult({ ok: true, message: 'Repository initialized successfully' })
+        } else {
+          setResult({ ok: false, message: data.error ?? 'Initialization failed' })
+        }
+      } catch (err) {
+        setResult({ ok: false, message: err instanceof Error ? err.message : String(err) })
+      }
+    })
+  }
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+      {!confirming && (
+        <button
+          type="button"
+          onClick={() => { setConfirming(true); setResult(null) }}
+          disabled={pending}
+          style={{
+            padding: '5px 14px', fontSize: 12, cursor: pending ? 'wait' : 'pointer',
+            borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+            background: 'var(--surf2)', color: 'var(--fg)',
+          }}
+        >
+          {pending ? 'Initializing…' : 'Initialize repository'}
+        </button>
+      )}
+
+      {confirming && (
+        <>
+          <span style={{ fontSize: 12, color: 'var(--fg-mute)' }}>
+            Run restic init? This is destructive if the repo already has data.
+          </span>
+          <button
+            type="button" onClick={onConfirm} disabled={pending}
+            style={{
+              padding: '4px 10px', fontSize: 12, cursor: 'pointer',
+              borderRadius: 'var(--radius-sm)', border: '1px solid var(--accent)',
+              background: 'var(--accent)', color: '#fff',
+            }}
+          >
+            Confirm
+          </button>
+          <button
+            type="button" onClick={() => setConfirming(false)} disabled={pending}
+            style={{
+              padding: '4px 10px', fontSize: 12, cursor: 'pointer',
+              borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+              background: 'var(--surf2)', color: 'var(--fg)',
+            }}
+          >
+            Cancel
+          </button>
+        </>
+      )}
+
+      {result && (
+        <span style={{ fontSize: 11, color: result.ok ? 'var(--ok)' : 'var(--err)' }}>
+          {result.ok ? '✓ ' : '✗ '}{result.message}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/repositories/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/repositories/[id]/page.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { RunCheckButton } from './run-check-button'
 import { PruneButton } from './prune-button'
 import { TestConnectionButton } from './test-connection-button'
+import { InitRepositoryButton } from './InitRepositoryButton'
 import { DeleteRepositoryButton } from './delete-button'
 import { TestMountButton } from './test-mount-button'
 import { MountStatusBadge } from './mount-status-badge'
@@ -99,6 +100,7 @@ export default async function RepoDetailPage({ params }: { params: Promise<{ id:
           <Button variant="secondary" size="md">Browse snapshots</Button>
         </Link>
         <TestConnectionButton repoId={id} />
+        <InitRepositoryButton repoId={id} />
         {(repo.backend === 'nfs' || repo.backend === 'smb') && (
           <>
             <TestMountButton repoId={id} />

--- a/apps/web/lib/ws-state.ts
+++ b/apps/web/lib/ws-state.ts
@@ -4,6 +4,7 @@ export type { DetectedResources }
 
 export interface RepoTestResult  { ok: boolean; error?: string; snapshotCount?: number }
 export interface MountTestResult { ok: boolean; error?: string }
+export interface InitRepoResult  { ok: boolean; error?: string }
 
 declare global {
   // eslint-disable-next-line no-var
@@ -14,6 +15,8 @@ declare global {
   var __bkp_pending_repo_tests: Map<string, (r: RepoTestResult) => void> | undefined
   // eslint-disable-next-line no-var
   var __bkp_pending_mount_tests: Map<string, (r: MountTestResult) => void> | undefined
+  // eslint-disable-next-line no-var
+  var __bkp_pending_init_repos: Map<string, (r: InitRepoResult) => void> | undefined
   // eslint-disable-next-line no-var
   var __bkp_pending_fs_restores: Map<string, (r: { ok: boolean; error?: string }) => void> | undefined
 }
@@ -29,6 +32,9 @@ const pendingRepoTests: Map<string, (r: RepoTestResult) => void> =
 
 const pendingMountTests: Map<string, (r: MountTestResult) => void> =
   (globalThis.__bkp_pending_mount_tests ??= new Map())
+
+const pendingInitRepos: Map<string, (r: InitRepoResult) => void> =
+  (globalThis.__bkp_pending_init_repos ??= new Map())
 
 const pendingFsRestores: Map<string, (r: { ok: boolean; error?: string }) => void> =
   (globalThis.__bkp_pending_fs_restores ??= new Map())
@@ -136,6 +142,36 @@ export function requestTestMount(agentId: string, mountConfig: MountConfig): Pro
 
 export function resolveTestMount(requestId: string, result: MountTestResult): void {
   pendingMountTests.get(requestId)?.(result)
+}
+
+export function requestInitRepository(
+  agentId: string,
+  repoUrl: string,
+  repoPassword: string,
+  envVars?: Record<string, string>,
+): Promise<InitRepoResult> {
+  return new Promise((resolve, reject) => {
+    const requestId = crypto.randomUUID()
+    const timer = setTimeout(() => {
+      pendingInitRepos.delete(requestId)
+      reject(new Error('Agent did not respond in time'))
+    }, 60_000)
+    pendingInitRepos.set(requestId, (result) => {
+      clearTimeout(timer)
+      pendingInitRepos.delete(requestId)
+      resolve(result)
+    })
+    const sent = dispatch(agentId, { type: 'init_repository', requestId, repoUrl, repoPassword, envVars })
+    if (!sent) {
+      clearTimeout(timer)
+      pendingInitRepos.delete(requestId)
+      reject(new Error('Agent not connected'))
+    }
+  })
+}
+
+export function resolveInitRepository(requestId: string, result: InitRepoResult): void {
+  pendingInitRepos.get(requestId)?.(result)
 }
 
 declare global {

--- a/apps/web/public/agent/bundle.js
+++ b/apps/web/public/agent/bundle.js
@@ -7763,6 +7763,44 @@ async function runMountRepository(msg, send2) {
   }
 }
 
+// src/handlers/testRepo.ts
+init_dist();
+async function runTestRepo(msg, send2, binaryPath) {
+  const { requestId, repoUrl, repoPassword, envVars } = msg;
+  try {
+    const engine = new ResticEngine({
+      repositoryUrl: repoUrl,
+      password: repoPassword,
+      envVars: envVars ?? {},
+      binaryPath
+    });
+    const snapshots = await engine.snapshots();
+    send2({ type: "test_repo_result", requestId, ok: true, snapshotCount: snapshots.length });
+  } catch (err) {
+    const error = err instanceof ResticError ? err.message : err instanceof Error ? err.message : String(err);
+    send2({ type: "test_repo_result", requestId, ok: false, error });
+  }
+}
+
+// src/handlers/initRepository.ts
+init_dist();
+async function runInitRepository(msg, send2, binaryPath) {
+  const { requestId, repoUrl, repoPassword, envVars } = msg;
+  try {
+    const engine = new ResticEngine({
+      repositoryUrl: repoUrl,
+      password: repoPassword,
+      envVars: envVars ?? {},
+      binaryPath
+    });
+    await engine.init();
+    send2({ type: "init_repository_result", requestId, ok: true });
+  } catch (err) {
+    const error = err instanceof ResticError ? err.message : err instanceof Error ? err.message : String(err);
+    send2({ type: "init_repository_result", requestId, ok: false, error });
+  }
+}
+
 // src/handlers/testMount.ts
 var import_child_process3 = require("child_process");
 var import_fs4 = require("fs");
@@ -8187,6 +8225,10 @@ async function handleMessage(raw) {
       job.ctrl.abort();
       send({ type: "backup_cancelled", jobId: msg.jobId, runId: job.runId, reason: "user_requested" });
     }
+  } else if (msg.type === "test_repo") {
+    void runTestRepo(msg, send, BINARY);
+  } else if (msg.type === "init_repository") {
+    void runInitRepository(msg, send, BINARY);
   } else if (msg.type === "verify_repo") {
     void verifyRepo(msg.repoId, msg.repoUrl, msg.repoPassword, msg.readData, msg.envVars);
   } else if (msg.type === "run_compose_backup") {

--- a/apps/web/public/agent/bundle.js
+++ b/apps/web/public/agent/bundle.js
@@ -3713,9 +3713,11 @@ var init_restic = __esm({
       }
       async init() {
         const result = await this.run(["init"], void 0, 6e4);
+        const log = buildRunLog(result.stdout, result.stderr);
         if (result.exitCode !== 0) {
           throw new ResticError("init", result);
         }
+        return { log };
       }
       async backup(opts) {
         if (opts.preHook)

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -10,7 +10,7 @@ import type { WebSocket } from 'ws'
 import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, verificationRuns, verificationTests, snapshots, eq, and, desc } from '@backupos/db'
 import { ResticEngine } from '@backupos/engine'
 import { parseExpression } from 'cron-parser'
-import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository, resolveFilesystemRestoreStarted, resolveDatabaseRestoreStarted, resolveDatabaseRestoreComplete } from './lib/ws-state'
+import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, requestInitRepository, resolveInitRepository, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository, resolveFilesystemRestoreStarted, resolveDatabaseRestoreStarted, resolveDatabaseRestoreComplete } from './lib/ws-state'
 import { ensureRepoMountedOnAgent } from './lib/repo-mount'
 import { loadOrCreateInternalToken } from './lib/internal-token'
 import { decryptField } from './lib/repo-crypto'
@@ -249,6 +249,32 @@ void app.prepare().then(async () => {
         requestTestRepo(agentId, repoCfg['repositoryUrl'] ?? '', decryptField(repo.resticPassword), repoCfg)
           .then(result => { res.writeHead(200, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(result)) })
           .catch((err: unknown) => { const msg = err instanceof Error ? err.message : 'Test failed'; res.writeHead(503, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ error: msg })) })
+      })()
+      return
+    }
+
+    // Initialize a repo via agent (restic init)
+    const initRepoMatch = parsed.pathname?.match(/^\/api\/repos\/([^/]+)\/init$/)
+    if (req.method === 'POST' && initRepoMatch) {
+      void (async () => {
+        const session = await requireSession(req)
+        if (!session) {
+          res.writeHead(401, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: 'unauthorized' }))
+          return
+        }
+        const repoId = initRepoMatch[1]!
+        const db2 = getDb()
+        const [repo] = await db2.select().from(repositories).where(eq(repositories.id, repoId)).limit(1)
+        if (!repo) { res.writeHead(404, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ error: 'Repository not found' })); return }
+        const repoCfg = JSON.parse(decryptField(repo.config)) as Record<string, string>
+        const connected = connectedAgentIds()
+        const jobs2 = await db2.select({ agentId: backupJobs.agentId }).from(backupJobs).where(eq(backupJobs.repositoryId, repoId)).all()
+        const agentId = jobs2.map(j => j.agentId).find(aid => aid && connected.includes(aid)) ?? connected[0] ?? null
+        if (!agentId) { res.writeHead(503, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ error: 'No connected agent. Connect a BackupOS agent first.' })); return }
+        requestInitRepository(agentId, repoCfg['repositoryUrl'] ?? '', decryptField(repo.resticPassword), repoCfg)
+          .then(result => { res.writeHead(200, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(result)) })
+          .catch((err: unknown) => { const msg = err instanceof Error ? err.message : 'Init failed'; res.writeHead(503, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ error: msg })) })
       })()
       return
     }
@@ -741,6 +767,9 @@ void app.prepare().then(async () => {
 
         } else if (msg.type === 'test_repo_result') {
           resolveTestRepo(msg.requestId, { ok: msg.ok, error: msg.error, snapshotCount: msg.snapshotCount })
+
+        } else if (msg.type === 'init_repository_result') {
+          resolveInitRepository(msg.requestId, { ok: msg.ok, error: msg.error })
 
         } else if (msg.type === 'test_mount_result') {
           resolveTestMount(msg.requestId, { ok: msg.ok, error: msg.error })

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -155,6 +155,7 @@ export type AgentMessage =
   | { type: 'verification_complete'; verificationRunId: string; success: boolean; log: string; errorMessage?: string }
   | { type: 'resources_result'; requestId: string; resources: DetectedResources }
   | { type: 'test_repo_result'; requestId: string; ok: boolean; error?: string; snapshotCount?: number }
+  | { type: 'init_repository_result'; requestId: string; ok: boolean; error?: string }
   | { type: 'test_mount_result'; requestId: string; ok: boolean; error?: string }
   | { type: 'compose_project_listing'; requestId: string; project: ComposeProjectListing }
   | { type: 'mount_complete'; requestId: string; repoId: string }
@@ -180,6 +181,7 @@ export type ServerMessage =
   | { type: 'verify_repo'; repoId: string; repoUrl: string; repoPassword: string; readData: boolean; envVars?: Record<string, string> }
   | { type: 'list_resources'; requestId: string }
   | { type: 'test_repo'; requestId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
+  | { type: 'init_repository'; requestId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
   | { type: 'test_mount'; requestId: string; mountConfig: MountConfig }
   | { type: 'force_update' }
   | { type: 'list_compose_project'; requestId: string; projectName: string }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -9,6 +9,8 @@ import { getSystemUptimeSeconds } from './system-uptime'
 import { detectCapabilities } from './capabilities'
 import { resolveHostPrefix, applyHostPrefixAll } from './lib/host-prefix'
 import { runMountRepository } from './handlers/mountRepository'
+import { runTestRepo } from './handlers/testRepo'
+import { runInitRepository } from './handlers/initRepository'
 import { runTestMount } from './handlers/testMount'
 import { handleFilesystemRestore } from './handlers/filesystemRestore'
 import { handleDatabaseRestore } from './handlers/databaseRestore'
@@ -238,6 +240,12 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
       job.ctrl.abort()
       send({ type: 'backup_cancelled', jobId: msg.jobId, runId: job.runId, reason: 'user_requested' })
     }
+
+  } else if (msg.type === 'test_repo') {
+    void runTestRepo(msg, send, BINARY)
+
+  } else if (msg.type === 'init_repository') {
+    void runInitRepository(msg, send, BINARY)
 
   } else if (msg.type === 'verify_repo') {
     void verifyRepo(msg.repoId, msg.repoUrl, msg.repoPassword, msg.readData, msg.envVars)

--- a/packages/agent/src/handlers/initRepository.ts
+++ b/packages/agent/src/handlers/initRepository.ts
@@ -1,0 +1,28 @@
+import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
+import { ResticEngine, ResticError } from '@backupos/engine'
+
+type InitRepoMsg = Extract<ServerMessage, { type: 'init_repository' }>
+
+export async function runInitRepository(
+  msg: InitRepoMsg,
+  send: (out: AgentMessage) => void,
+  binaryPath: string | undefined,
+): Promise<void> {
+  const { requestId, repoUrl, repoPassword, envVars } = msg
+
+  try {
+    const engine = new ResticEngine({
+      repositoryUrl: repoUrl,
+      password:      repoPassword,
+      envVars:       envVars ?? {},
+      binaryPath,
+    })
+    await engine.init()
+    send({ type: 'init_repository_result', requestId, ok: true })
+  } catch (err) {
+    const error = err instanceof ResticError
+      ? err.message
+      : err instanceof Error ? err.message : String(err)
+    send({ type: 'init_repository_result', requestId, ok: false, error })
+  }
+}

--- a/packages/agent/src/handlers/testRepo.ts
+++ b/packages/agent/src/handlers/testRepo.ts
@@ -1,0 +1,28 @@
+import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
+import { ResticEngine, ResticError } from '@backupos/engine'
+
+type TestRepoMsg = Extract<ServerMessage, { type: 'test_repo' }>
+
+export async function runTestRepo(
+  msg: TestRepoMsg,
+  send: (out: AgentMessage) => void,
+  binaryPath: string | undefined,
+): Promise<void> {
+  const { requestId, repoUrl, repoPassword, envVars } = msg
+
+  try {
+    const engine = new ResticEngine({
+      repositoryUrl: repoUrl,
+      password:      repoPassword,
+      envVars:       envVars ?? {},
+      binaryPath,
+    })
+    const snapshots = await engine.snapshots()
+    send({ type: 'test_repo_result', requestId, ok: true, snapshotCount: snapshots.length })
+  } catch (err) {
+    const error = err instanceof ResticError
+      ? err.message
+      : err instanceof Error ? err.message : String(err)
+    send({ type: 'test_repo_result', requestId, ok: false, error })
+  }
+}

--- a/packages/engine/src/restic.ts
+++ b/packages/engine/src/restic.ts
@@ -51,11 +51,13 @@ export class ResticEngine {
     this.binary = config.binaryPath ?? 'restic'
   }
 
-  async init(): Promise<void> {
+  async init(): Promise<{ log: string }> {
     const result = await this.run(['init'], undefined, 60_000)
+    const log = buildRunLog(result.stdout, result.stderr)
     if (result.exitCode !== 0) {
       throw new ResticError('init', result)
     }
+    return { log }
   }
 
   async backup(opts: BackupOptions): Promise<BackupResult> {


### PR DESCRIPTION
## Summary

**#314 (test_repo missing):** Agent was silently dropping `test_repo` messages — adds `packages/agent/src/handlers/testRepo.ts` and wires it into the dispatch chain. The "Test connection" button now works.

**#313 (no restic init path):** Adds end-to-end `restic init` support:
- `packages/agent/src/handlers/initRepository.ts` — calls `engine.init()`, sends `init_repository_result`
- `packages/agent-protocol` — `init_repository` (ServerMessage) and `init_repository_result` (AgentMessage) types
- `apps/web/lib/ws-state.ts` — `requestInitRepository` / `resolveInitRepository` helpers
- `apps/web/server.ts` — `POST /api/repos/:id/init` route + `init_repository_result` WS handler
- `apps/web/app/(dashboard)/repositories/[id]/InitRepositoryButton.tsx` — confirm dialog client component
- Repo detail page — "Initialize repository" button placed after "Test connection"
- Agent bundle rebuilt (288.6 kB)

## Test plan

- [x] `pnpm --filter @backupos/agent-protocol build` clean
- [x] `pnpm --filter @backupos/agent build` clean (bundle rebuilt)
- [x] `pnpm --filter @backupos/web build` clean
- [ ] Smoke test (Darius): restart agent on dockee01, click "Test connection" (should respond now), click "Initialize repository" → confirm → success within ~3s, second "Test connection" returns snapshotCount: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)