### PR TITLE
feat(verification): edit and delete UI for verification tests (closes #161)

### DIFF
--- a/apps/web/app/(dashboard)/verification/[id]/DeleteTestButton.tsx
+++ b/apps/web/app/(dashboard)/verification/[id]/DeleteTestButton.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { deleteVerificationTest } from '@/app/actions/verification'
+
+interface Props {
+  id:   string
+  name: string
+}
+
+export function DeleteTestButton({ id, name }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+
+  function onDelete() {
+    if (!confirm(
+      `Delete verification test "${name}"?\n\n` +
+      `This permanently removes the test and all its run history. ` +
+      `This cannot be undone.`,
+    )) return
+    startTransition(async () => {
+      const result = await deleteVerificationTest(id)
+      if (result.error) {
+        alert(`Delete failed: ${result.error}`)
+        return
+      }
+      router.push('/verification')
+    })
+  }
+
+  return (
+    <Button variant="ghost" size="md" onClick={onDelete} disabled={isPending}>
+      {isPending ? 'Deleting…' : 'Delete'}
+    </Button>
+  )
+}

--- a/apps/web/app/(dashboard)/verification/[id]/edit/EditVerificationForm.tsx
+++ b/apps/web/app/(dashboard)/verification/[id]/edit/EditVerificationForm.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { updateVerificationTest } from '@/app/actions/verification'
+
+interface SshInitial {
+  host:          string
+  port:          number
+  user:          string
+  remoteDir:     string
+  cleanupRemote: boolean
+}
+
+interface Props {
+  id:                    string
+  targetType:            string
+  initialName:           string
+  initialSchedule:       string
+  initialValidationHook: string
+  initialSsh:            SshInitial | null
+}
+
+export function EditVerificationForm(props: Props) {
+  const router = useRouter()
+  const [name,           setName]           = useState(props.initialName)
+  const [schedule,       setSchedule]       = useState(props.initialSchedule)
+  const [validationHook, setValidationHook] = useState(props.initialValidationHook)
+
+  const [sshHost,       setSshHost]       = useState(props.initialSsh?.host ?? '')
+  const [sshPort,       setSshPort]       = useState(String(props.initialSsh?.port ?? 22))
+  const [sshUser,       setSshUser]       = useState(props.initialSsh?.user ?? '')
+  const [sshKey,        setSshKey]        = useState('')  // blank = keep existing
+  const [remoteDir,     setRemoteDir]     = useState(props.initialSsh?.remoteDir ?? '')
+  const [cleanupRemote, setCleanupRemote] = useState(props.initialSsh?.cleanupRemote ?? true)
+
+  const [error, setError]            = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function onSave() {
+    setError(null)
+    startTransition(async () => {
+      const result = await updateVerificationTest({
+        id:             props.id,
+        name,
+        schedule,
+        validationHook,
+        ...(props.targetType === 'ssh_target' ? {
+          sshHost,
+          sshPort:       parseInt(sshPort, 10) || 22,
+          sshUser,
+          sshKey,
+          remoteDir,
+          cleanupRemote,
+        } : {}),
+      })
+      if (result.error) { setError(result.error); return }
+      router.push(`/verification/${props.id}`)
+    })
+  }
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%', padding: '8px 12px', boxSizing: 'border-box',
+    backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-sm)', color: 'var(--fg)', fontSize: 14, outline: 'none',
+  }
+  const labelStyle: React.CSSProperties = {
+    display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6, fontWeight: 500,
+  }
+  const fieldGroup: React.CSSProperties = { marginBottom: 20 }
+
+  return (
+    <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)', padding: 24 }}>
+      <div style={fieldGroup}>
+        <label style={labelStyle}>Name</label>
+        <input
+          type="text"
+          required
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          disabled={isPending}
+          style={inputStyle}
+        />
+      </div>
+
+      <div style={fieldGroup}>
+        <label style={labelStyle}>Target type</label>
+        <input
+          type="text"
+          value={props.targetType.replace(/_/g, ' ')}
+          disabled
+          style={{ ...inputStyle, color: 'var(--fg-mute)' }}
+        />
+        <p style={{ fontSize: 12, color: 'var(--fg-mute)', marginTop: 6 }}>
+          Target type cannot be changed after creation. Delete and recreate the test to change.
+        </p>
+      </div>
+
+      {props.targetType === 'ssh_target' && (
+        <>
+          <div style={fieldGroup}>
+            <label style={labelStyle}>SSH host</label>
+            <input type="text" required value={sshHost} onChange={(e) => setSshHost(e.target.value)} disabled={isPending} style={inputStyle} />
+          </div>
+          <div style={{ ...fieldGroup, display: 'grid', gridTemplateColumns: '1fr 100px', gap: 12 }}>
+            <div>
+              <label style={labelStyle}>SSH user</label>
+              <input type="text" required value={sshUser} onChange={(e) => setSshUser(e.target.value)} disabled={isPending} style={inputStyle} />
+            </div>
+            <div>
+              <label style={labelStyle}>Port</label>
+              <input type="number" value={sshPort} onChange={(e) => setSshPort(e.target.value)} disabled={isPending} style={inputStyle} />
+            </div>
+          </div>
+          <div style={fieldGroup}>
+            <label style={labelStyle}>Remote directory</label>
+            <input type="text" required value={remoteDir} onChange={(e) => setRemoteDir(e.target.value)} disabled={isPending} style={inputStyle} />
+          </div>
+          <div style={fieldGroup}>
+            <label style={labelStyle}>SSH private key (leave blank to keep existing)</label>
+            <textarea
+              value={sshKey}
+              onChange={(e) => setSshKey(e.target.value)}
+              disabled={isPending}
+              rows={6}
+              placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"
+              style={{ ...inputStyle, fontFamily: 'var(--font-mono)', fontSize: 12 }}
+            />
+          </div>
+          <div style={{ ...fieldGroup, display: 'flex', alignItems: 'center', gap: 8 }}>
+            <input
+              type="checkbox"
+              id="cleanup-remote"
+              checked={cleanupRemote}
+              onChange={(e) => setCleanupRemote(e.target.checked)}
+              disabled={isPending}
+            />
+            <label htmlFor="cleanup-remote" style={{ fontSize: 13, color: 'var(--fg)' }}>
+              Clean up remote directory after verification
+            </label>
+          </div>
+        </>
+      )}
+
+      <div style={fieldGroup}>
+        <label style={labelStyle}>Validation hook</label>
+        <input
+          type="text"
+          value={validationHook}
+          onChange={(e) => setValidationHook(e.target.value)}
+          disabled={isPending}
+          placeholder="e.g. test -f /tmp/restore/important.db"
+          style={{ ...inputStyle, fontFamily: 'var(--font-mono)', fontSize: 12 }}
+        />
+        <p style={{ fontSize: 12, color: 'var(--fg-mute)', marginTop: 6 }}>
+          Optional shell command run after restore. Non-zero exit = test fails. Leave blank to skip.
+        </p>
+      </div>
+
+      <div style={fieldGroup}>
+        <label style={labelStyle}>Schedule (cron)</label>
+        <input
+          type="text"
+          required
+          value={schedule}
+          onChange={(e) => setSchedule(e.target.value)}
+          disabled={isPending}
+          placeholder="0 3 * * 0"
+          style={{ ...inputStyle, fontFamily: 'var(--font-mono)', fontSize: 12 }}
+        />
+      </div>
+
+      {error && (
+        <div style={{ marginBottom: 16, padding: '10px 14px', fontSize: 13, color: 'var(--err)', border: '1px solid var(--err)', borderRadius: 'var(--radius-sm)' }}>
+          {error}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 8 }}>
+        <Button variant="primary" size="md" onClick={onSave} disabled={isPending}>
+          {isPending ? 'Saving…' : 'Save changes'}
+        </Button>
+        <Button variant="ghost" size="md" onClick={() => router.push(`/verification/${props.id}`)} disabled={isPending}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/verification/[id]/edit/page.tsx
+++ b/apps/web/app/(dashboard)/verification/[id]/edit/page.tsx
@@ -1,0 +1,55 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { getDb, verificationTests, eq } from '@backupos/db'
+import { EditVerificationForm } from './EditVerificationForm'
+
+export const dynamic = 'force-dynamic'
+
+interface SshConfig {
+  host:          string
+  port:          number
+  user:          string
+  remoteDir:     string
+  cleanupRemote: boolean
+}
+
+export default async function EditVerificationPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const db = getDb()
+
+  const [test] = await db.select().from(verificationTests).where(eq(verificationTests.id, id)).limit(1)
+  if (!test) notFound()
+
+  let sshConfig: SshConfig | null = null
+  if (test.targetType === 'ssh_target' && test.targetConfig) {
+    try {
+      const cfg = JSON.parse(test.targetConfig) as Record<string, string | number | boolean>
+      sshConfig = {
+        host:          (cfg['host'] as string) ?? '',
+        port:          (cfg['port'] as number) ?? 22,
+        user:          (cfg['user'] as string) ?? '',
+        remoteDir:     (cfg['remoteDir'] as string) ?? '',
+        cleanupRemote: (cfg['cleanupRemote'] as boolean) ?? true,
+      }
+    } catch { /* leave null */ }
+  }
+
+  return (
+    <div style={{ maxWidth: 640 }}>
+      <div style={{ marginBottom: 24 }}>
+        <Link href={`/verification/${id}`} style={{ fontSize: 13, color: 'var(--fg-mute)', textDecoration: 'none' }}>
+          ← {test.name}
+        </Link>
+        <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginTop: 8 }}>Edit verification test</h1>
+      </div>
+      <EditVerificationForm
+        id={id}
+        targetType={test.targetType}
+        initialName={test.name}
+        initialSchedule={test.schedule ?? ''}
+        initialValidationHook={test.validationHook ?? ''}
+        initialSsh={sshConfig}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/verification/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/verification/[id]/page.tsx
@@ -3,7 +3,9 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { getDb, verificationTests, verificationRuns, backupJobs, eq, desc } from '@backupos/db'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { RunVerificationButton } from './run-verification-button'
+import { DeleteTestButton } from './DeleteTestButton'
 import { PollWrapper } from '@/components/poll-wrapper'
 
 type BadgeStatus = ComponentProps<typeof Badge>['status']
@@ -109,6 +111,10 @@ export default async function VerificationDetailPage({ params }: { params: Promi
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginTop: 8 }}>
           <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)' }}>{test.name}</h1>
           <div style={{ display: 'flex', gap: 10 }}>
+            <Link href={`/verification/${id}/edit`} style={{ textDecoration: 'none' }}>
+              <Button variant="ghost" size="md">Edit</Button>
+            </Link>
+            <DeleteTestButton id={id} name={test.name} />
             <RunVerificationButton testId={id} />
           </div>
         </div>

--- a/apps/web/app/actions/verification.ts
+++ b/apps/web/app/actions/verification.ts
@@ -8,6 +8,7 @@ import { dispatchToAgent } from '@/lib/internal-dispatch'
 import { connectedAgentIds } from '@/lib/ws-state'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 import { requireAdmin } from '@/lib/user'
+import { appendAuditEntry } from '@/lib/audit'
 
 export async function createVerificationTest(data: {
   name: string
@@ -135,4 +136,105 @@ export async function runVerification(testId: string): Promise<void> {
   }
 
   revalidatePath(`/verification/${testId}`)
+}
+
+// ── Edit / Delete ─────────────────────────────────────────────────────────────
+
+export interface UpdateVerificationTestInput {
+  id:             string
+  name:           string
+  schedule:       string
+  validationHook: string
+  sshHost?:       string
+  sshPort?:       number
+  sshUser?:       string
+  sshKey?:        string  // empty = keep existing
+  remoteDir?:     string
+  cleanupRemote?: boolean
+}
+
+export async function updateVerificationTest(input: UpdateVerificationTestInput): Promise<{ error?: string }> {
+  const adminUser = await requireAdmin()
+  const db = getDb()
+
+  if (!input.name?.trim()) return { error: 'Name is required' }
+  if (!input.schedule?.trim()) return { error: 'Schedule is required' }
+  if (input.name.length > 200) return { error: 'Name too long (max 200 chars)' }
+
+  try {
+    const { parseExpression } = await import('cron-parser')
+    parseExpression(input.schedule)
+  } catch (err) {
+    return { error: `Invalid cron expression: ${(err as Error).message}` }
+  }
+
+  const [existing] = await db.select().from(verificationTests).where(eq(verificationTests.id, input.id)).limit(1)
+  if (!existing) return { error: 'Verification test not found' }
+
+  let nextTargetConfig: string | null = existing.targetConfig
+  if (existing.targetType === 'ssh_target') {
+    if (!input.sshHost || !input.sshUser || !input.remoteDir) {
+      return { error: 'SSH host, user, and remote directory are required for SSH targets' }
+    }
+    const oldCfg = existing.targetConfig
+      ? JSON.parse(existing.targetConfig) as Record<string, string | number | boolean>
+      : {}
+    const oldSshKeyEncrypted = typeof oldCfg['sshKey'] === 'string' ? oldCfg['sshKey'] as string : null
+    const newSshKeyEncrypted = input.sshKey?.trim()
+      ? encryptField(input.sshKey)
+      : oldSshKeyEncrypted
+
+    nextTargetConfig = JSON.stringify({
+      host:          input.sshHost,
+      port:          input.sshPort ?? 22,
+      user:          input.sshUser,
+      sshKey:        newSshKeyEncrypted,
+      remoteDir:     input.remoteDir,
+      cleanupRemote: input.cleanupRemote ?? true,
+    })
+  }
+
+  await db.update(verificationTests)
+    .set({
+      name:           input.name.trim(),
+      schedule:       input.schedule.trim(),
+      validationHook: input.validationHook?.trim() || null,
+      targetConfig:   nextTargetConfig,
+    })
+    .where(eq(verificationTests.id, input.id))
+
+  void appendAuditEntry({
+    action:       'verification.updated',
+    resourceType: 'verification_test',
+    resourceId:   input.id,
+    resourceName: input.name.trim(),
+    actor:        adminUser.id,
+    detail:       { schedule: input.schedule, hookChanged: input.validationHook !== existing.validationHook },
+  })
+
+  revalidatePath(`/verification/${input.id}`)
+  revalidatePath('/verification')
+  return {}
+}
+
+export async function deleteVerificationTest(id: string): Promise<{ error?: string }> {
+  const adminUser = await requireAdmin()
+  const db = getDb()
+
+  const [existing] = await db.select().from(verificationTests).where(eq(verificationTests.id, id)).limit(1)
+  if (!existing) return { error: 'Verification test not found' }
+
+  await db.delete(verificationRuns).where(eq(verificationRuns.testId, id))
+  await db.delete(verificationTests).where(eq(verificationTests.id, id))
+
+  void appendAuditEntry({
+    action:       'verification.deleted',
+    resourceType: 'verification_test',
+    resourceId:   id,
+    resourceName: existing.name,
+    actor:        adminUser.id,
+  })
+
+  revalidatePath('/verification')
+  return {}
 }

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -19,6 +19,7 @@ export type AuditAction =
   | 'user.role_changed'
   | 'pbs_token.created' | 'pbs_token.revoked'
   | 'pbs_datastore.created' | 'pbs_datastore.deleted' | 'pbs_datastore.updated' | 'pbs_datastore.gc_triggered'
+  | 'verification.updated' | 'verification.deleted'
 
 function canonical(fields: {
   action: string; resourceType: string; resourceId?: string | null;


### PR DESCRIPTION
## Summary

- **`updateVerificationTest`**: name, schedule, validation hook editable; SSH target config (host/user/port/remoteDir/cleanupRemote) editable with blank sshKey = keep existing encrypted value; cron expression validated via `cron-parser` before writing
- **`deleteVerificationTest`**: cascades `verificationRuns` before deleting test row
- **`audit.ts`**: added `verification.updated` and `verification.deleted` to `AuditAction` union
- **Detail page** (`/verification/[id]`): Edit link + Delete button rendered next to Run button
- **Edit page** (`/verification/[id]/edit`): pre-filled server component + `EditVerificationForm` client component; targetType shows as disabled field with explanatory note (cannot change after creation)
- **`DeleteTestButton`**: browser `confirm()` dialog, redirects to `/verification` list on success

## Test plan

- [x] `pnpm --filter @backupos/web build` — clean; `/verification/[id]/edit` appears in output
- [ ] Smoke test per spec (Darius to run post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)