### PR TITLE
fix(security): chown env file to service user so UI rotation can write it (closes #317)

### DIFF
--- a/scripts/server-install.sh
+++ b/scripts/server-install.sh
@@ -201,6 +201,8 @@ ok "User '$SVC_USER'"
 # ── 3. Directories ────────────────────────────────────────────────────────────
 mkdir -p "$INSTALL_DIR" "$DATA_DIR" "$CONF_DIR" "$LOG_DIR"
 chown "$SVC_USER:$SVC_USER" "$DATA_DIR" "$LOG_DIR"
+chown "$SVC_USER:$SVC_USER" "$CONF_DIR"
+chmod 700 "$CONF_DIR"
 
 # ── 4. Source code ────────────────────────────────────────────────────────────
 if [[ -n "$SOURCE_DIR" ]]; then
@@ -317,6 +319,7 @@ BETTER_AUTH_URL=$PUBLIC_URL
 ENCRYPTION_KEY=$(rand32)
 ENVEOF
   chmod 600 "$ENV_FILE"
+  chown "$SVC_USER:$SVC_USER" "$ENV_FILE"
   ok "Environment file created"
 else
   ok "Environment file already exists (keeping existing secrets)"
@@ -332,6 +335,17 @@ if ! grep -q '^BACKUPOS_INTERNAL_URL=' "$ENV_FILE" 2>/dev/null; then
   echo "BACKUPOS_INTERNAL_URL=http://127.0.0.1:3093" >> "$ENV_FILE"
   echo "[backupos] Set BACKUPOS_INTERNAL_URL"
 fi
+
+# Heal env-file ownership for upgrades from older installs that left the
+# file as root:root. The service runs as $SVC_USER and needs write access
+# for the UI key-rotation flow (#317).
+chown "$SVC_USER:$SVC_USER" "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+# Heal any pre-rotation backup files
+for backup in "$CONF_DIR"/server.env.pre-rotation-*; do
+  [ -f "$backup" ] && chown "$SVC_USER:$SVC_USER" "$backup" && chmod 600 "$backup"
+done
 
 # ── 7. Log rotation ───────────────────────────────────────────────────────────
 cat > /etc/logrotate.d/$SERVICE_NAME <<LREOF


### PR DESCRIPTION
## Summary

- `$CONF_DIR` (`/etc/backupos`) now gets `chown backupos:backupos` + `chmod 700` on creation
- `$ENV_FILE` gets `chown backupos:backupos` immediately after `chmod 600` on creation
- Unconditional heal block after the `BACKUPOS_INTERNAL_URL` stanza fixes ownership on existing installs (idempotent — safe to re-run)
- Heal loop fixes any `server.env.pre-rotation-*` backup files in `$CONF_DIR`

**Root cause:** `/etc/backupos/server.env` was created as `root:root 600`. The `backupos` service user could read it via `EnvironmentFile=` but not write it, so the UI rotation succeeded at the DB layer (PR #316) then failed with `EACCES` when writing the updated env file.

## Test plan

- [x] `bash -n scripts/server-install.sh` — syntax clean
- [ ] Smoke test per spec (Darius to run post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)