### PR TITLE
fix(security): coerce SSRF link-local AND to unsigned (follow-up to #185)

### DIFF
--- a/apps/web/lib/ssrf-guard.ts
+++ b/apps/web/lib/ssrf-guard.ts
@@ -42,7 +42,7 @@ function ipToInt(ip: string): number | null {
 function isLinkLocalV4(ip: string): boolean {
   const n = ipToInt(ip)
   if (n === null) return false
-  return (n & LINK_LOCAL_V4_MASK) === LINK_LOCAL_V4_BASE
+  return ((n & LINK_LOCAL_V4_MASK) >>> 0) === LINK_LOCAL_V4_BASE
 }
 
 function isBlockedIPv6(ip: string): boolean {


### PR DESCRIPTION
## Summary
Exactly one line changed in `ssrf-guard.ts`.

`(n & LINK_LOCAL_V4_MASK)` coerces to signed 32-bit in JS. For 169.254.x.x addresses bit 31 is set, so the result is `-1442840576` instead of `0xa9fe0000` — the equality check always fails and the link-local block is bypassed. Adding `>>> 0` converts to unsigned before the comparison.

```
// Before:  -1442840576 === 2851995648  → false  ❌  (169.254/16 not blocked)
// After:   2851995648  === 2851995648  → true   ✓
```

## Test plan
- [ ] Monitor test `http://169.254.169.254/latest/meta-data/` → blocked with SSRF error

🤖 Generated with [Claude Code](https://claude.com/claude-code)