### PR TITLE
fix(install): self-reexec on update --source to apply latest script (closes #305)

### DIFF
--- a/scripts/server-install.sh
+++ b/scripts/server-install.sh
@@ -44,6 +44,33 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# ── Self-reexec on update ────────────────────────────────────────────────────
+# When updating from a source dir, the rsync below will overwrite this very
+# script. Bash runs scripts lazily, so the OLD in-memory script keeps executing
+# even after the file on disk has been replaced — meaning any new logic added
+# below the rsync line silently fails on the first update.
+#
+# Fix: if running update with --source, sync the script first, then re-exec
+# the new version with the original arguments. A guard env var prevents
+# infinite loops. See #305.
+if [[ "$COMMAND" == "update" ]] && [[ -n "$SOURCE_DIR" ]] && [[ -z "$BACKUPOS_REEXECED" ]]; then
+  NEW_SCRIPT="$SOURCE_DIR/scripts/server-install.sh"
+  SELF_PATH="/opt/backupos/scripts/server-install.sh"
+  if [[ -f "$NEW_SCRIPT" ]] && [[ -f "$SELF_PATH" ]] && ! cmp -s "$NEW_SCRIPT" "$SELF_PATH"; then
+    echo "[backupos] Installer script changed — updating and re-executing..."
+    cp "$NEW_SCRIPT" "$SELF_PATH"
+    chmod +x "$SELF_PATH"
+    export BACKUPOS_REEXECED=1
+    REEXEC_ARGS=("$COMMAND")
+    [[ -n "$PUBLIC_URL" ]] && REEXEC_ARGS+=(--url "$PUBLIC_URL")
+    REEXEC_ARGS+=(--port "$PORT")
+    REEXEC_ARGS+=(--pbs-port "$PBS_PORT")
+    REEXEC_ARGS+=(--user "$SVC_USER")
+    REEXEC_ARGS+=(--source "$SOURCE_DIR")
+    exec bash "$SELF_PATH" "${REEXEC_ARGS[@]}"
+  fi
+fi
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 log()    { echo "[backupos] $*"; }
 ok()     { echo "[backupos] ✓ $*"; }


### PR DESCRIPTION
## Problem

When running `sudo bash /opt/backupos/scripts/server-install.sh update --source ~/backupos`, the rsync step overwrites the script on disk — but bash has already read the old script into memory. Any new logic added below the rsync line (e.g. the `BACKUPOS_INTERNAL_SECRET` / `BACKUPOS_INTERNAL_URL` blocks from #303) silently never executes on that first update run.

This is a class of bug: any future change to env handling, systemd unit generation, or post-build steps below the rsync line will fail silently on the first update.

## Fix

Adds a self-reexec block immediately after arg parsing (before the helpers section). When all conditions are met:

1. Command is `update`
2. `--source` was supplied
3. Guard env var `BACKUPOS_REEXECED` is unset
4. Source script differs from installed script (`cmp -s`)

The block copies the new script into place and `exec`s it with reconstructed args + `BACKUPOS_REEXECED=1`. The guard prevents infinite loops on the second execution.

No effect on `install`, `uninstall`, or `update` without `--source`.

## Test plan

- [ ] `update --source` with identical scripts → no reexec, no log line
- [ ] `update --source` with a changed script → logs "Installer script changed — updating and re-executing...", reexec'd run completes normally
- [ ] Reexec'd run does NOT trigger a second reexec (guard works)
- [ ] `install` and `uninstall` paths unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)