### PR TITLE
fix(security): use sync transaction in key rotation (closes #311)

### DIFF
--- a/apps/web/lib/key-rotation.test.ts
+++ b/apps/web/lib/key-rotation.test.ts
@@ -26,8 +26,9 @@ describe('rotateEncryptionKey', () => {
     await expect(rotateEncryptionKey(KEY_A, 'abc')).rejects.toThrow(/64 hex/)
   })
 
-  // Integration tests below need a real DB with migrations.
-  // Marked .skip until a shared in-memory DB fixture is available.
+  // Integration tests below require injecting a test DB into rotateEncryptionKey.
+  // getDb() from @backupos/db is a module-level singleton with no injection point,
+  // so these tests cannot be wired without a refactor that is out of scope for this PR.
   // The smoke test in the acceptance checklist covers the integration path.
 
   it.skip('round-trips: rotate A→B, decrypt with B succeeds', async () => {

--- a/apps/web/lib/key-rotation.ts
+++ b/apps/web/lib/key-rotation.ts
@@ -113,57 +113,61 @@ export async function rotateEncryptionKey(
     return JSON.stringify(cfg)
   }
 
-  await db.transaction(async (tx) => {
+  db.transaction((tx) => {
     // repositories: config + resticPassword
-    const repoRows = await tx.select().from(repositories).all()
+    const repoRows = tx.select().from(repositories).all()
     for (const row of repoRows) {
       const newConfig         = reencrypt(row.config)
       const newResticPassword = reencrypt(row.resticPassword)
       if (newConfig === row.config && newResticPassword === row.resticPassword) continue
       if (!opts.dryRun) {
-        await tx.update(repositories)
+        tx.update(repositories)
           .set({ config: newConfig!, resticPassword: newResticPassword! })
           .where(eq(repositories.id, row.id))
+          .run()
       }
       stats.repositories++
     }
 
     // smtpConfig: password
-    const smtpRows = await tx.select().from(smtpConfig).all()
+    const smtpRows = tx.select().from(smtpConfig).all()
     for (const row of smtpRows) {
       if (!row.password) continue
       const newPassword = reencrypt(row.password)
       if (newPassword === row.password) continue
       if (!opts.dryRun) {
-        await tx.update(smtpConfig)
+        tx.update(smtpConfig)
           .set({ password: newPassword })
           .where(eq(smtpConfig.id, row.id))
+          .run()
       }
       stats.smtpConfig++
     }
 
     // alertChannels: per-type encrypted fields inside config JSON
-    const alertRows = await tx.select().from(alertChannels).all()
+    const alertRows = tx.select().from(alertChannels).all()
     for (const row of alertRows) {
       const newConfig = reencryptChannelConfig(row.type, row.config)
       if (newConfig === row.config) continue
       if (!opts.dryRun) {
-        await tx.update(alertChannels)
+        tx.update(alertChannels)
           .set({ config: newConfig })
           .where(eq(alertChannels.id, row.id))
+          .run()
       }
       stats.alertChannels++
     }
 
     // verificationTests: sshKey inside targetConfig JSON, only for ssh_target
-    const verifyRows = await tx.select().from(verificationTests).all()
+    const verifyRows = tx.select().from(verificationTests).all()
     for (const row of verifyRows) {
       const newTargetConfig = reencryptVerificationConfig(row.targetType, row.targetConfig)
       if (newTargetConfig === row.targetConfig) continue
       if (!opts.dryRun) {
-        await tx.update(verificationTests)
+        tx.update(verificationTests)
           .set({ targetConfig: newTargetConfig })
           .where(eq(verificationTests.id, row.id))
+          .run()
       }
       stats.verificationTests++
     }


### PR DESCRIPTION
## Summary

- `db.transaction(async (tx) => {...})` → `db.transaction((tx) => {...})` — removes `async` and outer `await`
- Drops `await` from all `tx.select()` calls inside (`.all()` already executes synchronously)
- Adds explicit `.run()` to every `tx.update().set().where()` chain (required without `await` to trigger execution)
- Updates `.skip` test comments to explain why integration tests remain skipped (non-injectable `getDb()` singleton — out of scope to refactor here)

**Root cause:** better-sqlite3's `.transaction()` rejects Promise-returning callbacks. The async callback was causing `tx.update()` calls to execute outside the transaction frame in autocommit mode, allowing partial writes before the wrapper threw — exactly the failure mode from 2026-05-04.

## Test plan

- [x] `pnpm --filter @backupos/web build` — clean, no TS errors
- [x] `vitest run lib/key-rotation.test.ts` — 3 pass, 3 skipped (unchanged)
- [ ] Smoke test per spec (Darius to run post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)