### PR TITLE
fix(verification): use static cron-parser import (follow-up to #322)

### DIFF
--- a/apps/web/app/actions/verification.ts
+++ b/apps/web/app/actions/verification.ts
@@ -9,6 +9,7 @@ import { connectedAgentIds } from '@/lib/ws-state'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 import { requireAdmin } from '@/lib/user'
 import { appendAuditEntry } from '@/lib/audit'
+import { parseExpression } from 'cron-parser'
 
 export async function createVerificationTest(data: {
   name: string
@@ -162,7 +163,6 @@ export async function updateVerificationTest(input: UpdateVerificationTestInput)
   if (input.name.length > 200) return { error: 'Name too long (max 200 chars)' }
 
   try {
-    const { parseExpression } = await import('cron-parser')
     parseExpression(input.schedule)
   } catch (err) {
     return { error: `Invalid cron expression: ${(err as Error).message}` }


### PR DESCRIPTION
## Summary

`cron-parser` v4 when dynamic-imported causes `parseExpression` to destructure as `undefined`, throwing "b is not a function" at runtime. Switch to a static top-level import, matching the pattern used successfully in `server.ts`.

## Test plan

- [x] `pnpm --filter @backupos/web build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)