### PR TITLE
fix(auth): use requestPasswordReset for better-auth v1.6.5 server API

### DIFF
--- a/apps/web/app/actions/forgot-password.ts
+++ b/apps/web/app/actions/forgot-password.ts
@@ -21,8 +21,7 @@ export async function requestPasswordReset(formData: FormData): Promise<{ messag
   }
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (auth.api as any).forgetPassword({
+    await auth.api.requestPasswordReset({
       body: {
         email,
         redirectTo: '/reset-password',


### PR DESCRIPTION
## Summary
`auth.api.forgetPassword` does not exist in better-auth v1.6.5 — it is a client-side method only. The server-side method is `auth.api.requestPasswordReset`. The previous `as any` cast hid the mistake; the try/catch then swallowed the runtime error, so reset emails never fired.

## Diff
- Remove `// eslint-disable-next-line @typescript-eslint/no-explicit-any`
- Remove `(auth.api as any).forgetPassword(` → `auth.api.requestPasswordReset(`

## Test plan
- [ ] Submit `/forgot-password` form — new row appears in `verification` table
- [ ] With SMTP configured: reset email arrives in inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)