### PR TITLE
feat(auth): OIDC SSO with admin config UI (closes #187)

### DIFF
--- a/apps/web/app/(auth)/login/form.tsx
+++ b/apps/web/app/(auth)/login/form.tsx
@@ -4,8 +4,14 @@ import Link from 'next/link'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { authClient } from '@/lib/auth-client'
+import { SsoButton } from './sso-button'
 
-export function LoginForm() {
+interface Props {
+  ssoEnabled?:     boolean
+  ssoButtonLabel?: string
+}
+
+export function LoginForm({ ssoEnabled = false, ssoButtonLabel = 'Sign in with SSO' }: Props) {
   const router = useRouter()
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
@@ -85,6 +91,8 @@ export function LoginForm() {
           >
             {loading ? 'Signing in…' : 'Sign in'}
           </button>
+
+          {ssoEnabled && <SsoButton buttonLabel={ssoButtonLabel} />}
         </form>
 
         <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginTop: 20, textAlign: 'center' }}>

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 import { getDb, user } from '@backupos/db'
 import { LoginForm } from './form'
+import { getOidcConfigPublic } from '@/lib/oidc-config'
 
 export default async function LoginPage() {
   const db = getDb()
@@ -9,5 +10,13 @@ export default async function LoginPage() {
   // No users yet — send to first-run setup
   if (!existing) redirect('/signup')
 
-  return <LoginForm />
+  let oidc: ReturnType<typeof getOidcConfigPublic> = null
+  try { oidc = getOidcConfigPublic() } catch { /* DB not migrated yet */ }
+
+  return (
+    <LoginForm
+      ssoEnabled={!!oidc?.enabled}
+      ssoButtonLabel={oidc?.buttonLabel ?? 'Sign in with SSO'}
+    />
+  )
 }

--- a/apps/web/app/(auth)/login/sso-button.tsx
+++ b/apps/web/app/(auth)/login/sso-button.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useState } from 'react'
+import { authClient } from '@/lib/auth-client'
+
+interface Props {
+  buttonLabel: string
+}
+
+export function SsoButton({ buttonLabel }: Props) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError]     = useState('')
+
+  async function handleClick() {
+    setLoading(true)
+    setError('')
+    try {
+      const result = await authClient.signIn.oauth2({
+        providerId:  'oidc',
+        callbackURL: '/dashboard',
+      })
+      if (result.error) {
+        setError(result.error.message ?? 'SSO sign-in failed')
+        setLoading(false)
+      }
+      // better-auth handles the redirect on success; nothing else needed.
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'SSO sign-in failed')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 12,
+        margin: '20px 0', fontSize: 12, color: 'var(--fg-dim)',
+      }}>
+        <div style={{ flex: 1, height: 1, background: 'var(--border)' }} />
+        <span>OR</span>
+        <div style={{ flex: 1, height: 1, background: 'var(--border)' }} />
+      </div>
+
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={loading}
+        style={{
+          width: '100%', padding: '9px 16px',
+          backgroundColor: 'var(--surf2)', color: 'var(--fg)',
+          border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)',
+          fontSize: 14, fontWeight: 500,
+          cursor: loading ? 'not-allowed' : 'pointer',
+          opacity: loading ? 0.7 : 1,
+        }}
+      >
+        {loading ? 'Redirecting…' : buttonLabel}
+      </button>
+
+      {error && (
+        <p style={{ fontSize: 13, color: 'var(--err)', marginTop: 12 }}>{error}</p>
+      )}
+    </>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/auth/sso/form.tsx
+++ b/apps/web/app/(dashboard)/settings/auth/sso/form.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { saveOidcConfig, disableOidc, testOidcDiscovery } from '@/app/actions/oidc-config'
+
+interface Props {
+  initial: {
+    enabled:       boolean
+    providerLabel: string
+    discoveryUrl:  string
+    clientId:      string
+    scopes:        string
+    buttonLabel:   string
+  } | null
+}
+
+const PROVIDER_LABELS = ['Authentik', 'Okta', 'Duo', 'Custom']
+
+export function SsoForm({ initial }: Props) {
+  const [providerLabel, setProviderLabel] = useState(initial?.providerLabel ?? 'Authentik')
+  const [discoveryUrl,  setDiscoveryUrl]  = useState(initial?.discoveryUrl ?? '')
+  const [clientId,      setClientId]      = useState(initial?.clientId ?? '')
+  const [clientSecret,  setClientSecret]  = useState('')
+  const [scopes,        setScopes]        = useState(initial?.scopes ?? 'openid profile email')
+  const [buttonLabel,   setButtonLabel]   = useState(initial?.buttonLabel ?? 'Sign in with SSO')
+  const [enabled,       setEnabled]       = useState(initial?.enabled ?? false)
+
+  const [pending, startTransition] = useTransition()
+  const [message, setMessage] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null)
+  const [discoveryStatus, setDiscoveryStatus] = useState<{ ok: boolean; text: string } | null>(null)
+
+  function handleSave() {
+    setMessage(null)
+    if (!discoveryUrl.trim() || !clientId.trim()) {
+      setMessage({ kind: 'err', text: 'Discovery URL and Client ID are required' })
+      return
+    }
+    if (!initial && !clientSecret.trim()) {
+      setMessage({ kind: 'err', text: 'Client Secret is required on first save' })
+      return
+    }
+    startTransition(async () => {
+      const result = await saveOidcConfig({
+        enabled,
+        providerLabel,
+        discoveryUrl: discoveryUrl.trim(),
+        clientId:     clientId.trim(),
+        clientSecret: clientSecret.trim() || undefined,
+        scopes:       scopes.trim() || 'openid profile email',
+        buttonLabel:  buttonLabel.trim() || 'Sign in with SSO',
+      })
+      if (result.error) {
+        setMessage({ kind: 'err', text: result.error })
+      } else {
+        setMessage({ kind: 'ok', text: 'Saved. Restart the BackupOS service for changes to take effect.' })
+        setClientSecret('')
+      }
+    })
+  }
+
+  function handleTestDiscovery() {
+    setDiscoveryStatus(null)
+    if (!discoveryUrl.trim()) return
+    startTransition(async () => {
+      const result = await testOidcDiscovery(discoveryUrl.trim())
+      setDiscoveryStatus({ ok: result.ok, text: result.message })
+    })
+  }
+
+  function handleDisable() {
+    if (!confirm('Disable SSO? Existing sessions remain valid; new SSO logins will be blocked after the next service restart.')) return
+    startTransition(async () => {
+      const result = await disableOidc()
+      if (result.error) {
+        setMessage({ kind: 'err', text: result.error })
+      } else {
+        setEnabled(false)
+        setMessage({ kind: 'ok', text: 'SSO disabled. Restart the BackupOS service for changes to take effect.' })
+      }
+    })
+  }
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%', padding: '8px 12px', fontSize: 13,
+    backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-sm)', color: 'var(--fg)',
+    outline: 'none', boxSizing: 'border-box',
+  }
+  const labelStyle: React.CSSProperties = { display: 'block', fontSize: 12, fontWeight: 500, color: 'var(--fg-mute)', marginBottom: 4 }
+  const fieldStyle: React.CSSProperties = { marginBottom: 16 }
+
+  return (
+    <div>
+      <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)', padding: '20px 24px', marginBottom: 16 }}>
+
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20, paddingBottom: 16, borderBottom: '1px solid var(--border2)' }}>
+          <div>
+            <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)' }}>Enable SSO</div>
+            <div style={{ fontSize: 12, color: 'var(--fg-dim)' }}>Show &quot;Sign in with SSO&quot; on the login page</div>
+          </div>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+            <input type="checkbox" checked={enabled} onChange={e => setEnabled(e.target.checked)} />
+            <span style={{ fontSize: 13, color: 'var(--fg-mute)' }}>Enabled</span>
+          </label>
+        </div>
+
+        <div style={fieldStyle}>
+          <label style={labelStyle}>Provider</label>
+          <select value={providerLabel} onChange={e => setProviderLabel(e.target.value)} style={inputStyle}>
+            {PROVIDER_LABELS.map(p => <option key={p} value={p}>{p}</option>)}
+          </select>
+        </div>
+
+        <div style={fieldStyle}>
+          <label style={labelStyle}>Discovery URL (.well-known/openid-configuration)</label>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <input
+              type="url"
+              value={discoveryUrl}
+              onChange={e => setDiscoveryUrl(e.target.value)}
+              placeholder="https://authentik.example.com/application/o/backupos/.well-known/openid-configuration"
+              style={inputStyle}
+            />
+            <button
+              type="button"
+              onClick={handleTestDiscovery}
+              disabled={pending || !discoveryUrl.trim()}
+              style={{
+                padding: '8px 14px', fontSize: 13, whiteSpace: 'nowrap',
+                background: 'var(--surf2)', color: 'var(--fg)', border: '1px solid var(--border)',
+                borderRadius: 'var(--radius-sm)', cursor: pending ? 'not-allowed' : 'pointer',
+              }}
+            >
+              Test
+            </button>
+          </div>
+          {discoveryStatus && (
+            <div style={{ marginTop: 6, fontSize: 12, color: discoveryStatus.ok ? 'var(--ok)' : 'var(--err)' }}>
+              {discoveryStatus.ok ? '✓' : '✗'} {discoveryStatus.text}
+            </div>
+          )}
+        </div>
+
+        <div style={fieldStyle}>
+          <label style={labelStyle}>Client ID</label>
+          <input type="text" value={clientId} onChange={e => setClientId(e.target.value)} style={inputStyle} />
+        </div>
+
+        <div style={fieldStyle}>
+          <label style={labelStyle}>
+            Client Secret{initial && <span style={{ color: 'var(--fg-dim)', fontWeight: 400 }}> (leave blank to keep current)</span>}
+          </label>
+          <input
+            type="password"
+            value={clientSecret}
+            onChange={e => setClientSecret(e.target.value)}
+            placeholder={initial ? '••••••••' : ''}
+            style={inputStyle}
+          />
+        </div>
+
+        <div style={fieldStyle}>
+          <label style={labelStyle}>Scopes (space-separated)</label>
+          <input type="text" value={scopes} onChange={e => setScopes(e.target.value)} style={inputStyle} />
+        </div>
+
+        <div style={fieldStyle}>
+          <label style={labelStyle}>Button label on login page</label>
+          <input type="text" value={buttonLabel} onChange={e => setButtonLabel(e.target.value)} style={inputStyle} />
+        </div>
+
+      </div>
+
+      {message && (
+        <div style={{
+          padding: '10px 16px', marginBottom: 16,
+          backgroundColor: message.kind === 'ok' ? 'var(--ok-dim)' : 'var(--err-dim)',
+          border: `1px solid color-mix(in srgb, ${message.kind === 'ok' ? 'var(--ok)' : 'var(--err)'} 30%, transparent)`,
+          borderRadius: 'var(--radius-sm)', fontSize: 13,
+          color: message.kind === 'ok' ? 'var(--ok)' : 'var(--err)',
+        }}>
+          {message.text}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button
+          onClick={handleSave}
+          disabled={pending}
+          style={{
+            padding: '8px 20px', backgroundColor: 'var(--accent)', color: 'var(--accent-fg)',
+            border: 'none', borderRadius: 'var(--radius-sm)', fontSize: 13, fontWeight: 600,
+            cursor: pending ? 'not-allowed' : 'pointer', opacity: pending ? 0.7 : 1,
+          }}
+        >
+          Save changes
+        </button>
+        {initial && (
+          <button
+            onClick={handleDisable}
+            disabled={pending}
+            style={{
+              padding: '8px 16px', background: 'var(--surf2)', color: 'var(--fg-mute)',
+              border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)',
+              fontSize: 13, cursor: pending ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Disable SSO
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/auth/sso/page.tsx
+++ b/apps/web/app/(dashboard)/settings/auth/sso/page.tsx
@@ -1,0 +1,51 @@
+import { redirect } from 'next/navigation'
+import { getCurrentUser, isAdmin } from '@/lib/user'
+import { getOidcConfigPublic } from '@/lib/oidc-config'
+import { SsoForm } from './form'
+
+export default async function SsoSettingsPage() {
+  const user = await getCurrentUser()
+  if (!user) redirect('/login')
+  if (!isAdmin(user)) redirect('/dashboard')
+
+  let cfg: ReturnType<typeof getOidcConfigPublic> = null
+  try { cfg = getOidcConfigPublic() } catch { /* DB not migrated yet */ }
+
+  return (
+    <div style={{ padding: '32px 40px', maxWidth: 720 }}>
+      <a href="/settings" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--fg-dim)', textDecoration: 'none', marginBottom: 24 }}>← Settings</a>
+      <h1 style={{ fontSize: 20, fontWeight: 700, color: 'var(--fg)', marginBottom: 4 }}>OIDC Single Sign-On</h1>
+      <p style={{ fontSize: 13, color: 'var(--fg-dim)', marginBottom: 24 }}>
+        Configure an OpenID Connect identity provider so users can sign in with Authentik, Okta, Duo, or any compliant OIDC IdP.
+      </p>
+
+      <div style={{
+        padding: '12px 16px', marginBottom: 20,
+        background: 'color-mix(in srgb, var(--warn) 12%, transparent)',
+        border: '1px solid color-mix(in srgb, var(--warn) 30%, transparent)',
+        borderRadius: 'var(--radius-sm)',
+        fontSize: 13, color: 'var(--warn)',
+      }}>
+        ⚠ Changes to SSO configuration require a BackupOS service restart to take effect:
+        <code style={{ display: 'block', marginTop: 6, padding: '4px 8px', background: 'var(--surf2)', color: 'var(--fg)', borderRadius: 4, fontFamily: 'var(--font-mono)' }}>
+          sudo systemctl restart backupos
+        </code>
+      </div>
+
+      <div style={{
+        padding: '12px 16px', marginBottom: 24,
+        background: 'var(--surf2)',
+        border: '1px solid var(--border)',
+        borderRadius: 'var(--radius-sm)',
+        fontSize: 13, color: 'var(--fg-mute)',
+      }}>
+        Redirect URI to register at your IdP:{' '}
+        <code style={{ color: 'var(--fg)' }}>
+          {process.env['NEXT_PUBLIC_BASE_URL'] ?? '<your-base-url>'}/api/auth/oauth2/callback/oidc
+        </code>
+      </div>
+
+      <SsoForm initial={cfg} />
+    </div>
+  )
+}

--- a/apps/web/app/actions/oidc-config.ts
+++ b/apps/web/app/actions/oidc-config.ts
@@ -1,0 +1,102 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { requireAdmin } from '@/lib/user'
+import { upsertOidcConfig, disableOidc as disableOidcDb } from '@/lib/oidc-config'
+import { appendAuditEntry } from '@/lib/audit'
+
+export async function saveOidcConfig(input: {
+  enabled:       boolean
+  providerLabel: string
+  discoveryUrl:  string
+  clientId:      string
+  clientSecret?: string
+  scopes:        string
+  buttonLabel:   string
+}): Promise<{ error?: string }> {
+  const admin = await requireAdmin()
+
+  if (!input.discoveryUrl?.trim()) return { error: 'Discovery URL is required' }
+  if (!input.clientId?.trim())     return { error: 'Client ID is required' }
+
+  try { new URL(input.discoveryUrl) } catch { return { error: 'Discovery URL is not a valid URL' } }
+
+  try {
+    upsertOidcConfig(input)
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'Failed to save config' }
+  }
+
+  appendAuditEntry({
+    action:       'settings.updated',
+    resourceType: 'oidc_config',
+    resourceId:   'singleton',
+    actor:        admin.id,
+    detail:       { enabled: input.enabled, providerLabel: input.providerLabel },
+  })
+
+  revalidatePath('/settings/auth/sso')
+  return {}
+}
+
+export async function disableOidc(): Promise<{ error?: string }> {
+  const admin = await requireAdmin()
+  try {
+    disableOidcDb()
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'Failed to disable' }
+  }
+
+  appendAuditEntry({
+    action:       'settings.updated',
+    resourceType: 'oidc_config',
+    resourceId:   'singleton',
+    actor:        admin.id,
+    detail:       { enabled: false, action: 'disable' },
+  })
+
+  revalidatePath('/settings/auth/sso')
+  return {}
+}
+
+export async function testOidcDiscovery(discoveryUrl: string): Promise<{ ok: boolean; message: string }> {
+  await requireAdmin()
+  if (!discoveryUrl.trim()) return { ok: false, message: 'No URL provided' }
+
+  let parsed: URL
+  try { parsed = new URL(discoveryUrl) } catch { return { ok: false, message: 'Invalid URL' } }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return { ok: false, message: 'Only http:// and https:// URLs are allowed' }
+  }
+
+  const { assertSafeUrl, SSRFViolation } = await import('@/lib/ssrf-guard')
+  try {
+    await assertSafeUrl(discoveryUrl)
+  } catch (err) {
+    if (err instanceof SSRFViolation) {
+      return { ok: false, message: 'URL points to a private/loopback address — not allowed' }
+    }
+    throw err
+  }
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 5000)
+  try {
+    const res = await fetch(discoveryUrl, { method: 'GET', signal: controller.signal })
+    clearTimeout(timer)
+    if (!res.ok) return { ok: false, message: `Discovery returned HTTP ${res.status}` }
+
+    const data = await res.json() as Record<string, unknown>
+    const required = ['authorization_endpoint', 'token_endpoint', 'issuer']
+    const missing  = required.filter(k => !data[k])
+    if (missing.length > 0) {
+      return { ok: false, message: `Missing fields in discovery document: ${missing.join(', ')}` }
+    }
+    return { ok: true, message: `Discovered issuer: ${data['issuer']}` }
+  } catch (err: unknown) {
+    clearTimeout(timer)
+    const msg = err instanceof Error ? err.message : String(err)
+    if (msg.toLowerCase().includes('abort')) return { ok: false, message: 'Discovery timed out after 5s' }
+    return { ok: false, message: msg }
+  }
+}

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -7,7 +7,7 @@ export type AuditAction =
   | 'repo.created'   | 'repo.updated'   | 'repo.deleted'
   | 'agent.enrolled' | 'agent.deleted'
   | 'snapshot.pinned' | 'snapshot.tagged' | 'snapshot.held' | 'snapshot.deleted'
-  | 'user.login'     | 'user.logout'    | 'user.password_changed'
+  | 'user.login'     | 'user.login.sso' | 'user.logout'    | 'user.password_changed'
   | 'totp.enabled'   | 'totp.disabled'  | 'backup_code.redeemed'
   | 'session.created'| 'session.revoked'
   | 'escrow.accessed'

--- a/apps/web/lib/auth-client.ts
+++ b/apps/web/lib/auth-client.ts
@@ -20,7 +20,14 @@ interface AuthMethods {
   resetPassword(opts: { newPassword: string; token: string }): Promise<TwoFactorResult<{ status: boolean }>>
 }
 
-type AuthClientType = ReturnType<typeof createAuthClient> & { twoFactor: TwoFactorMethods } & AuthMethods
+interface SignInExtensions {
+  oauth2(opts: { providerId: string; callbackURL?: string }): Promise<{ data: { url: string; redirect: boolean } | null; error: { message?: string } | null }>
+}
+
+type AuthClientType = ReturnType<typeof createAuthClient> & {
+  twoFactor: TwoFactorMethods
+  signIn:    ReturnType<typeof createAuthClient>['signIn'] & SignInExtensions
+} & AuthMethods
 
 // Explicit cast avoids TS2742 "inferred type cannot be named" from better-auth internals.
 // twoFactor methods are manually typed against the plugin's documented API.

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,8 +1,45 @@
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
-import { twoFactor as twoFactorPlugin } from 'better-auth/plugins'
+import { twoFactor as twoFactorPlugin, genericOAuth } from 'better-auth/plugins'
 import { getDb, user, session, account, verification, twoFactor, eq } from '@backupos/db'
 import { isPrivateOrigin } from './private-origin'
+import { getOidcConfigDecrypted } from './oidc-config'
+
+function buildPlugins(): ReturnType<typeof twoFactorPlugin>[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const plugins: any[] = [twoFactorPlugin({ issuer: 'BackupOS' })]
+
+  // Conditionally load genericOAuth from DB config.
+  // NOTE: This runs at module-init. Changes to /settings/auth/sso require service restart.
+  // TODO #187 follow-up: wire databaseHooks.session.create to record user.login.sso vs user.login
+  // based on the account row's providerId. Currently login events are not audited at all
+  // because better-auth doesn't expose a clean post-login hook in this version.
+  let oidc: ReturnType<typeof getOidcConfigDecrypted> = null
+  try {
+    oidc = getOidcConfigDecrypted()
+  } catch {
+    // DB may not be migrated yet on first boot; skip silently.
+  }
+
+  if (oidc?.enabled) {
+    plugins.push(genericOAuth({
+      config: [{
+        providerId:   'oidc',
+        discoveryUrl: oidc.discoveryUrl,
+        clientId:     oidc.clientId,
+        clientSecret: oidc.clientSecret,
+        scopes:       oidc.scopes.split(/\s+/).filter(Boolean),
+        pkce:         true,
+        mapProfileToUser: (profile: Record<string, unknown>) => ({
+          email: profile['email'] as string,
+          name:  (profile['name'] || profile['preferred_username'] || profile['email']) as string,
+        }),
+      }],
+    }))
+  }
+
+  return plugins
+}
 
 const explicitTrusted = process.env['BETTER_AUTH_TRUSTED_ORIGINS']
   ?.split(',').map(s => s.trim()).filter(Boolean) ?? []
@@ -13,7 +50,7 @@ export const auth = betterAuth({
     const origin = request?.headers.get('origin') ?? ''
     return isPrivateOrigin(origin) ? [...explicitTrusted, origin] : explicitTrusted
   },
-  plugins: [twoFactorPlugin({ issuer: 'BackupOS' })],
+  plugins: buildPlugins(),
   database: drizzleAdapter(getDb(), {
     provider: 'sqlite',
     schema: { user, session, account, verification, twoFactor },

--- a/apps/web/lib/key-rotation.ts
+++ b/apps/web/lib/key-rotation.ts
@@ -1,11 +1,12 @@
 import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
-import { getDb, repositories, smtpConfig, alertChannels, verificationTests, eq } from '@backupos/db'
+import { getDb, repositories, smtpConfig, alertChannels, verificationTests, oidcConfig, eq } from '@backupos/db'
 
 export interface RotationStats {
   repositories:      number
   smtpConfig:        number
   alertChannels:     number
   verificationTests: number
+  oidcConfig:        number
   total:             number
   durationMs:        number
 }
@@ -44,7 +45,7 @@ export async function rotateEncryptionKey(
   const startedAt = Date.now()
   const db = getDb()
   const stats: RotationStats = {
-    repositories: 0, smtpConfig: 0, alertChannels: 0, verificationTests: 0,
+    repositories: 0, smtpConfig: 0, alertChannels: 0, verificationTests: 0, oidcConfig: 0,
     total: 0, durationMs: 0,
   }
 
@@ -171,9 +172,24 @@ export async function rotateEncryptionKey(
       }
       stats.verificationTests++
     }
+
+    // oidcConfig: clientSecretEnc
+    const oidcRows = tx.select().from(oidcConfig).all()
+    for (const row of oidcRows) {
+      if (!row.clientSecretEnc) continue
+      const newClientSecretEnc = reencrypt(row.clientSecretEnc)
+      if (newClientSecretEnc === row.clientSecretEnc) continue
+      if (!opts.dryRun) {
+        tx.update(oidcConfig)
+          .set({ clientSecretEnc: newClientSecretEnc! })
+          .where(eq(oidcConfig.id, row.id))
+          .run()
+      }
+      stats.oidcConfig++
+    }
   })
 
-  stats.total      = stats.repositories + stats.smtpConfig + stats.alertChannels + stats.verificationTests
+  stats.total      = stats.repositories + stats.smtpConfig + stats.alertChannels + stats.verificationTests + stats.oidcConfig
   stats.durationMs = Date.now() - startedAt
   return stats
 }

--- a/apps/web/lib/oidc-config.ts
+++ b/apps/web/lib/oidc-config.ts
@@ -1,0 +1,116 @@
+import { getDb, oidcConfig, eq } from '@backupos/db'
+import { encryptField, decryptField } from './repo-crypto'
+
+export interface OidcConfigDecrypted {
+  id:            'singleton'
+  enabled:       boolean
+  providerLabel: string
+  discoveryUrl:  string
+  clientId:      string
+  clientSecret:  string
+  scopes:        string
+  buttonLabel:   string
+  createdAt:     Date
+  updatedAt:     Date
+}
+
+export interface OidcConfigPublic {
+  enabled:       boolean
+  providerLabel: string
+  discoveryUrl:  string
+  clientId:      string
+  scopes:        string
+  buttonLabel:   string
+}
+
+export function getOidcConfigDecrypted(): OidcConfigDecrypted | null {
+  const db = getDb()
+  const row = db.select().from(oidcConfig).where(eq(oidcConfig.id, 'singleton')).limit(1).get()
+  if (!row) return null
+  return {
+    id:            'singleton',
+    enabled:       row.enabled,
+    providerLabel: row.providerLabel,
+    discoveryUrl:  row.discoveryUrl,
+    clientId:      row.clientId,
+    clientSecret:  decryptField(row.clientSecretEnc),
+    scopes:        row.scopes,
+    buttonLabel:   row.buttonLabel,
+    createdAt:     row.createdAt,
+    updatedAt:     row.updatedAt,
+  }
+}
+
+export function getOidcConfigPublic(): OidcConfigPublic | null {
+  const db = getDb()
+  const row = db.select().from(oidcConfig).where(eq(oidcConfig.id, 'singleton')).limit(1).get()
+  if (!row) return null
+  return {
+    enabled:       row.enabled,
+    providerLabel: row.providerLabel,
+    discoveryUrl:  row.discoveryUrl,
+    clientId:      row.clientId,
+    scopes:        row.scopes,
+    buttonLabel:   row.buttonLabel,
+  }
+}
+
+export function isSsoEnabled(): boolean {
+  const cfg = getOidcConfigPublic()
+  return !!cfg?.enabled
+}
+
+export function upsertOidcConfig(input: {
+  enabled:       boolean
+  providerLabel: string
+  discoveryUrl:  string
+  clientId:      string
+  clientSecret?: string
+  scopes:        string
+  buttonLabel:   string
+}): void {
+  const db  = getDb()
+  const now = new Date()
+
+  const existing = db.select().from(oidcConfig).where(eq(oidcConfig.id, 'singleton')).limit(1).get()
+
+  const clientSecretEnc = input.clientSecret
+    ? encryptField(input.clientSecret)
+    : (existing?.clientSecretEnc ?? '')
+
+  if (!clientSecretEnc) throw new Error('Client secret required on first save')
+
+  if (existing) {
+    db.update(oidcConfig).set({
+      enabled:         input.enabled,
+      providerLabel:   input.providerLabel,
+      discoveryUrl:    input.discoveryUrl,
+      clientId:        input.clientId,
+      clientSecretEnc,
+      scopes:          input.scopes,
+      buttonLabel:     input.buttonLabel,
+      updatedAt:       now,
+    }).where(eq(oidcConfig.id, 'singleton')).run()
+  } else {
+    db.insert(oidcConfig).values({
+      id:             'singleton',
+      enabled:        input.enabled,
+      providerLabel:  input.providerLabel,
+      discoveryUrl:   input.discoveryUrl,
+      clientId:       input.clientId,
+      clientSecretEnc,
+      scopes:         input.scopes,
+      buttonLabel:    input.buttonLabel,
+      createdAt:      now,
+      updatedAt:      now,
+    }).run()
+  }
+}
+
+export function disableOidc(): void {
+  const db = getDb()
+  db.update(oidcConfig)
+    .set({ enabled: false, updatedAt: new Date() })
+    .where(eq(oidcConfig.id, 'singleton'))
+    .run()
+}

--- a/apps/web/lib/ssrf-guard.ts
+++ b/apps/web/lib/ssrf-guard.ts
@@ -42,7 +42,7 @@ function ipToInt(ip: string): number | null {
 function isLinkLocalV4(ip: string): boolean {
   const n = ipToInt(ip)
   if (n === null) return false
-  return (n & LINK_LOCAL_V4_MASK) === LINK_LOCAL_V4_BASE
+  return ((n & LINK_LOCAL_V4_MASK) >>> 0) === LINK_LOCAL_V4_BASE
 }
 
 function isBlockedIPv6(ip: string): boolean {

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -296,6 +296,22 @@ Configured in `apps/web/next.config.ts`:
 
 The `audit_log` table stores enumerated action types only (no raw user input or credential values). Each entry chains to the previous via SHA-256, providing tamper-evidence. The `detail` JSON field is set only by application code, never reflects user form data verbatim.
 
+### OIDC Single Sign-On
+
+When SSO is configured at `/settings/auth/sso`:
+
+- Local password authentication remains available unless administratively disabled
+- SSO users sign in via the configured IdP (Authentik, Okta, Duo, or any OIDC-compliant provider)
+- First sign-in creates a local user with role `viewer`. Admin can promote on `/settings/users`
+- SSO users have no local password set — they cannot use `/forgot-password`
+- TOTP 2FA is bypassed for SSO sessions (the IdP is responsible for MFA). The twoFactor plugin only challenges users who have `twoFactorEnabled = true` on their local user row; SSO-created users never enroll TOTP and so skip the challenge naturally
+- The `account` table records the OIDC linkage; `account.providerId = 'oidc'`
+- Audit log distinguishes login methods: `user.login` for password, `user.login.sso` for SSO (wiring deferred — tracked separately as a follow-up to #187)
+
+The OIDC client secret is encrypted with the same AES-256-GCM key used for repository credentials (`ENCRYPTION_KEY` / `ENCRYPTION_KEY_FILE`). The encryption key rotation tool at `/settings/security` and `scripts/rotate-key.ts` covers it.
+
+**Operational note:** changes to OIDC config require a service restart because the better-auth plugin list (`genericOAuth`) is read at module-init time.
+
 ### What is NOT included in V1
 
 - DDoS protection (responsibility of the reverse proxy in front of BackupOS)

--- a/packages/db/migrations/0047_add_oidc_config.sql
+++ b/packages/db/migrations/0047_add_oidc_config.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `oidc_config` (
+  `id` text PRIMARY KEY NOT NULL,
+  `enabled` integer NOT NULL DEFAULT 0,
+  `provider_label` text NOT NULL,
+  `discovery_url` text NOT NULL,
+  `client_id` text NOT NULL,
+  `client_secret_enc` text NOT NULL,
+  `scopes` text NOT NULL DEFAULT 'openid profile email',
+  `button_label` text NOT NULL DEFAULT 'Sign in with SSO',
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1778025600000,
       "tag": "0046_alert_channel_subscriptions",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1778112000000,
+      "tag": "0047_add_oidc_config",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -660,6 +660,23 @@ export const pbsTokens = sqliteTable('pbs_tokens', {
   uniqueIndex('pbs_tokens_user_realm_token_name_uniq').on(t.user, t.realm, t.tokenName),
 ])
 
+// ── OIDC SSO config ───────────────────────────────────────────────────────
+// Singleton row (id = 'singleton') storing the OIDC IdP credentials.
+// client_secret_enc is AES-256-GCM encrypted with ENCRYPTION_KEY.
+
+export const oidcConfig = sqliteTable('oidc_config', {
+  id:              text('id').primaryKey(),  // always 'singleton'
+  enabled:         integer('enabled',        { mode: 'boolean' }).notNull().default(false),
+  providerLabel:   text('provider_label').notNull(),
+  discoveryUrl:    text('discovery_url').notNull(),
+  clientId:        text('client_id').notNull(),
+  clientSecretEnc: text('client_secret_enc').notNull(),
+  scopes:          text('scopes').notNull().default('openid profile email'),
+  buttonLabel:     text('button_label').notNull().default('Sign in with SSO'),
+  createdAt:       integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+  updatedAt:       integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
+})
+
 export const pbsActiveSessions = sqliteTable('pbs_active_sessions', {
   id:           text('id').primaryKey(),
   tokenId:      text('token_id').references(() => pbsTokens.id),


### PR DESCRIPTION
## Summary

- Adds `oidc_config` singleton table (migration 0047) with encrypted `client_secret_enc` via existing repo-crypto
- `genericOAuth` plugin loaded conditionally at module-init from DB row; `/settings/auth/sso` admin UI to manage config with live discovery test (SSRF-guarded)
- "Sign in with SSO" button on `/login` when SSO is enabled; first SSO user created as `viewer`
- `lib/key-rotation.ts` rotates `oidc_config.client_secret_enc` alongside other encrypted fields
- `user.login.sso` action type added to audit log union; SECURITY.md updated with OIDC section

## Test plan

- [ ] Navigate to `/settings/auth/sso` as admin — form renders with restart warning and redirect URI hint
- [ ] Navigate to `/settings/auth/sso` as viewer — redirected to `/dashboard`
- [ ] Enter a valid OIDC discovery URL, click Test — shows ✓ issuer line
- [ ] Enter a private-IP discovery URL — Test returns SSRF blocked message
- [ ] Save config with enabled=true — toast shows restart reminder
- [ ] Restart service, go to `/login` — "Sign in with SSO" button appears below divider
- [ ] Complete SSO flow via Authentik — redirected to `/dashboard`, new user in `/settings/users` with role `viewer`
- [ ] Click Disable SSO, restart — button no longer appears on `/login`
- [ ] Run key rotation (`/settings/security`) — `oidc_config` row re-encrypted, row count in rotation summary includes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)