### PR TITLE
fix(auth): use requestPasswordReset (correct better-auth v1.6.5 API method)

### DIFF
--- a/apps/web/app/(auth)/forgot-password/form.tsx
+++ b/apps/web/app/(auth)/forgot-password/form.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { requestPasswordReset } from '@/app/actions/forgot-password'
+
+export function ForgotPasswordForm() {
+  const [submitting, setSubmitting] = useState(false)
+  const [message, setMessage]       = useState('')
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setSubmitting(true)
+    const result = await requestPasswordReset(new FormData(e.currentTarget))
+    setSubmitting(false)
+    setMessage(result.error ?? result.message)
+  }
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%', padding: '8px 12px', boxSizing: 'border-box',
+    backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-sm)', color: 'var(--fg)', fontSize: 14, outline: 'none',
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: 'var(--bg)' }}>
+      <div style={{ width: 380, backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)', padding: 32 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 24 }}>
+          <svg width="32" height="32" viewBox="0 0 48 48" fill="none">
+            <rect width="48" height="48" rx="12" fill="#1A1206" />
+            <rect x="4" y="4" width="19" height="19" fill="#F5A623" />
+            <rect x="25" y="4" width="19" height="19" fill="#854F0B" />
+            <rect x="4" y="25" width="19" height="19" fill="#854F0B" />
+            <rect x="25" y="25" width="19" height="19" fill="#C77A14" />
+            <rect x="19" y="19" width="10" height="10" fill="#FEF5E0" />
+          </svg>
+          <span style={{ fontSize: 18, fontWeight: 600, color: 'var(--fg)' }}>BackupOS</span>
+        </div>
+
+        <h1 style={{ fontSize: 18, fontWeight: 600, color: 'var(--fg)', marginBottom: 4 }}>Reset password</h1>
+        <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginBottom: 24 }}>
+          Enter your email and we&apos;ll send you a reset link.
+        </p>
+
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: 24 }}>
+            <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6 }}>Email</label>
+            <input name="email" type="email" required placeholder="you@example.com" style={inputStyle} />
+          </div>
+
+          {message && (
+            <div style={{
+              fontSize: 13,
+              color: 'var(--fg)',
+              backgroundColor: 'var(--surf2)',
+              border: '1px solid var(--border)',
+              padding: '10px 14px',
+              borderRadius: 'var(--radius-sm)',
+              marginBottom: 16,
+            }}>
+              {message}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            style={{
+              width: '100%', padding: '9px 16px',
+              backgroundColor: 'var(--accent)', color: 'var(--accent-fg)',
+              border: 'none', borderRadius: 'var(--radius-sm)',
+              fontSize: 14, fontWeight: 600,
+              cursor: submitting ? 'not-allowed' : 'pointer',
+              opacity: submitting ? 0.7 : 1,
+              marginBottom: 12,
+            }}
+          >
+            {submitting ? 'Sending…' : 'Send reset link'}
+          </button>
+
+          <div style={{ textAlign: 'center', fontSize: 13 }}>
+            <Link href="/login" style={{ color: 'var(--fg-mute)', textDecoration: 'none' }}>
+              ← Back to sign in
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(auth)/forgot-password/page.tsx
+++ b/apps/web/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,5 @@
+import { ForgotPasswordForm } from './form'
+
+export default function ForgotPasswordPage() {
+  return <ForgotPasswordForm />
+}

--- a/apps/web/app/(auth)/login/form.tsx
+++ b/apps/web/app/(auth)/login/form.tsx
@@ -60,7 +60,12 @@ export function LoginForm() {
           </div>
 
           <div style={{ marginBottom: 24 }}>
-            <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6 }}>Password</label>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 6 }}>
+              <label style={{ fontSize: 13, color: 'var(--fg-mute)' }}>Password</label>
+              <Link href="/forgot-password" style={{ fontSize: 12, color: 'var(--fg-dim)', textDecoration: 'none' }}>
+                Forgot password?
+              </Link>
+            </div>
             <input name="password" type="password" required placeholder="••••••••" style={inputStyle} />
           </div>
 

--- a/apps/web/app/(auth)/reset-password/[token]/form.tsx
+++ b/apps/web/app/(auth)/reset-password/[token]/form.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { authClient } from '@/lib/auth-client'
+
+interface Props { token: string }
+
+export function ResetPasswordForm({ token }: Props) {
+  const router = useRouter()
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError]           = useState('')
+  const [done, setDone]             = useState(false)
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError('')
+    const form = new FormData(e.currentTarget)
+    const newPassword = form.get('password') as string
+    const confirm     = form.get('confirm')  as string
+    if (newPassword.length < 8) { setError('Password must be at least 8 characters'); return }
+    if (newPassword !== confirm) { setError('Passwords do not match'); return }
+
+    setSubmitting(true)
+    const result = await authClient.resetPassword({ newPassword, token })
+    setSubmitting(false)
+
+    if (result.error) {
+      setError(result.error.message ?? 'Reset failed — link may be expired')
+      return
+    }
+    setDone(true)
+  }
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%', padding: '8px 12px', boxSizing: 'border-box',
+    backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-sm)', color: 'var(--fg)', fontSize: 14, outline: 'none',
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: 'var(--bg)' }}>
+      <div style={{ width: 380, backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)', padding: 32 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 24 }}>
+          <svg width="32" height="32" viewBox="0 0 48 48" fill="none">
+            <rect width="48" height="48" rx="12" fill="#1A1206" />
+            <rect x="4" y="4" width="19" height="19" fill="#F5A623" />
+            <rect x="25" y="4" width="19" height="19" fill="#854F0B" />
+            <rect x="4" y="25" width="19" height="19" fill="#854F0B" />
+            <rect x="25" y="25" width="19" height="19" fill="#C77A14" />
+            <rect x="19" y="19" width="10" height="10" fill="#FEF5E0" />
+          </svg>
+          <span style={{ fontSize: 18, fontWeight: 600, color: 'var(--fg)' }}>BackupOS</span>
+        </div>
+
+        {done ? (
+          <>
+            <h1 style={{ fontSize: 18, fontWeight: 600, color: 'var(--fg)', marginBottom: 4 }}>Password reset</h1>
+            <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginBottom: 24 }}>
+              Your password has been changed. All existing sessions have been signed out.
+            </p>
+            <button
+              onClick={() => router.push('/login')}
+              style={{
+                width: '100%', padding: '9px 16px',
+                backgroundColor: 'var(--accent)', color: 'var(--accent-fg)',
+                border: 'none', borderRadius: 'var(--radius-sm)',
+                fontSize: 14, fontWeight: 600, cursor: 'pointer',
+              }}
+            >
+              Sign in
+            </button>
+          </>
+        ) : (
+          <>
+            <h1 style={{ fontSize: 18, fontWeight: 600, color: 'var(--fg)', marginBottom: 4 }}>Set new password</h1>
+            <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginBottom: 24 }}>
+              Choose a new password for your BackupOS account.
+            </p>
+
+            <form onSubmit={handleSubmit}>
+              <div style={{ marginBottom: 16 }}>
+                <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6 }}>New password</label>
+                <input name="password" type="password" required minLength={8} placeholder="••••••••" style={inputStyle} />
+              </div>
+
+              <div style={{ marginBottom: 24 }}>
+                <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6 }}>Confirm password</label>
+                <input name="confirm" type="password" required minLength={8} placeholder="••••••••" style={inputStyle} />
+              </div>
+
+              {error && <p style={{ fontSize: 13, color: 'var(--err)', marginBottom: 16 }}>{error}</p>}
+
+              <button
+                type="submit"
+                disabled={submitting}
+                style={{
+                  width: '100%', padding: '9px 16px',
+                  backgroundColor: 'var(--accent)', color: 'var(--accent-fg)',
+                  border: 'none', borderRadius: 'var(--radius-sm)',
+                  fontSize: 14, fontWeight: 600,
+                  cursor: submitting ? 'not-allowed' : 'pointer',
+                  opacity: submitting ? 0.7 : 1,
+                  marginBottom: 12,
+                }}
+              >
+                {submitting ? 'Resetting…' : 'Reset password'}
+              </button>
+
+              <div style={{ textAlign: 'center', fontSize: 13 }}>
+                <Link href="/login" style={{ color: 'var(--fg-mute)', textDecoration: 'none' }}>
+                  ← Back to sign in
+                </Link>
+              </div>
+            </form>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(auth)/reset-password/[token]/page.tsx
+++ b/apps/web/app/(auth)/reset-password/[token]/page.tsx
@@ -1,0 +1,6 @@
+import { ResetPasswordForm } from './form'
+
+export default async function ResetPasswordPage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params
+  return <ResetPasswordForm token={token} />
+}

--- a/apps/web/app/(dashboard)/jobs/[id]/edit/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/[id]/edit/page.tsx
@@ -1,10 +1,11 @@
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import Link from 'next/link'
 import { getDb, backupJobs, repositories, agents, eq } from '@backupos/db'
 import { Button } from '@/components/ui/button'
 import { SourceConfigSection } from '@/components/source-config-section'
 import { updateJob } from '@/app/actions/jobs'
 import { CronInput } from '@/components/cron-input'
+import { getCurrentUser, isAdmin } from '@/lib/user'
 
 export default async function EditJobPage({
   params,
@@ -14,6 +15,9 @@ export default async function EditJobPage({
   searchParams: Promise<{ cronError?: string; composeError?: string }>
 }) {
   const { id }      = await params
+  const currentUser = await getCurrentUser()
+  if (!currentUser) redirect('/login')
+  if (!isAdmin(currentUser)) redirect(`/jobs/${id}`)
   const { cronError, composeError } = await searchParams
   const db = getDb()
 

--- a/apps/web/app/(dashboard)/repositories/[id]/edit/page.tsx
+++ b/apps/web/app/(dashboard)/repositories/[id]/edit/page.tsx
@@ -1,11 +1,15 @@
 import { getDb, repositories } from '@backupos/db'
 import { eq } from '@backupos/db'
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import { EditRepositoryForm } from './edit-form'
 import { decryptField } from '@/lib/repo-crypto'
+import { getCurrentUser, isAdmin } from '@/lib/user'
 
 export default async function EditRepositoryPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+  const currentUser = await getCurrentUser()
+  if (!currentUser) redirect('/login')
+  if (!isAdmin(currentUser)) redirect(`/repositories/${id}`)
   const db     = getDb()
   const [repo] = await db.select().from(repositories).where(eq(repositories.id, id)).limit(1)
   if (!repo) notFound()

--- a/apps/web/app/(dashboard)/settings/bandwidth/page.tsx
+++ b/apps/web/app/(dashboard)/settings/bandwidth/page.tsx
@@ -1,8 +1,14 @@
+import { redirect } from 'next/navigation'
+import { getCurrentUser, isAdmin } from '@/lib/user'
 import { getDb, bandwidthProfiles, bandwidthRules } from '@backupos/db'
 import { BandwidthProfileManager } from '@/components/bandwidth-profile-manager'
 import { createProfile } from '@/app/actions/bandwidth'
+import { ViewOnlyBanner } from '@/components/ui/view-only-banner'
 
 export default async function BandwidthSettingsPage({ searchParams }: { searchParams: Promise<{ saved?: string }> }) {
+  const user = await getCurrentUser()
+  if (!user) redirect('/login')
+  const canEdit = isAdmin(user)
   const db       = getDb()
   const profiles = await db.select().from(bandwidthProfiles).all()
   const rules    = await db.select().from(bandwidthRules).all()
@@ -16,6 +22,8 @@ export default async function BandwidthSettingsPage({ searchParams }: { searchPa
   return (
     <div style={{ padding: '32px 40px', maxWidth: 800 }}>
       <a href="/settings" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--fg-dim)', textDecoration: 'none', marginBottom: 24 }}>← Settings</a>
+
+      {!canEdit && <ViewOnlyBanner />}
 
       {saved === '1' && (
         <div style={{ padding: '10px 16px', marginBottom: 20, backgroundColor: 'var(--ok-dim)', border: '1px solid color-mix(in srgb, var(--ok) 30%, transparent)', borderRadius: 'var(--radius-sm)', fontSize: 13, color: 'var(--ok)' }}>
@@ -37,6 +45,7 @@ export default async function BandwidthSettingsPage({ searchParams }: { searchPa
           name="name"
           placeholder="Profile name"
           required
+          disabled={!canEdit}
           style={{
             padding: '7px 12px', fontSize: 13,
             backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
@@ -46,6 +55,7 @@ export default async function BandwidthSettingsPage({ searchParams }: { searchPa
         <input
           name="description"
           placeholder="Description (optional)"
+          disabled={!canEdit}
           style={{
             padding: '7px 12px', fontSize: 13,
             backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
@@ -53,19 +63,19 @@ export default async function BandwidthSettingsPage({ searchParams }: { searchPa
           }}
         />
         <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--fg-mute)', whiteSpace: 'nowrap' }}>
-          <input type="checkbox" name="isGlobal" />
+          <input type="checkbox" name="isGlobal" disabled={!canEdit} />
           Set as global default
         </label>
-        <button type="submit" style={{
-          padding: '7px 16px', fontSize: 13, cursor: 'pointer',
+        <button type="submit" disabled={!canEdit} style={{
+          padding: '7px 16px', fontSize: 13, cursor: canEdit ? 'pointer' : 'default',
           borderRadius: 'var(--radius-sm)', border: 'none',
-          background: 'var(--accent)', color: '#fff',
+          background: 'var(--accent)', color: '#fff', opacity: canEdit ? 1 : 0.5,
         }}>
           Create profile
         </button>
       </form>
 
-      <BandwidthProfileManager profiles={profilesWithRules} />
+      <BandwidthProfileManager profiles={profilesWithRules} canEdit={canEdit} />
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/settings/infra-os/page.tsx
+++ b/apps/web/app/(dashboard)/settings/infra-os/page.tsx
@@ -1,7 +1,10 @@
+import { redirect } from 'next/navigation'
+import { getCurrentUser, isAdmin } from '@/lib/user'
 import { getDb, infraOsServices, backupJobs } from '@backupos/db'
 import { addInfraServiceAction, removeInfraService } from '@/app/actions/infra-os'
 import Link from 'next/link'
 import { Cpu } from 'lucide-react'
+import { ViewOnlyBanner } from '@/components/ui/view-only-banner'
 
 const SERVICE_TYPES = [
   { value: 'database',   label: 'Database',   desc: 'PostgreSQL, MySQL, Redis, etc.' },
@@ -10,6 +13,9 @@ const SERVICE_TYPES = [
 ]
 
 export default async function InfraOsSettingsPage({ searchParams }: { searchParams: Promise<{ saved?: string }> }) {
+  const user = await getCurrentUser()
+  if (!user) redirect('/login')
+  const canEdit = isAdmin(user)
   const db       = getDb()
   const services = await db.select().from(infraOsServices).all()
   const { saved } = await searchParams
@@ -31,6 +37,8 @@ export default async function InfraOsSettingsPage({ searchParams }: { searchPara
           Register the services and infrastructure your organization runs. BackupOS tracks which ones have backup jobs and surfaces gaps on the dashboard.
         </p>
       </div>
+
+      {!canEdit && <ViewOnlyBanner />}
 
       {saved === '1' && (
         <div style={{ padding: '10px 16px', marginBottom: 20, backgroundColor: 'var(--ok-dim)', border: '1px solid color-mix(in srgb, var(--ok) 30%, transparent)', borderRadius: 'var(--radius-sm)', fontSize: 13, color: 'var(--ok)' }}>
@@ -56,6 +64,7 @@ export default async function InfraOsSettingsPage({ searchParams }: { searchPara
                 type="text"
                 required
                 placeholder="PostgreSQL main"
+                disabled={!canEdit}
                 style={{ width: '100%', padding: '6px 10px', fontSize: 13, backgroundColor: 'var(--surf2)', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none', boxSizing: 'border-box' }}
               />
             </div>
@@ -65,6 +74,7 @@ export default async function InfraOsSettingsPage({ searchParams }: { searchPara
                 name="host"
                 type="text"
                 placeholder="db.internal:5432"
+                disabled={!canEdit}
                 style={{ width: '100%', padding: '6px 10px', fontSize: 13, backgroundColor: 'var(--surf2)', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none', boxSizing: 'border-box' }}
               />
             </div>
@@ -74,6 +84,7 @@ export default async function InfraOsSettingsPage({ searchParams }: { searchPara
             <select
               name="serviceType"
               required
+              disabled={!canEdit}
               style={{ width: '100%', padding: '6px 10px', fontSize: 13, backgroundColor: 'var(--surf2)', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', color: 'var(--fg)' }}
             >
               <option value="">— Select type —</option>
@@ -88,14 +99,15 @@ export default async function InfraOsSettingsPage({ searchParams }: { searchPara
               name="description"
               type="text"
               placeholder="Optional notes"
+              disabled={!canEdit}
               style={{ width: '100%', padding: '6px 10px', fontSize: 13, backgroundColor: 'var(--surf2)', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', color: 'var(--fg)', outline: 'none', boxSizing: 'border-box' }}
             />
           </div>
           <div>
-            <button type="submit" style={{
-              fontSize: 13, padding: '7px 16px', cursor: 'pointer',
+            <button type="submit" disabled={!canEdit} style={{
+              fontSize: 13, padding: '7px 16px', cursor: canEdit ? 'pointer' : 'default',
               borderRadius: 'var(--radius-sm)', border: 'none',
-              background: 'var(--accent)', color: '#fff',
+              background: 'var(--accent)', color: '#fff', opacity: canEdit ? 1 : 0.5,
             }}>
               Add service
             </button>
@@ -151,15 +163,17 @@ export default async function InfraOsSettingsPage({ searchParams }: { searchPara
                     Create backup job →
                   </Link>
                 )}
-                <form action={boundRemove}>
-                  <button type="submit" style={{
-                    fontSize: 12, padding: '3px 10px', cursor: 'pointer',
-                    borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
-                    color: 'var(--fg-mute)', background: 'var(--surf2)',
-                  }}>
-                    Remove
-                  </button>
-                </form>
+                {canEdit && (
+                  <form action={boundRemove}>
+                    <button type="submit" style={{
+                      fontSize: 12, padding: '3px 10px', cursor: 'pointer',
+                      borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+                      color: 'var(--fg-mute)', background: 'var(--surf2)',
+                    }}>
+                      Remove
+                    </button>
+                  </form>
+                )}
               </div>
             )
           })}

--- a/apps/web/app/(dashboard)/settings/logging/page.tsx
+++ b/apps/web/app/(dashboard)/settings/logging/page.tsx
@@ -1,4 +1,7 @@
+import { redirect } from 'next/navigation'
+import { getCurrentUser, isAdmin } from '@/lib/user'
 import { getLoggingConfig, saveLoggingConfig } from '@/app/actions/logging-config'
+import { ViewOnlyBanner } from '@/components/ui/view-only-banner'
 
 const ACTIVITY_OPTIONS = ['30d', '90d', '180d', '365d', 'forever']
 const AUDIT_OPTIONS    = ['90d', '365d', '3y', '7y', 'forever']
@@ -14,6 +17,9 @@ const selectStyle: React.CSSProperties = {
 }
 
 export default async function LoggingSettingsPage({ searchParams }: { searchParams: Promise<{ saved?: string }> }) {
+  const user = await getCurrentUser()
+  if (!user) redirect('/login')
+  const canEdit = isAdmin(user)
   const config = await getLoggingConfig()
   const { saved } = await searchParams
 
@@ -21,6 +27,8 @@ export default async function LoggingSettingsPage({ searchParams }: { searchPara
     <div style={{ maxWidth: 560 }}>
       <a href="/settings" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--fg-dim)', textDecoration: 'none', marginBottom: 24 }}>← Settings</a>
       <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginBottom: 24 }}>Logging</h1>
+
+      {!canEdit && <ViewOnlyBanner />}
 
       {saved === '1' && (
         <div style={{ padding: '10px 16px', marginBottom: 20, backgroundColor: 'var(--ok-dim)', border: '1px solid color-mix(in srgb, var(--ok) 30%, transparent)', borderRadius: 'var(--radius-sm)', fontSize: 13, color: 'var(--ok)' }}>
@@ -35,28 +43,28 @@ export default async function LoggingSettingsPage({ searchParams }: { searchPara
           </div>
           <div style={rowStyle}>
             <span style={{ color: 'var(--fg)' }}>Activity feed</span>
-            <select name="activityRetention" defaultValue={config.activityRetention} style={selectStyle}>
+            <select name="activityRetention" defaultValue={config.activityRetention} style={selectStyle} disabled={!canEdit}>
               {ACTIVITY_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
             </select>
           </div>
           <div style={rowStyle}>
             <span style={{ color: 'var(--fg)' }}>Audit log</span>
-            <select name="auditRetention" defaultValue={config.auditRetention} style={selectStyle}>
+            <select name="auditRetention" defaultValue={config.auditRetention} style={selectStyle} disabled={!canEdit}>
               {AUDIT_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
             </select>
           </div>
           <div style={rowStyle}>
             <span style={{ color: 'var(--fg)' }}>Operational logs</span>
-            <select name="opsRetention" defaultValue={config.opsRetention} style={selectStyle}>
+            <select name="opsRetention" defaultValue={config.opsRetention} style={selectStyle} disabled={!canEdit}>
               {OPS_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
             </select>
           </div>
         </div>
 
-        <button type="submit" style={{
+        <button type="submit" disabled={!canEdit} style={{
           padding: '8px 20px', fontSize: 13, fontWeight: 500,
           borderRadius: 'var(--radius-sm)', border: 'none',
-          backgroundColor: 'var(--accent)', color: '#fff', cursor: 'pointer',
+          backgroundColor: 'var(--accent)', color: '#fff', cursor: canEdit ? 'pointer' : 'default', opacity: canEdit ? 1 : 0.5,
         }}>
           Save
         </button>

--- a/apps/web/app/(dashboard)/settings/retention/page.tsx
+++ b/apps/web/app/(dashboard)/settings/retention/page.tsx
@@ -1,11 +1,13 @@
 import { redirect } from 'next/navigation'
-import { getCurrentUser } from '@/lib/user'
+import { getCurrentUser, isAdmin } from '@/lib/user'
 import { getDb, backupDefaults } from '@backupos/db'
 import { saveBackupDefaults } from '@/app/actions/settings'
+import { ViewOnlyBanner } from '@/components/ui/view-only-banner'
 
 export default async function RetentionPage({ searchParams }: { searchParams: Promise<{ saved?: string }> }) {
   const user = await getCurrentUser()
   if (!user) redirect('/login')
+  const canEdit = isAdmin(user)
 
   const { saved } = await searchParams
   const db = getDb()
@@ -33,6 +35,8 @@ export default async function RetentionPage({ searchParams }: { searchParams: Pr
       <h1 style={{ fontSize: 20, fontWeight: 700, color: 'var(--fg)', marginBottom: 4 }}>Retention policy</h1>
       <p style={{ fontSize: 13, color: 'var(--fg-dim)', marginBottom: 24 }}>Default snapshot retention for new backup jobs. Individual jobs can override these.</p>
 
+      {!canEdit && <ViewOnlyBanner />}
+
       {saved === '1' && (
         <div style={{ padding: '10px 16px', marginBottom: 20, backgroundColor: 'var(--ok-dim)', border: '1px solid color-mix(in srgb, var(--ok) 30%, transparent)', borderRadius: 'var(--radius-sm)', fontSize: 13, color: 'var(--ok)' }}>
           Settings saved.
@@ -45,7 +49,7 @@ export default async function RetentionPage({ searchParams }: { searchParams: Pr
             {fields.map(f => (
               <div key={f.name}>
                 <label style={labelStyle}>{f.label} <span style={{ color: 'var(--fg-faint)', fontWeight: 400 }}>(snapshots)</span></label>
-                <input name={f.name} type="number" min="0" defaultValue={f.value} style={inputStyle} />
+                <input name={f.name} type="number" min="0" defaultValue={f.value} style={inputStyle} disabled={!canEdit} />
               </div>
             ))}
           </div>
@@ -53,7 +57,7 @@ export default async function RetentionPage({ searchParams }: { searchParams: Pr
         </div>
         <input type="hidden" name="scheduleStart" value={String(cfg?.scheduleStart ?? 0)} />
         <input type="hidden" name="scheduleEnd" value={String(cfg?.scheduleEnd ?? 23)} />
-        <button type="submit" style={{ padding: '8px 20px', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)', border: 'none', borderRadius: 'var(--radius-sm)', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
+        <button type="submit" disabled={!canEdit} style={{ padding: '8px 20px', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)', border: 'none', borderRadius: 'var(--radius-sm)', fontSize: 13, fontWeight: 600, cursor: canEdit ? 'pointer' : 'default', opacity: canEdit ? 1 : 0.5 }}>
           Save defaults
         </button>
       </form>

--- a/apps/web/app/(dashboard)/settings/schedule-windows/page.tsx
+++ b/apps/web/app/(dashboard)/settings/schedule-windows/page.tsx
@@ -1,7 +1,8 @@
 import { redirect } from 'next/navigation'
-import { getCurrentUser } from '@/lib/user'
+import { getCurrentUser, isAdmin } from '@/lib/user'
 import { getDb, backupDefaults } from '@backupos/db'
 import { saveBackupDefaults } from '@/app/actions/settings'
+import { ViewOnlyBanner } from '@/components/ui/view-only-banner'
 
 const HOURS = Array.from({ length: 24 }, (_, i) => ({
   value: i,
@@ -11,6 +12,7 @@ const HOURS = Array.from({ length: 24 }, (_, i) => ({
 export default async function ScheduleWindowsPage({ searchParams }: { searchParams: Promise<{ saved?: string }> }) {
   const user = await getCurrentUser()
   if (!user) redirect('/login')
+  const canEdit = isAdmin(user)
 
   const { saved } = await searchParams
   const db = getDb()
@@ -30,6 +32,8 @@ export default async function ScheduleWindowsPage({ searchParams }: { searchPara
       <h1 style={{ fontSize: 20, fontWeight: 700, color: 'var(--fg)', marginBottom: 4 }}>Schedule windows</h1>
       <p style={{ fontSize: 13, color: 'var(--fg-dim)', marginBottom: 24 }}>Default time window for backup jobs. Individual jobs can override this.</p>
 
+      {!canEdit && <ViewOnlyBanner />}
+
       {saved === '1' && (
         <div style={{ padding: '10px 16px', marginBottom: 20, backgroundColor: 'var(--ok-dim)', border: '1px solid color-mix(in srgb, var(--ok) 30%, transparent)', borderRadius: 'var(--radius-sm)', fontSize: 13, color: 'var(--ok)' }}>
           Settings saved.
@@ -41,13 +45,13 @@ export default async function ScheduleWindowsPage({ searchParams }: { searchPara
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
             <div>
               <label style={labelStyle}>Window start</label>
-              <select name="scheduleStart" defaultValue={cfg?.scheduleStart ?? 0} style={inputStyle}>
+              <select name="scheduleStart" defaultValue={cfg?.scheduleStart ?? 0} style={inputStyle} disabled={!canEdit}>
                 {HOURS.map(h => <option key={h.value} value={h.value}>{h.label}</option>)}
               </select>
             </div>
             <div>
               <label style={labelStyle}>Window end</label>
-              <select name="scheduleEnd" defaultValue={cfg?.scheduleEnd ?? 23} style={inputStyle}>
+              <select name="scheduleEnd" defaultValue={cfg?.scheduleEnd ?? 23} style={inputStyle} disabled={!canEdit}>
                 {HOURS.map(h => <option key={h.value} value={h.value}>{h.label}</option>)}
               </select>
             </div>
@@ -62,7 +66,7 @@ export default async function ScheduleWindowsPage({ searchParams }: { searchPara
         <input type="hidden" name="keepWeekly"  value={String(cfg?.keepWeekly  ?? 4)}  />
         <input type="hidden" name="keepMonthly" value={String(cfg?.keepMonthly ?? 12)} />
         <input type="hidden" name="keepYearly"  value={String(cfg?.keepYearly  ?? 0)}  />
-        <button type="submit" style={{ padding: '8px 20px', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)', border: 'none', borderRadius: 'var(--radius-sm)', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
+        <button type="submit" disabled={!canEdit} style={{ padding: '8px 20px', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)', border: 'none', borderRadius: 'var(--radius-sm)', fontSize: 13, fontWeight: 600, cursor: canEdit ? 'pointer' : 'default', opacity: canEdit ? 1 : 0.5 }}>
           Save defaults
         </button>
       </form>

--- a/apps/web/app/(dashboard)/settings/smtp/page.tsx
+++ b/apps/web/app/(dashboard)/settings/smtp/page.tsx
@@ -1,12 +1,14 @@
 import { redirect } from 'next/navigation'
-import { getCurrentUser } from '@/lib/user'
+import { getCurrentUser, isAdmin } from '@/lib/user'
 import { getDb, smtpConfig } from '@backupos/db'
 import { saveSmtpConfig, testSmtpConnection } from '@/app/actions/settings'
 import { SmtpTestButton } from './test-button'
+import { ViewOnlyBanner } from '@/components/ui/view-only-banner'
 
 export default async function SmtpSettingsPage({ searchParams }: { searchParams: Promise<{ saved?: string }> }) {
   const user = await getCurrentUser()
   if (!user) redirect('/login')
+  const canEdit = isAdmin(user)
 
   const { saved } = await searchParams
   const db = getDb()
@@ -33,6 +35,8 @@ export default async function SmtpSettingsPage({ searchParams }: { searchParams:
         </div>
       )}
 
+      {!canEdit && <ViewOnlyBanner />}
+
       {cfg?.enabled && !cfg?.toAddresses && (
         <div style={{ padding: '10px 16px', marginBottom: 20, backgroundColor: 'var(--warn-dim)', border: '1px solid color-mix(in srgb, var(--warn) 30%, transparent)', borderRadius: 'var(--radius-sm)', fontSize: 13, color: 'var(--warn)' }}>
           Alerts will not be delivered — no recipients configured. Add at least one address below.
@@ -46,8 +50,8 @@ export default async function SmtpSettingsPage({ searchParams }: { searchParams:
               <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)' }}>Enable SMTP</div>
               <div style={{ fontSize: 12, color: 'var(--fg-dim)' }}>Send emails via your SMTP server</div>
             </div>
-            <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
-              <input name="enabled" type="checkbox" defaultChecked={cfg?.enabled ?? false} />
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: canEdit ? 'pointer' : 'default' }}>
+              <input name="enabled" type="checkbox" defaultChecked={cfg?.enabled ?? false} disabled={!canEdit} />
               <span style={{ fontSize: 13, color: 'var(--fg-mute)' }}>Enabled</span>
             </label>
           </div>
@@ -55,55 +59,55 @@ export default async function SmtpSettingsPage({ searchParams }: { searchParams:
           <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 12, marginBottom: 16 }}>
             <div>
               <label style={labelStyle}>SMTP host</label>
-              <input name="host" type="text" defaultValue={cfg?.host ?? ''} placeholder="smtp.example.com" style={inputStyle} />
+              <input name="host" type="text" defaultValue={cfg?.host ?? ''} placeholder="smtp.example.com" style={inputStyle} disabled={!canEdit} />
             </div>
             <div style={{ width: 100 }}>
               <label style={labelStyle}>Port</label>
-              <input name="port" type="number" defaultValue={cfg?.port ?? 587} style={inputStyle} />
+              <input name="port" type="number" defaultValue={cfg?.port ?? 587} style={inputStyle} disabled={!canEdit} />
             </div>
           </div>
 
           <div style={fieldStyle}>
             <label style={labelStyle}>Username</label>
-            <input name="username" type="text" defaultValue={cfg?.username ?? ''} placeholder="user@example.com" style={inputStyle} />
+            <input name="username" type="text" defaultValue={cfg?.username ?? ''} placeholder="user@example.com" style={inputStyle} disabled={!canEdit} />
           </div>
 
           <div style={fieldStyle}>
             <label style={labelStyle}>Password</label>
-            <input name="password" type="password" defaultValue={cfg?.password ?? ''} placeholder="••••••••" style={inputStyle} />
+            <input name="password" type="password" defaultValue={cfg?.password ?? ''} placeholder="••••••••" style={inputStyle} disabled={!canEdit} />
           </div>
 
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 16 }}>
             <div>
               <label style={labelStyle}>From name</label>
-              <input name="fromName" type="text" defaultValue={cfg?.fromName ?? 'BackupOS'} style={inputStyle} />
+              <input name="fromName" type="text" defaultValue={cfg?.fromName ?? 'BackupOS'} style={inputStyle} disabled={!canEdit} />
             </div>
             <div>
               <label style={labelStyle}>From email</label>
-              <input name="fromEmail" type="email" defaultValue={cfg?.fromEmail ?? ''} placeholder="noreply@example.com" style={inputStyle} />
+              <input name="fromEmail" type="email" defaultValue={cfg?.fromEmail ?? ''} placeholder="noreply@example.com" style={inputStyle} disabled={!canEdit} />
             </div>
           </div>
 
           <div style={fieldStyle}>
             <label style={labelStyle}>Send alerts to</label>
-            <input name="toAddresses" type="text" defaultValue={cfg?.toAddresses ?? ''} placeholder="alice@example.com, bob@example.com" style={inputStyle} />
+            <input name="toAddresses" type="text" defaultValue={cfg?.toAddresses ?? ''} placeholder="alice@example.com, bob@example.com" style={inputStyle} disabled={!canEdit} />
             <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginTop: 4 }}>Comma-separated list of email addresses to receive alerts. Leave blank to disable alert delivery.</div>
           </div>
 
-          <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
-            <input name="tls" type="checkbox" defaultChecked={cfg?.tls ?? true} />
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: canEdit ? 'pointer' : 'default' }}>
+            <input name="tls" type="checkbox" defaultChecked={cfg?.tls ?? true} disabled={!canEdit} />
             <span style={{ fontSize: 13, color: 'var(--fg-mute)' }}>Use TLS/STARTTLS</span>
           </label>
         </div>
 
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, flexWrap: 'wrap' }}>
-          <button type="submit" style={{ padding: '8px 20px', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)', border: 'none', borderRadius: 'var(--radius-sm)', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
+          <button type="submit" disabled={!canEdit} style={{ padding: '8px 20px', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)', border: 'none', borderRadius: 'var(--radius-sm)', fontSize: 13, fontWeight: 600, cursor: canEdit ? 'pointer' : 'default', opacity: canEdit ? 1 : 0.5 }}>
             Save changes
           </button>
           <SmtpTestButton
             testAction={testSmtpConnection}
-            disabled={!(cfg?.enabled && cfg?.host && cfg?.fromEmail && cfg?.toAddresses)}
-            disabledReason={!cfg?.enabled ? 'SMTP is not enabled' : !cfg?.toAddresses ? 'No recipients configured' : 'SMTP not fully configured'}
+            disabled={!canEdit || !(cfg?.enabled && cfg?.host && cfg?.fromEmail && cfg?.toAddresses)}
+            disabledReason={!canEdit ? 'Admin role required' : !cfg?.enabled ? 'SMTP is not enabled' : !cfg?.toAddresses ? 'No recipients configured' : 'SMTP not fully configured'}
           />
         </div>
       </form>

--- a/apps/web/app/(dashboard)/settings/users/client.tsx
+++ b/apps/web/app/(dashboard)/settings/users/client.tsx
@@ -343,7 +343,7 @@ export function UsersClient({ users: initialUsers, invites: initialInvites, base
                 </div>
                 <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
                   <button style={btnGhost} onClick={() => copyLink(link)}>Copy link</button>
-                  {smtpConfigured && (
+                  {smtpConfigured && currentUserIsAdmin && (
                     <button
                       style={btnGhost}
                       onClick={() => startTransition(async () => {

--- a/apps/web/app/actions/forgot-password.ts
+++ b/apps/web/app/actions/forgot-password.ts
@@ -21,7 +21,8 @@ export async function requestPasswordReset(formData: FormData): Promise<{ messag
   }
 
   try {
-    await auth.api.requestPasswordReset({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (auth.api as any).forgetPassword({
       body: {
         email,
         redirectTo: '/reset-password',

--- a/apps/web/app/actions/forgot-password.ts
+++ b/apps/web/app/actions/forgot-password.ts
@@ -21,8 +21,7 @@ export async function requestPasswordReset(formData: FormData): Promise<{ messag
   }
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (auth.api as any).forgetPassword({
+    await auth.api.requestPasswordReset({
       body: {
         email,
         redirectTo: '/reset-password',

--- a/apps/web/app/actions/forgot-password.ts
+++ b/apps/web/app/actions/forgot-password.ts
@@ -1,0 +1,35 @@
+'use server'
+
+import { headers } from 'next/headers'
+import { auth } from '@/lib/auth'
+import { checkForgotPasswordRateLimit } from '@/lib/forgot-password-rate-limit'
+
+const GENERIC_OK_MESSAGE = 'If an account exists for that email, a reset link has been sent.'
+
+export async function requestPasswordReset(formData: FormData): Promise<{ message: string; error?: string }> {
+  const email = (formData.get('email') as string | null)?.trim().toLowerCase()
+  if (!email) return { message: '', error: 'Email is required' }
+
+  const headerStore = await headers()
+  const ip = headerStore.get('x-forwarded-for')?.split(',')[0]?.trim()
+    ?? headerStore.get('x-real-ip')
+    ?? 'unknown'
+
+  const rate = checkForgotPasswordRateLimit(email, ip)
+  if (!rate.ok) {
+    return { message: GENERIC_OK_MESSAGE }
+  }
+
+  try {
+    await auth.api.requestPasswordReset({
+      body: {
+        email,
+        redirectTo: '/reset-password',
+      },
+    })
+  } catch (err) {
+    console.error('[forgot-password]', err)
+  }
+
+  return { message: GENERIC_OK_MESSAGE }
+}

--- a/apps/web/components/bandwidth-profile-manager.tsx
+++ b/apps/web/components/bandwidth-profile-manager.tsx
@@ -23,6 +23,7 @@ interface Profile {
 
 interface Props {
   profiles: Profile[]
+  canEdit?: boolean
 }
 
 const HOURS = Array.from({ length: 25 }, (_, i) => i)
@@ -48,7 +49,7 @@ function Sparkline({ rules }: { rules: BandwidthRule[] }) {
   )
 }
 
-function RuleEditor({ profileId, rules }: { profileId: string; rules: Rule[] }) {
+function RuleEditor({ profileId, rules, canEdit = true }: { profileId: string; rules: Rule[]; canEdit?: boolean }) {
   const [startHour, setStartHour] = useState('0')
   const [endHour,   setEndHour]   = useState('8')
   const [limitKbps, setLimitKbps] = useState('')
@@ -81,12 +82,14 @@ function RuleEditor({ profileId, rules }: { profileId: string; rules: Rule[] }) 
                 <td style={{ padding: '4px 8px', color: 'var(--fg)' }}>{r.endHour}:00</td>
                 <td style={{ padding: '4px 8px', color: 'var(--fg)' }}>{fmtLimit(r.limitKbps)}</td>
                 <td style={{ padding: '4px 8px' }}>
-                  <button
-                    onClick={() => startTransition(() => { deleteRule(r.id) })}
-                    style={{ fontSize: 11, color: 'var(--fg-dim)', background: 'none', border: 'none', cursor: 'pointer' }}
-                  >
-                    Remove
-                  </button>
+                  {canEdit && (
+                    <button
+                      onClick={() => startTransition(() => { deleteRule(r.id) })}
+                      style={{ fontSize: 11, color: 'var(--fg-dim)', background: 'none', border: 'none', cursor: 'pointer' }}
+                    >
+                      Remove
+                    </button>
+                  )}
                 </td>
               </tr>
             ))}
@@ -94,37 +97,39 @@ function RuleEditor({ profileId, rules }: { profileId: string; rules: Rule[] }) 
         </table>
       )}
 
-      <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
-        <select value={startHour} onChange={e => setStartHour(e.target.value)} style={{ ...inputSm, width: 68 }}>
-          {HOURS.slice(0, 24).map(h => <option key={h} value={h}>{h}:00</option>)}
-        </select>
-        <span style={{ fontSize: 12, color: 'var(--fg-mute)' }}>to</span>
-        <select value={endHour} onChange={e => setEndHour(e.target.value)} style={{ ...inputSm, width: 68 }}>
-          {HOURS.slice(1).map(h => <option key={h} value={h}>{h}:00</option>)}
-        </select>
-        <input
-          type="number"
-          value={limitKbps}
-          onChange={e => setLimitKbps(e.target.value)}
-          placeholder="KB/s (blank = unlimited)"
-          style={{ ...inputSm, width: 160 }}
-        />
-        <button
-          onClick={handleAdd}
-          style={{
-            padding: '5px 12px', fontSize: 12, cursor: 'pointer',
-            borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
-            background: 'none', color: 'var(--fg)',
-          }}
-        >
-          Add rule
-        </button>
-      </div>
+      {canEdit && (
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+          <select value={startHour} onChange={e => setStartHour(e.target.value)} style={{ ...inputSm, width: 68 }}>
+            {HOURS.slice(0, 24).map(h => <option key={h} value={h}>{h}:00</option>)}
+          </select>
+          <span style={{ fontSize: 12, color: 'var(--fg-mute)' }}>to</span>
+          <select value={endHour} onChange={e => setEndHour(e.target.value)} style={{ ...inputSm, width: 68 }}>
+            {HOURS.slice(1).map(h => <option key={h} value={h}>{h}:00</option>)}
+          </select>
+          <input
+            type="number"
+            value={limitKbps}
+            onChange={e => setLimitKbps(e.target.value)}
+            placeholder="KB/s (blank = unlimited)"
+            style={{ ...inputSm, width: 160 }}
+          />
+          <button
+            onClick={handleAdd}
+            style={{
+              padding: '5px 12px', fontSize: 12, cursor: 'pointer',
+              borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+              background: 'none', color: 'var(--fg)',
+            }}
+          >
+            Add rule
+          </button>
+        </div>
+      )}
     </div>
   )
 }
 
-export function BandwidthProfileManager({ profiles }: Props) {
+export function BandwidthProfileManager({ profiles, canEdit = true }: Props) {
   const [expanded, setExpanded] = useState<string | null>(null)
   const [, startTransition] = useTransition()
 
@@ -177,19 +182,21 @@ export function BandwidthProfileManager({ profiles }: Props) {
             <span style={{ fontSize: 12, color: 'var(--fg-dim)', marginLeft: 4 }}>
               {p.rules.length} rule{p.rules.length !== 1 ? 's' : ''}
             </span>
-            <button
-              onClick={e => {
-                e.stopPropagation()
-                startTransition(() => { deleteProfile(p.id) })
-              }}
-              style={{
-                fontSize: 12, color: 'var(--fg-dim)', background: 'none',
-                border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)',
-                padding: '3px 10px', cursor: 'pointer',
-              }}
-            >
-              Delete
-            </button>
+            {canEdit && (
+              <button
+                onClick={e => {
+                  e.stopPropagation()
+                  startTransition(() => { deleteProfile(p.id) })
+                }}
+                style={{
+                  fontSize: 12, color: 'var(--fg-dim)', background: 'none',
+                  border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)',
+                  padding: '3px 10px', cursor: 'pointer',
+                }}
+              >
+                Delete
+              </button>
+            )}
             <span style={{ fontSize: 12, color: 'var(--fg-dim)' }}>
               {expanded === p.id ? '▲' : '▼'}
             </span>
@@ -201,7 +208,7 @@ export function BandwidthProfileManager({ profiles }: Props) {
               padding: '14px 18px',
               backgroundColor: 'var(--surf2)',
             }}>
-              <RuleEditor profileId={p.id} rules={p.rules} />
+              <RuleEditor profileId={p.id} rules={p.rules} canEdit={canEdit} />
             </div>
           )}
         </div>

--- a/apps/web/components/ui/view-only-banner.tsx
+++ b/apps/web/components/ui/view-only-banner.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react'
+
+interface Props {
+  message?: ReactNode
+}
+
+export function ViewOnlyBanner({ message }: Props) {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 8,
+      padding: '10px 14px',
+      marginBottom: 20,
+      backgroundColor: 'color-mix(in srgb, var(--surf2) 70%, var(--accent) 10%)',
+      border: '1px solid var(--border)',
+      borderRadius: 'var(--radius-sm)',
+      fontSize: 13,
+      color: 'var(--fg-mute)',
+    }}>
+      <span style={{ fontSize: 14 }}>👁</span>
+      <span>
+        {message ?? "You're viewing this page in read-only mode. Admin role required to make changes."}
+      </span>
+    </div>
+  )
+}

--- a/apps/web/lib/auth-client.ts
+++ b/apps/web/lib/auth-client.ts
@@ -15,7 +15,12 @@ interface TwoFactorMethods {
   verifyBackupCode(opts: { code: string; trustDevice?: boolean }): Promise<TwoFactorResult<unknown>>
 }
 
-type AuthClientType = ReturnType<typeof createAuthClient> & { twoFactor: TwoFactorMethods }
+interface AuthMethods {
+  forgetPassword(opts: { email: string; redirectTo?: string }): Promise<TwoFactorResult<{ status: boolean }>>
+  resetPassword(opts: { newPassword: string; token: string }): Promise<TwoFactorResult<{ status: boolean }>>
+}
+
+type AuthClientType = ReturnType<typeof createAuthClient> & { twoFactor: TwoFactorMethods } & AuthMethods
 
 // Explicit cast avoids TS2742 "inferred type cannot be named" from better-auth internals.
 // twoFactor methods are manually typed against the plugin's documented API.

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,7 +1,7 @@
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { twoFactor as twoFactorPlugin } from 'better-auth/plugins'
-import { getDb, user, session, account, verification, twoFactor } from '@backupos/db'
+import { getDb, user, session, account, verification, twoFactor, eq } from '@backupos/db'
 import { isPrivateOrigin } from './private-origin'
 
 const explicitTrusted = process.env['BETTER_AUTH_TRUSTED_ORIGINS']
@@ -21,6 +21,23 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled:    true,
     autoSignIn: true,
+    resetPasswordTokenExpiresIn: 60 * 15,
+    sendResetPassword: async ({ user: u, url }: { user: { email: string }; url: string }) => {
+      const base = process.env['NEXT_PUBLIC_BASE_URL'] ?? process.env['BETTER_AUTH_URL'] ?? ''
+      const link = url
+        .replace(/^https?:\/\/[^/]+/, base)
+        .replace('/api/auth/reset-password', '/reset-password')
+      const { sendResetPasswordEmail } = await import('./mailer')
+      await sendResetPasswordEmail({ to: u.email, link })
+    },
+    onPasswordReset: async ({ user: u }: { user: { id: string; email: string } }) => {
+      const db = getDb()
+      await db.delete(session).where(eq(session.userId, u.id))
+      try {
+        const { sendPasswordChangedNotification } = await import('./mailer')
+        await sendPasswordChangedNotification({ to: u.email })
+      } catch { /* non-fatal */ }
+    },
   },
   session: {
     expiresIn: 60 * 60 * 24 * 30,

--- a/apps/web/lib/forgot-password-rate-limit.ts
+++ b/apps/web/lib/forgot-password-rate-limit.ts
@@ -1,0 +1,36 @@
+// Per-process in-memory rate limiter for /forgot-password.
+// Two independent buckets: per-email (5 req / 15 min) and per-IP (20 req / 60 min).
+// Resets on process restart — acceptable for self-hosted single-instance deployment.
+
+interface Bucket { count: number; resetAt: number }
+
+const emailStore = new Map<string, Bucket>()
+const ipStore    = new Map<string, Bucket>()
+
+const EMAIL_LIMIT  = 5
+const EMAIL_WINDOW = 15 * 60 * 1000
+
+const IP_LIMIT  = 20
+const IP_WINDOW = 60 * 60 * 1000
+
+function checkBucket(store: Map<string, Bucket>, key: string, limit: number, window: number): boolean {
+  const now = Date.now()
+  const entry = store.get(key)
+  if (!entry || entry.resetAt < now) {
+    store.set(key, { count: 1, resetAt: now + window })
+    return true
+  }
+  if (entry.count >= limit) return false
+  entry.count++
+  return true
+}
+
+export function checkForgotPasswordRateLimit(email: string, ip: string): { ok: boolean; reason?: string } {
+  if (!checkBucket(emailStore, email.toLowerCase(), EMAIL_LIMIT, EMAIL_WINDOW)) {
+    return { ok: false, reason: 'email' }
+  }
+  if (!checkBucket(ipStore, ip, IP_LIMIT, IP_WINDOW)) {
+    return { ok: false, reason: 'ip' }
+  }
+  return { ok: true }
+}

--- a/apps/web/lib/mailer.ts
+++ b/apps/web/lib/mailer.ts
@@ -68,3 +68,127 @@ export async function sendInviteEmail(opts: InviteEmailOpts): Promise<void> {
     throw new Error(`Failed to send invite email: ${err instanceof Error ? err.message : String(err)}`)
   }
 }
+
+interface ResetPasswordEmailOpts {
+  to:   string
+  link: string
+}
+
+export async function sendResetPasswordEmail(opts: ResetPasswordEmailOpts): Promise<void> {
+  const host = process.env['SMTP_HOST']
+  if (!host) return
+
+  const transporter = nodemailer.createTransport({
+    host,
+    port:   Number(process.env['SMTP_PORT'] ?? 587),
+    secure: Number(process.env['SMTP_PORT'] ?? 587) === 465,
+    auth: {
+      user: process.env['SMTP_USER'],
+      pass: process.env['SMTP_PASS'],
+    },
+  })
+
+  const from = process.env['SMTP_FROM'] ?? `BackupOS <noreply@backupos.dev>`
+
+  try {
+    await transporter.sendMail({
+      from,
+      to:      opts.to,
+      subject: 'Reset your BackupOS password',
+      html: `
+<!DOCTYPE html>
+<html>
+<body style="margin:0;padding:0;background:#0E0E0E;font-family:system-ui,sans-serif">
+  <div style="max-width:480px;margin:40px auto;background:#1A1A1A;border:1px solid #2A2A2A;border-radius:12px;overflow:hidden">
+    <div style="padding:32px 32px 24px">
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:28px">
+        <svg width="32" height="32" viewBox="0 0 48 48" fill="none">
+          <rect width="48" height="48" rx="12" fill="#1A1206"/>
+          <rect x="4" y="4" width="19" height="19" fill="#F5A623"/>
+          <rect x="25" y="4" width="19" height="19" fill="#854F0B"/>
+          <rect x="4" y="25" width="19" height="19" fill="#854F0B"/>
+          <rect x="25" y="25" width="19" height="19" fill="#C77A14"/>
+          <rect x="19" y="19" width="10" height="10" fill="#FEF5E0"/>
+        </svg>
+        <span style="color:#F5F5F5;font-size:16px;font-weight:600">BackupOS</span>
+      </div>
+      <h1 style="color:#F5F5F5;font-size:20px;font-weight:700;margin:0 0 8px">Reset your password</h1>
+      <p style="color:#A3A3A3;font-size:14px;margin:0 0 28px">
+        Click the button below to reset your password. This link expires in 15 minutes.
+      </p>
+      <a href="${escHtml(opts.link)}"
+         style="display:inline-block;padding:10px 24px;background:#F5A623;color:#000;font-size:14px;font-weight:600;border-radius:6px;text-decoration:none">
+        Reset password
+      </a>
+      <p style="color:#6B6B6B;font-size:12px;margin:24px 0 0">
+        If you didn't request this, ignore this email — your password will not be changed.
+      </p>
+    </div>
+  </div>
+</body>
+</html>`,
+    })
+  } catch (err) {
+    throw new Error(`Failed to send reset email: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+interface PasswordChangedNotificationOpts {
+  to: string
+}
+
+export async function sendPasswordChangedNotification(opts: PasswordChangedNotificationOpts): Promise<void> {
+  const host = process.env['SMTP_HOST']
+  if (!host) return
+
+  const transporter = nodemailer.createTransport({
+    host,
+    port:   Number(process.env['SMTP_PORT'] ?? 587),
+    secure: Number(process.env['SMTP_PORT'] ?? 587) === 465,
+    auth: {
+      user: process.env['SMTP_USER'],
+      pass: process.env['SMTP_PASS'],
+    },
+  })
+
+  const from = process.env['SMTP_FROM'] ?? `BackupOS <noreply@backupos.dev>`
+
+  try {
+    await transporter.sendMail({
+      from,
+      to:      opts.to,
+      subject: 'Your BackupOS password was changed',
+      html: `
+<!DOCTYPE html>
+<html>
+<body style="margin:0;padding:0;background:#0E0E0E;font-family:system-ui,sans-serif">
+  <div style="max-width:480px;margin:40px auto;background:#1A1A1A;border:1px solid #2A2A2A;border-radius:12px;overflow:hidden">
+    <div style="padding:32px 32px 24px">
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:28px">
+        <svg width="32" height="32" viewBox="0 0 48 48" fill="none">
+          <rect width="48" height="48" rx="12" fill="#1A1206"/>
+          <rect x="4" y="4" width="19" height="19" fill="#F5A623"/>
+          <rect x="25" y="4" width="19" height="19" fill="#854F0B"/>
+          <rect x="4" y="25" width="19" height="19" fill="#854F0B"/>
+          <rect x="25" y="25" width="19" height="19" fill="#C77A14"/>
+          <rect x="19" y="19" width="10" height="10" fill="#FEF5E0"/>
+        </svg>
+        <span style="color:#F5F5F5;font-size:16px;font-weight:600">BackupOS</span>
+      </div>
+      <h1 style="color:#F5F5F5;font-size:20px;font-weight:700;margin:0 0 8px">Password changed</h1>
+      <p style="color:#A3A3A3;font-size:14px;margin:0 0 12px">
+        Your BackupOS password was just changed. All existing sessions have been signed out.
+      </p>
+      <p style="color:#A3A3A3;font-size:14px;margin:0 0 28px">
+        If you didn't do this, contact your BackupOS administrator immediately.
+      </p>
+    </div>
+  </div>
+</body>
+</html>`,
+    })
+  } catch (err) {
+    // Notification failure is non-fatal — don't roll back the password change
+    console.error('[mailer] password change notification failed:', err)
+  }
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -7,6 +7,7 @@ const PUBLIC_PATHS = [
   '/login',
   '/login/two-factor',
   '/signup',
+  '/forgot-password',
   '/install.sh',
   '/install.ps1',
   '/manifest.webmanifest',
@@ -21,6 +22,7 @@ const PUBLIC_PREFIXES = [
   '/apple-icon',
   '/opengraph-image',
   '/icon',
+  '/reset-password/',
 ]
 
 export function middleware(request: NextRequest) {


### PR DESCRIPTION
## Summary
Reverts the incorrect `forgetPassword` change. `auth.api.requestPasswordReset` is the correct method in better-auth v1.6.5. Also removes the `as any` cast that was added to work around the misidentified method name.

## Test plan
- [ ] Submit `/forgot-password` form — server action runs without throwing, returns generic OK message
- [ ] Verify `verification` table gets a new row for the submitted email

🤖 Generated with [Claude Code](https://claude.com/claude-code)