### PR TITLE
fix(pbs): fire webhook in goroutine to unblock FinishRun (closes #304)

### DIFF
--- a/services/backupos-pbs/internal/jobsync/jobsync.go
+++ b/services/backupos-pbs/internal/jobsync/jobsync.go
@@ -121,7 +121,17 @@ func FinishRun(db *sql.DB, runID, jobID, status string, snapshotID, errorMessage
 	if _, err := db.Exec(updateJob, completedAt.UnixMilli(), status, jobID); err != nil {
 		return fmt.Errorf("update job: %w", err)
 	}
-	fireWebhook(runID, status, errorMessage)
+	// Fire-and-forget: webhook is best-effort, must not block FinishRun.
+	// See #304. Panic-recover guards against any future change in fireWebhook
+	// or its dependencies that could panic on bad input.
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("jobsync: webhook goroutine panic", "panic", r, "runID", runID)
+			}
+		}()
+		fireWebhook(runID, status, errorMessage)
+	}()
 	return nil
 }
 


### PR DESCRIPTION
## Problem

`FinishRun` called `fireWebhook(...)` synchronously. The webhook client has a 5s timeout, so a slow or unreachable BackupOS web app would block backup completion for up to 5 seconds per finished PBS session. The function-level comment on `fireWebhook` already stated:

> fireWebhook is best-effort: never blocks the FinishRun success path

— the goroutine wrapping was simply never added at the call site.

## Fix

Wraps the `fireWebhook` call in a goroutine so `FinishRun` returns immediately after the DB updates complete. Adds panic-recover inside the goroutine because panics in goroutines crash the entire PBS service, and `fireWebhook` builds JSON, dials HTTP, and parses URLs.

Single call site changed — `fireWebhook` itself and its direct test callers are untouched and remain synchronous.

## Test plan

- [ ] Existing `TestFinishRun_*` and `TestFireWebhook_*` tests pass (`go test ./internal/jobsync/...`)
- [ ] `FinishRun` returns before webhook completes when webhook URL is slow

🤖 Generated with [Claude Code](https://claude.com/claude-code)