### PR TITLE
feat(pbs): M7 — datastore management UI + internal Go endpoints (closes #320)

### DIFF
--- a/apps/web/app/(dashboard)/pbs/client.tsx
+++ b/apps/web/app/(dashboard)/pbs/client.tsx
@@ -1,35 +1,31 @@
 'use client'
 
-import { useState, useTransition } from 'react'
-import { deletePbsDatastore }       from '@/app/actions/pbs-datastores'
-import { Button }                   from '@/components/ui/button'
+import { useState } from 'react'
 
 export interface DatastoreRow {
-  id:        string
-  name:      string
-  path:      string
-  createdAt: string
+  id:              string
+  name:            string
+  path:            string
+  createdAt:       string
+  pruneSchedule:   string | null
+  gcSchedule:      string | null
+  lastGcAt:        string | null
+  totalSizeBytes:  number | null
+  uniqueSizeBytes: number | null
+}
+
+function bytesToHuman(n: number | null | undefined): string {
+  if (n == null) return '—'
+  if (n < 1024) return `${n} B`
+  const units = ['KB', 'MB', 'GB', 'TB', 'PB']
+  let v = n / 1024
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++ }
+  return `${v.toFixed(1)} ${units[i]}`
 }
 
 export function DatastoreList({ initialDatastores }: { initialDatastores: DatastoreRow[] }) {
-  const [datastores, setDatastores]  = useState(initialDatastores)
-  const [error, setError]            = useState<string | null>(null)
-  const [isPending, startTransition] = useTransition()
-
-  function handleDelete(id: string, name: string) {
-    if (!confirm(
-      `Delete datastore "${name}"?\n\n` +
-      `This permanently removes all chunks and snapshots stored here. ` +
-      `PVE clusters configured to back up to this datastore will fail their next backup.\n\n` +
-      `This cannot be undone.`,
-    )) return
-    setError(null)
-    startTransition(async () => {
-      const result = await deletePbsDatastore(id)
-      if (result.error) { setError(result.error); return }
-      setDatastores(ds => ds.filter(d => d.id !== id))
-    })
-  }
+  const [datastores] = useState(initialDatastores)
 
   const th: React.CSSProperties = {
     textAlign: 'left', padding: '8px 10px', fontSize: 12,
@@ -40,51 +36,57 @@ export function DatastoreList({ initialDatastores }: { initialDatastores: Datast
   }
 
   return (
-    <div>
-      {error && (
-        <div style={{ marginBottom: 12, padding: '10px 14px', fontSize: 13, color: 'var(--err,#ef4444)', border: '1px solid var(--err,#ef4444)', borderRadius: 'var(--radius-sm)' }}>
-          {error}
-        </div>
-      )}
-      <div style={{ border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', overflow: 'hidden' }}>
-        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
-          <thead>
+    <div style={{ border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', overflow: 'hidden' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+        <thead>
+          <tr>
+            <th style={th}>Name</th>
+            <th style={th}>Path</th>
+            <th style={th}>Size</th>
+            <th style={th}>GC schedule</th>
+            <th style={th}>Last GC</th>
+            <th style={{ ...th, width: 40 }}></th>
+          </tr>
+        </thead>
+        <tbody>
+          {datastores.length === 0 ? (
             <tr>
-              <th style={th}>Name</th>
-              <th style={th}>Path</th>
-              <th style={th}>Created</th>
-              <th style={{ ...th, width: 80 }}></th>
+              <td colSpan={6} style={{ ...td, textAlign: 'center', color: 'var(--fg-dim)', padding: 32 }}>
+                No datastores yet
+              </td>
             </tr>
-          </thead>
-          <tbody>
-            {datastores.length === 0 ? (
-              <tr>
-                <td colSpan={4} style={{ ...td, textAlign: 'center', color: 'var(--fg-dim)', padding: 32 }}>
-                  No datastores yet
+          ) : (
+            datastores.map(d => (
+              <tr key={d.id}>
+                <td style={td}>
+                  <a
+                    href={`/pbs/datastores/${d.id}`}
+                    style={{ color: 'var(--fg)', textDecoration: 'none', fontFamily: 'var(--font-mono)', fontSize: 12 }}
+                  >
+                    {d.name}
+                  </a>
+                </td>
+                <td style={{ ...td, color: 'var(--fg-dim)', fontSize: 12 }}><code>{d.path}</code></td>
+                <td style={{ ...td, color: 'var(--fg-dim)' }}>{bytesToHuman(d.totalSizeBytes)}</td>
+                <td style={{ ...td, color: 'var(--fg-dim)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+                  {d.gcSchedule ?? '—'}
+                </td>
+                <td style={{ ...td, color: 'var(--fg-dim)' }}>
+                  {d.lastGcAt ? new Date(d.lastGcAt).toLocaleString() : '—'}
+                </td>
+                <td style={{ ...td, textAlign: 'right' }}>
+                  <a
+                    href={`/pbs/datastores/${d.id}`}
+                    style={{ fontSize: 12, color: 'var(--fg-dim)', textDecoration: 'none' }}
+                  >
+                    →
+                  </a>
                 </td>
               </tr>
-            ) : (
-              datastores.map(d => (
-                <tr key={d.id}>
-                  <td style={td}><code style={{ fontSize: 12 }}>{d.name}</code></td>
-                  <td style={{ ...td, color: 'var(--fg-dim)', fontSize: 12 }}><code>{d.path}</code></td>
-                  <td style={{ ...td, color: 'var(--fg-dim)' }}>{new Date(d.createdAt).toLocaleString()}</td>
-                  <td style={{ ...td, textAlign: 'right' }}>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleDelete(d.id, d.name)}
-                      disabled={isPending}
-                    >
-                      Delete
-                    </Button>
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+            ))
+          )}
+        </tbody>
+      </table>
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/pbs/datastores/[id]/DangerZone.tsx
+++ b/apps/web/app/(dashboard)/pbs/datastores/[id]/DangerZone.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { deletePbsDatastore } from '@/app/actions/pbs-datastores'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  id:   string
+  name: string
+}
+
+export function DangerZone({ id, name }: Props) {
+  const router = useRouter()
+  const [confirmText, setConfirmText] = useState('')
+  const [error, setError]             = useState<string | null>(null)
+  const [isPending, startTransition]  = useTransition()
+
+  const matches = confirmText === name
+
+  function onDelete() {
+    if (!matches) return
+    setError(null)
+    startTransition(async () => {
+      const r = await deletePbsDatastore(id)
+      if (r.error) { setError(r.error); return }
+      router.push('/pbs')
+    })
+  }
+
+  return (
+    <section style={{ padding: 20, border: '1px solid var(--err)', borderRadius: 'var(--radius-sm)' }}>
+      <h2 style={{ fontSize: 14, fontWeight: 600, color: 'var(--err)', marginTop: 0, marginBottom: 8 }}>Danger zone</h2>
+      <p style={{ fontSize: 13, color: 'var(--fg-dim)', marginTop: 0, marginBottom: 16 }}>
+        Deleting a datastore permanently removes all chunks and snapshots stored in it. PVE clusters
+        configured to back up to this datastore will fail their next backup. This cannot be undone.
+      </p>
+      <p style={{ fontSize: 12, color: 'var(--fg-mute)', marginBottom: 8 }}>
+        Type the datastore name (<code>{name}</code>) to confirm:
+      </p>
+      <input
+        value={confirmText}
+        onChange={(e) => setConfirmText(e.target.value)}
+        placeholder={name}
+        disabled={isPending}
+        style={{
+          display: 'block', width: '100%', padding: '6px 10px', fontSize: 13,
+          fontFamily: 'var(--font-mono)',
+          backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none',
+          boxSizing: 'border-box', marginBottom: 12,
+        }}
+      />
+      {error && (
+        <div style={{ padding: '8px 12px', fontSize: 13, color: 'var(--err)', border: '1px solid var(--err)', borderRadius: 'var(--radius-sm)', marginBottom: 12 }}>
+          {error}
+        </div>
+      )}
+      <Button variant="ghost" size="sm" onClick={onDelete} disabled={!matches || isPending}>
+        {isPending ? 'Deleting…' : 'Delete datastore'}
+      </Button>
+    </section>
+  )
+}

--- a/apps/web/app/(dashboard)/pbs/datastores/[id]/EditScheduleForm.tsx
+++ b/apps/web/app/(dashboard)/pbs/datastores/[id]/EditScheduleForm.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { updatePbsDatastore } from '@/app/actions/pbs-datastores'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  id:                   string
+  initialPruneSchedule: string
+  initialGcSchedule:    string
+}
+
+export function EditScheduleForm({ id, initialPruneSchedule, initialGcSchedule }: Props) {
+  const [pruneSchedule, setPruneSchedule] = useState(initialPruneSchedule)
+  const [gcSchedule, setGcSchedule]       = useState(initialGcSchedule)
+  const [error, setError]                 = useState<string | null>(null)
+  const [savedAt, setSavedAt]             = useState<number | null>(null)
+  const [isPending, startTransition]      = useTransition()
+
+  const dirty = pruneSchedule !== initialPruneSchedule || gcSchedule !== initialGcSchedule
+
+  function onSave() {
+    setError(null)
+    startTransition(async () => {
+      const result = await updatePbsDatastore({
+        id,
+        pruneSchedule: pruneSchedule.trim() || null,
+        gcSchedule:    gcSchedule.trim() || null,
+      })
+      if (result.error) { setError(result.error); return }
+      setSavedAt(Date.now())
+    })
+  }
+
+  const inputStyle: React.CSSProperties = {
+    display: 'block', width: '100%', padding: '6px 10px', fontSize: 13,
+    fontFamily: 'var(--font-mono)',
+    backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none',
+    boxSizing: 'border-box',
+  }
+  const labelStyle: React.CSSProperties = {
+    display: 'block', fontSize: 12, color: 'var(--fg-dim)', marginBottom: 4,
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <div>
+        <label style={labelStyle} htmlFor="prune-schedule">Prune schedule (cron)</label>
+        <input
+          id="prune-schedule"
+          value={pruneSchedule}
+          onChange={(e) => setPruneSchedule(e.target.value)}
+          placeholder="0 2 * * *"
+          disabled={isPending}
+          style={inputStyle}
+        />
+      </div>
+      <div>
+        <label style={labelStyle} htmlFor="gc-schedule">GC schedule (cron)</label>
+        <input
+          id="gc-schedule"
+          value={gcSchedule}
+          onChange={(e) => setGcSchedule(e.target.value)}
+          placeholder="0 3 * * 0"
+          disabled={isPending}
+          style={inputStyle}
+        />
+      </div>
+      {error && (
+        <div style={{ padding: '8px 12px', fontSize: 13, color: 'var(--err)', border: '1px solid var(--err)', borderRadius: 'var(--radius-sm)' }}>
+          {error}
+        </div>
+      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <Button variant="primary" size="sm" onClick={onSave} disabled={!dirty || isPending}>
+          {isPending ? 'Saving…' : 'Save schedules'}
+        </Button>
+        {savedAt && !dirty && (
+          <span style={{ fontSize: 11, color: 'var(--ok)' }}>✓ Saved</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/pbs/datastores/[id]/StatsRefreshButton.tsx
+++ b/apps/web/app/(dashboard)/pbs/datastores/[id]/StatsRefreshButton.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { syncPbsDatastoreStats } from '@/app/actions/pbs-datastores'
+import { Button } from '@/components/ui/button'
+
+export function StatsRefreshButton({ id }: { id: string }) {
+  const router = useRouter()
+  const [error, setError]            = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function onRefresh() {
+    setError(null)
+    startTransition(async () => {
+      const result = await syncPbsDatastoreStats(id)
+      if (!result.ok) { setError(result.error ?? 'Unknown error'); return }
+      router.refresh()
+    })
+  }
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <Button variant="ghost" size="sm" onClick={onRefresh} disabled={isPending}>
+        {isPending ? 'Refreshing…' : 'Refresh stats'}
+      </Button>
+      {error && <span style={{ fontSize: 11, color: 'var(--err)' }}>✗ {error}</span>}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/pbs/datastores/[id]/TriggerGcButton.tsx
+++ b/apps/web/app/(dashboard)/pbs/datastores/[id]/TriggerGcButton.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { triggerPbsGc } from '@/app/actions/pbs-datastores'
+import { Button } from '@/components/ui/button'
+
+export function TriggerGcButton({ id }: { id: string }) {
+  const [confirming, setConfirming]  = useState(false)
+  const [result, setResult]          = useState<{ ok: boolean; message: string } | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function onConfirm() {
+    setConfirming(false)
+    setResult(null)
+    startTransition(async () => {
+      const r = await triggerPbsGc(id)
+      if (r.ok) {
+        setResult({ ok: true, message: r.taskId ? `GC started (task ${r.taskId.slice(0, 8)}…)` : 'GC started' })
+      } else {
+        setResult({ ok: false, message: r.error ?? 'Unknown error' })
+      }
+    })
+  }
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+      {!confirming && (
+        <Button variant="ghost" size="sm" onClick={() => { setConfirming(true); setResult(null) }} disabled={isPending}>
+          {isPending ? 'Starting…' : 'Run GC now'}
+        </Button>
+      )}
+      {confirming && (
+        <>
+          <span style={{ fontSize: 12, color: 'var(--fg-mute)' }}>
+            Run garbage collection? Rebuilds the chunk reference index.
+          </span>
+          <Button variant="primary" size="sm" onClick={onConfirm} disabled={isPending}>Confirm</Button>
+          <Button variant="ghost" size="sm" onClick={() => setConfirming(false)} disabled={isPending}>Cancel</Button>
+        </>
+      )}
+      {result && (
+        <span style={{ fontSize: 11, color: result.ok ? 'var(--ok)' : 'var(--err)' }}>
+          {result.ok ? '✓ ' : '✗ '}{result.message}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/pbs/datastores/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/pbs/datastores/[id]/page.tsx
@@ -1,0 +1,90 @@
+import { redirect, notFound } from 'next/navigation'
+import { getDb, pbsDatastores, eq } from '@backupos/db'
+import { getCurrentUser } from '@/lib/user'
+import { EditScheduleForm } from './EditScheduleForm'
+import { StatsRefreshButton } from './StatsRefreshButton'
+import { TriggerGcButton } from './TriggerGcButton'
+import { DangerZone } from './DangerZone'
+
+export const dynamic = 'force-dynamic'
+
+function bytesToHuman(n: number | null | undefined): string {
+  if (n == null) return '—'
+  if (n < 1024) return `${n} B`
+  const units = ['KB', 'MB', 'GB', 'TB', 'PB']
+  let v = n / 1024
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++ }
+  return `${v.toFixed(1)} ${units[i]}`
+}
+
+export default async function PbsDatastoreDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const user = await getCurrentUser()
+  if (!user) redirect('/login')
+  if (user.role !== 'admin') redirect('/dashboard')
+
+  const { id } = await params
+  const db = getDb()
+  const [ds] = await db.select().from(pbsDatastores).where(eq(pbsDatastores.id, id)).limit(1)
+  if (!ds) notFound()
+
+  return (
+    <div style={{ maxWidth: 800, padding: '32px 0' }}>
+      <a href="/pbs" style={{ display: 'inline-block', fontSize: 13, color: 'var(--fg-dim)', textDecoration: 'none', marginBottom: 24 }}>
+        ← Back to datastores
+      </a>
+      <h1 style={{ fontSize: 22, fontWeight: 700, color: 'var(--fg)', marginBottom: 4 }}>
+        <code style={{ fontSize: 22 }}>{ds.name}</code>
+      </h1>
+      <p style={{ fontSize: 13, color: 'var(--fg-dim)', marginBottom: 28 }}>
+        <code style={{ fontSize: 12 }}>{ds.path}</code>
+      </p>
+
+      {/* Stats panel */}
+      <section style={{ marginBottom: 32, padding: 20, border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+          <h2 style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', margin: 0 }}>Storage</h2>
+          <StatsRefreshButton id={ds.id} />
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16 }}>
+          <Stat label="Total"  value={bytesToHuman(ds.totalSizeBytes)}  />
+          <Stat label="Used"   value={bytesToHuman(ds.uniqueSizeBytes)} />
+          <Stat label="Chunks" value={ds.chunkCount?.toLocaleString() ?? '—'} />
+        </div>
+      </section>
+
+      {/* Schedules panel */}
+      <section style={{ marginBottom: 32, padding: 20, border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)' }}>
+        <h2 style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', marginTop: 0, marginBottom: 16 }}>Schedules</h2>
+        <EditScheduleForm
+          id={ds.id}
+          initialPruneSchedule={ds.pruneSchedule ?? ''}
+          initialGcSchedule={ds.gcSchedule ?? ''}
+        />
+      </section>
+
+      {/* Garbage collection panel */}
+      <section style={{ marginBottom: 32, padding: 20, border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+          <h2 style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', margin: 0 }}>Garbage collection</h2>
+          <TriggerGcButton id={ds.id} />
+        </div>
+        <p style={{ fontSize: 13, color: 'var(--fg-dim)', margin: 0 }}>
+          Last run: {ds.lastGcAt ? new Date(ds.lastGcAt).toLocaleString() : '—'}
+        </p>
+      </section>
+
+      {/* Danger zone */}
+      <DangerZone id={ds.id} name={ds.name} />
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div style={{ fontSize: 11, color: 'var(--fg-dim)', textTransform: 'uppercase', letterSpacing: 0.5 }}>{label}</div>
+      <div style={{ fontSize: 18, fontWeight: 600, color: 'var(--fg)', marginTop: 4 }}>{value}</div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/pbs/page.tsx
+++ b/apps/web/app/(dashboard)/pbs/page.tsx
@@ -18,10 +18,15 @@ export default async function PbsIndexPage() {
     .orderBy(desc(pbsDatastores.createdAt))
 
   const datastores = rows.map(r => ({
-    id:        r.id,
-    name:      r.name,
-    path:      r.path,
-    createdAt: r.createdAt.toISOString(),
+    id:              r.id,
+    name:            r.name,
+    path:            r.path,
+    createdAt:       r.createdAt.toISOString(),
+    pruneSchedule:   r.pruneSchedule,
+    gcSchedule:      r.gcSchedule,
+    lastGcAt:        r.lastGcAt?.toISOString() ?? null,
+    totalSizeBytes:  r.totalSizeBytes,
+    uniqueSizeBytes: r.uniqueSizeBytes,
   }))
 
   return (

--- a/apps/web/app/actions/pbs-datastores.ts
+++ b/apps/web/app/actions/pbs-datastores.ts
@@ -5,10 +5,12 @@ import { redirect }       from 'next/navigation'
 import { rm }             from 'node:fs/promises'
 import { join }           from 'node:path'
 import { randomBytes }    from 'node:crypto'
+import { request as httpsRequest, Agent } from 'node:https'
 import { getDb, pbsDatastores, eq } from '@backupos/db'
 import { FsChunkStore }   from '@backupos/pbs-storage'
 import { requireAdmin }   from '@/lib/user'
 import { appendAuditEntry } from '@/lib/audit'
+import { getPbsServerInfo } from '@/lib/pbs-server'
 
 /**
  * Root under which each datastore creates a named subdirectory.
@@ -20,6 +22,76 @@ import { appendAuditEntry } from '@/lib/audit'
  * and key.pem; they are outside any datastore directory.
  */
 const PBS_ROOT = '/var/lib/backupos/pbs'
+
+// ── Internal HTTP helper ──────────────────────────────────────────────────────
+
+interface PbsInternalRequestOpts {
+  path:   string
+  method: 'GET' | 'POST'
+  body?:  string
+}
+interface PbsInternalResult {
+  ok:      boolean
+  status?: number
+  body?:   string
+  error?:  string
+}
+
+async function pbsInternalRequest(opts: PbsInternalRequestOpts): Promise<PbsInternalResult> {
+  const internalSecret = process.env['BACKUPOS_INTERNAL_SECRET']
+  if (!internalSecret) {
+    return { ok: false, error: 'BACKUPOS_INTERNAL_SECRET not set' }
+  }
+  let server
+  try {
+    server = await getPbsServerInfo()
+  } catch (e) {
+    return { ok: false, error: `Could not read PBS server info: ${(e as Error).message}` }
+  }
+  return new Promise((resolve) => {
+    const agent = new Agent({ rejectUnauthorized: false })
+    const req = httpsRequest({
+      host:   'localhost',
+      port:   server.port,
+      path:   opts.path,
+      method: opts.method,
+      agent,
+      headers: {
+        'Authorization': `Bearer ${internalSecret}`,
+        ...(opts.body
+          ? { 'Content-Type': 'application/json', 'Content-Length': String(Buffer.byteLength(opts.body)) }
+          : {}),
+      },
+      timeout: 30_000,
+    }, (res) => {
+      const peerCert = (res.socket as NodeJS.Socket & {
+        getPeerCertificate?: () => { fingerprint256?: string }
+      }).getPeerCertificate?.()
+      if (peerCert?.fingerprint256 && peerCert.fingerprint256 !== server.fingerprint) {
+        resolve({ ok: false, error: 'PBS server certificate fingerprint mismatch' })
+        req.destroy()
+        return
+      }
+      const chunks: Buffer[] = []
+      res.on('data', (c: Buffer) => chunks.push(c))
+      res.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf8')
+        resolve({
+          ok:     (res.statusCode ?? 0) >= 200 && (res.statusCode ?? 0) < 300,
+          status: res.statusCode,
+          body,
+          error:  (res.statusCode ?? 0) >= 400 ? `HTTP ${res.statusCode}: ${body.slice(0, 200)}` : undefined,
+        })
+      })
+    })
+    req.on('error', (err) => resolve({ ok: false, error: err.message }))
+    req.on('timeout', () => { req.destroy(); resolve({ ok: false, error: 'Request timed out' }) })
+    if (opts.body) req.write(opts.body)
+    req.end()
+  })
+}
+
+// ── Existing actions ──────────────────────────────────────────────────────────
 
 export interface CreatePbsDatastoreResult {
   id?:    string
@@ -124,4 +196,127 @@ export async function deletePbsDatastore(id: string): Promise<{ error?: string }
 
   revalidatePath('/pbs')
   return {}
+}
+
+// ── New actions ───────────────────────────────────────────────────────────────
+
+export interface UpdatePbsDatastoreInput {
+  id:            string
+  pruneSchedule: string | null
+  gcSchedule:    string | null
+}
+
+export async function updatePbsDatastore(input: UpdatePbsDatastoreInput): Promise<{ error?: string }> {
+  const adminUser = await requireAdmin()
+  const db = getDb()
+
+  if (input.pruneSchedule !== null && input.pruneSchedule.length > 64) {
+    return { error: 'Prune schedule too long (max 64 chars)' }
+  }
+  if (input.gcSchedule !== null && input.gcSchedule.length > 64) {
+    return { error: 'GC schedule too long (max 64 chars)' }
+  }
+
+  const [existing] = await db.select().from(pbsDatastores).where(eq(pbsDatastores.id, input.id)).limit(1)
+  if (!existing) return { error: 'Datastore not found' }
+
+  await db.update(pbsDatastores)
+    .set({
+      pruneSchedule: input.pruneSchedule,
+      gcSchedule:    input.gcSchedule,
+    })
+    .where(eq(pbsDatastores.id, input.id))
+
+  void appendAuditEntry({
+    action:       'pbs_datastore.updated',
+    resourceType: 'pbs_datastore',
+    resourceId:   input.id,
+    resourceName: existing.name,
+    actor:        adminUser.id,
+    detail:       { pruneSchedule: input.pruneSchedule, gcSchedule: input.gcSchedule },
+  })
+
+  revalidatePath(`/pbs/datastores/${input.id}`)
+  revalidatePath('/pbs')
+  return {}
+}
+
+export interface SyncStatsResult {
+  ok:     boolean
+  total?: number
+  used?:  number
+  avail?: number
+  error?: string
+}
+
+export async function syncPbsDatastoreStats(id: string): Promise<SyncStatsResult> {
+  await requireAdmin()
+  const db = getDb()
+
+  const [ds] = await db.select().from(pbsDatastores).where(eq(pbsDatastores.id, id)).limit(1)
+  if (!ds) return { ok: false, error: 'Datastore not found' }
+
+  const result = await pbsInternalRequest({
+    path:   `/api2/internal/datastore/${encodeURIComponent(ds.name)}/status`,
+    method: 'GET',
+  })
+  if (!result.ok) return { ok: false, error: result.error ?? 'Unknown error' }
+
+  let parsed: { total: number; used: number; avail: number }
+  try {
+    const json = JSON.parse(result.body ?? '{}') as { data?: typeof parsed } & typeof parsed
+    parsed = json.data ?? json
+  } catch {
+    return { ok: false, error: 'Could not parse PBS response' }
+  }
+
+  await db.update(pbsDatastores)
+    .set({
+      totalSizeBytes:  parsed.total,
+      uniqueSizeBytes: parsed.used,
+    })
+    .where(eq(pbsDatastores.id, id))
+
+  revalidatePath(`/pbs/datastores/${id}`)
+  return { ok: true, total: parsed.total, used: parsed.used, avail: parsed.avail }
+}
+
+export interface TriggerGcResult {
+  ok:      boolean
+  taskId?: string
+  error?:  string
+}
+
+export async function triggerPbsGc(id: string): Promise<TriggerGcResult> {
+  const adminUser = await requireAdmin()
+  const db = getDb()
+
+  const [ds] = await db.select().from(pbsDatastores).where(eq(pbsDatastores.id, id)).limit(1)
+  if (!ds) return { ok: false, error: 'Datastore not found' }
+
+  const result = await pbsInternalRequest({
+    path:   `/api2/internal/datastore/${encodeURIComponent(ds.name)}/gc`,
+    method: 'POST',
+  })
+
+  if (result.status === 409) return { ok: false, error: 'Garbage collection is already running for this datastore' }
+  if (!result.ok) return { ok: false, error: result.error ?? 'Unknown error' }
+
+  let taskId: string | undefined
+  try {
+    const json = JSON.parse(result.body ?? '{}') as { data?: { task_id?: string } }
+    taskId = json.data?.task_id
+  } catch { /* ignore */ }
+
+  void appendAuditEntry({
+    action:       'pbs_datastore.gc_triggered',
+    resourceType: 'pbs_datastore',
+    resourceId:   id,
+    resourceName: ds.name,
+    actor:        adminUser.id,
+    detail:       { taskId },
+  })
+
+  revalidatePath(`/pbs/datastores/${id}`)
+  return { ok: true, taskId }
 }

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -18,7 +18,7 @@ export type AuditAction =
   | 'user.created'
   | 'user.role_changed'
   | 'pbs_token.created' | 'pbs_token.revoked'
-  | 'pbs_datastore.created' | 'pbs_datastore.deleted'
+  | 'pbs_datastore.created' | 'pbs_datastore.deleted' | 'pbs_datastore.updated' | 'pbs_datastore.gc_triggered'
 
 function canonical(fields: {
   action: string; resourceType: string; resourceId?: string | null;

--- a/services/backupos-pbs/cmd/backupos-pbs/main.go
+++ b/services/backupos-pbs/cmd/backupos-pbs/main.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/internalauth"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/blob"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/jobsync"
 	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/datastore"
@@ -219,6 +220,30 @@ func main() {
 		},
 	))
 	mux.HandleFunc("/api2/json/admin/self-test/datastore/", selfTestHandler.ServeHTTP)
+
+	// Internal-only routes, gated by BACKUPOS_INTERNAL_SECRET (no PBS token required).
+	// Used by the web UI for stats sync and manual GC trigger.
+	//
+	//   GET  /api2/internal/datastore/<store>/status  → datastoreStatusHandler
+	//   POST /api2/internal/datastore/<store>/gc      → gcAdminHandler (start GC)
+	//   GET  /api2/internal/datastore/<store>/gc      → gcAdminHandler (last status)
+	//
+	// Path is rewritten from /api2/internal/... to /api2/json/admin/... before
+	// forwarding so the underlying handlers' path parsing works unchanged.
+	mux.Handle("/api2/internal/datastore/", internalauth.Middleware(internalSecret,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.URL.Path = strings.Replace(r.URL.Path, "/api2/internal/datastore/", "/api2/json/admin/datastore/", 1)
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/gc"):
+				gcAdminHandler.ServeHTTP(w, r)
+			case strings.HasSuffix(r.URL.Path, "/status"):
+				datastoreStatusHandler.ServeHTTP(w, r)
+			default:
+				http.NotFound(w, r)
+			}
+		}),
+	))
+
 	mux.HandleFunc("/", notFound)
 
 	// serverCtx is cancelled on SIGINT/SIGTERM so background goroutines

--- a/services/backupos-pbs/internal/internalauth/internalauth.go
+++ b/services/backupos-pbs/internal/internalauth/internalauth.go
@@ -1,0 +1,55 @@
+// Package internalauth provides middleware for endpoints that should only be
+// callable by the local backupos.service (web process) — never by external
+// PBS clients.
+//
+// Requires header: Authorization: Bearer <BACKUPOS_INTERNAL_SECRET>
+//
+// The secret is read once at handler construction; rotating it requires a
+// service restart (which is fine — it's set in /etc/backupos/server.env).
+package internalauth
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/auth"
+)
+
+// syntheticIdentity is injected into context for requests that pass internal
+// auth. Empty TokenDatastoreID means unrestricted — AuthorizeDatastore passes
+// for any datastore.
+var syntheticIdentity = &auth.Identity{
+	TokenID:          "internal",
+	User:             "backupos",
+	Realm:            "internal",
+	TokenName:        "internal",
+	Permissions:      "admin",
+	TokenDatastoreID: "",
+}
+
+// Middleware wraps next, rejecting requests without a valid bearer token.
+// If secret is empty, EVERY request is rejected (fail-closed).
+// On success, a synthetic admin Identity is injected into the context so
+// downstream handlers that call auth.AuthorizeDatastore pass unconditionally.
+func Middleware(secret string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if secret == "" {
+			http.Error(w, "internal auth not configured", http.StatusServiceUnavailable)
+			return
+		}
+		gotAuth := r.Header.Get("Authorization")
+		const prefix = "Bearer "
+		if !strings.HasPrefix(gotAuth, prefix) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		got := gotAuth[len(prefix):]
+		if subtle.ConstantTimeCompare([]byte(got), []byte(secret)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		ctx := auth.WithIdentity(r.Context(), syntheticIdentity)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/services/backupos-pbs/internal/internalauth/internalauth_test.go
+++ b/services/backupos-pbs/internal/internalauth/internalauth_test.go
@@ -1,0 +1,58 @@
+package internalauth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dariusvorster/backupos/services/backupos-pbs/internal/internalauth"
+)
+
+const testSecret = "supersecret"
+
+func okHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func TestMiddleware_EmptySecret_Returns503(t *testing.T) {
+	h := internalauth.Middleware("", http.HandlerFunc(okHandler))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer anything")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rr.Code)
+	}
+}
+
+func TestMiddleware_MissingAuthHeader_Returns401(t *testing.T) {
+	h := internalauth.Middleware(testSecret, http.HandlerFunc(okHandler))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestMiddleware_WrongToken_Returns401(t *testing.T) {
+	h := internalauth.Middleware(testSecret, http.HandlerFunc(okHandler))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer wrongtoken")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestMiddleware_CorrectToken_CallsNext(t *testing.T) {
+	h := internalauth.Middleware(testSecret, http.HandlerFunc(okHandler))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+testSecret)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary

- **Go — `internalauth` package**: Bearer-token middleware validates `BACKUPOS_INTERNAL_SECRET`, injects synthetic admin `Identity` into context so `auth.AuthorizeDatastore()` passes for any datastore. Fails closed (503) when secret is empty.
- **Go — internal routes**: `GET/POST /api2/internal/datastore/<store>/status|gc` path-rewrite to existing handlers, gated by `internalauth.Middleware`
- **Web — 3 new server actions**: `updatePbsDatastore`, `syncPbsDatastoreStats`, `triggerPbsGc` + `pbsInternalRequest` HTTPS helper with fingerprint verification
- **Web — detail page** at `/pbs/datastores/[id]`: storage stats panel, cron schedule editor, GC panel with confirm-then-run, danger zone with name-typed delete
- **Web — list page**: added Size / GC schedule / Last GC columns; name is now a link to detail page; inline Delete button removed (moved to DangerZone on detail page)
- **`audit.ts`**: added `pbs_datastore.updated` and `pbs_datastore.gc_triggered` action types

## Notes

Go is not installed in the dev environment — Go build must be verified on the deployment server (`go build ./...` and `go test ./internal/internalauth/...`). Web build passes clean locally.

## Test plan

- [x] `pnpm --filter @backupos/web build` — clean
- [ ] `cd services/backupos-pbs && go build ./...` — verify on server
- [ ] `cd services/backupos-pbs && go test ./internal/internalauth/...` — 4 tests
- [ ] Smoke test per spec (Darius to run post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)