### PR TITLE
fix(audit): resolve OIDC providerId from context.params (follow-up to #335)

### DIFF
--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -70,7 +70,8 @@ export const auth = betterAuth({
             providerId = 'credential'
           } else if (path.startsWith('/oauth2/callback/') || path.startsWith('/callback/')) {
             action     = 'user.login.sso'
-            providerId = path.split('/').pop() || 'oauth'
+            const ctxParams = (context as { params?: { id?: string; providerId?: string } } | null)?.params
+            providerId = ctxParams?.id || ctxParams?.providerId || 'oauth'
           } else if (path === '/two-factor/verify-totp' || path === '/two-factor/verify-backup-code') {
             action     = 'user.login'
             providerId = 'credential+totp'


### PR DESCRIPTION
## Summary

- `path.split('/').pop()` returned the literal template string `:providerId` instead of the resolved provider (e.g. `'oidc'`)
- Reads `context.params.id || context.params.providerId` instead, matching better-auth's own `last-login-method` plugin approach

## Test plan

- [ ] Sign in via SSO → audit log row shows `providerId: 'oidc'` (not `':providerId'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)