### PR TITLE
fix(auth): enable trusted account linking for OIDC (follow-up to #187)

### DIFF
--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -51,6 +51,12 @@ export const auth = betterAuth({
     return isPrivateOrigin(origin) ? [...explicitTrusted, origin] : explicitTrusted
   },
   plugins: buildPlugins(),
+  account: {
+    accountLinking: {
+      enabled: true,
+      trustedProviders: ['oidc'],
+    },
+  },
   database: drizzleAdapter(getDb(), {
     provider: 'sqlite',
     schema: { user, session, account, verification, twoFactor },


### PR DESCRIPTION
## Summary

- SSO sign-in failed with `account_not_linked` when the IdP returned an email matching an existing local user
- Adds `account.accountLinking` with `trustedProviders: ['oidc']` — auto-links on email match for OIDC only

## Test plan

- [ ] Sign in via SSO with an email that already has a local password account — succeeds, lands on `/dashboard`
- [ ] Sign in via SSO with a new email — creates a new `viewer` user as before
- [ ] Local password sign-in unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)