### PR TITLE
fix(pbs): populate total_size on backup_runs and pbs_snapshots

### DIFF
--- a/services/backupos-pbs/internal/finish/finish.go
+++ b/services/backupos-pbs/internal/finish/finish.go
@@ -73,15 +73,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var totalBytes int64
+	if sc.WriterState != nil {
+		totalBytes = int64(sc.WriterState.TotalBytes())
+	}
+
 	// Insert / upsert the pbs_snapshots row. This is best-effort: if the
 	// DB write fails the files are still on disk and can be re-indexed later.
-	h.insertSnapshot(sc)
+	h.insertSnapshot(sc, totalBytes)
 
 	// Finalize the synthetic run row if one was created at upgrade time.
 	if sc.RunID != "" {
 		snapshotID := buildSnapshotID(sc.DatastoreID, sc.Namespace, sc.BackupType, sc.BackupID, sc.BackupTime)
 		if err := jobsync.FinishRun(h.db, sc.RunID, sc.JobID, "success",
-			&snapshotID, nil, sc.SessionStartedAt, time.Now()); err != nil {
+			&snapshotID, nil, &totalBytes, sc.SessionStartedAt, time.Now()); err != nil {
 			slog.Error("finish: FinishRun failed (backup still saved)",
 				"error", err, "run_id", sc.RunID)
 		}
@@ -121,7 +126,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // insertSnapshot upserts a pbs_snapshots row for the completed backup.
 // Errors are logged but do not affect the HTTP response — disk is the
 // source of truth and the row can be re-inserted later.
-func (h *Handler) insertSnapshot(sc *streamctx.SessionContext) {
+func (h *Handler) insertSnapshot(sc *streamctx.SessionContext, totalSizeBytes int64) {
 	snapshotID := buildSnapshotID(sc.DatastoreID, sc.Namespace, sc.BackupType, sc.BackupID, sc.BackupTime)
 	namespaceID := h.resolveNamespaceID(sc.DatastoreID, sc.Namespace)
 
@@ -144,7 +149,7 @@ func (h *Handler) insertSnapshot(sc *streamctx.SessionContext) {
 		snapshotID, sc.DatastoreID, namespaceID,
 		sc.BackupType, sc.BackupID, sc.BackupTime.UnixMilli(),
 		time.Now().UnixMilli(), manifest,
-		nil, nil, // total_size_bytes, unique_size_bytes — TODO when stats land
+		totalSizeBytes, nil, // total_size_bytes (filled); unique_size_bytes still TODO
 	)
 	if err != nil {
 		slog.Error("finish: pbs_snapshots insert failed (snapshot still on disk)",

--- a/services/backupos-pbs/internal/jobsync/jobsync.go
+++ b/services/backupos-pbs/internal/jobsync/jobsync.go
@@ -101,15 +101,16 @@ func InsertRunningRun(db *sql.DB, jobID string, startedAt time.Time) (string, er
 }
 
 // FinishRun marks a run as completed (success or failed) and updates the parent Job.
-// snapshotID and errorMessage may be nil for the unused branch.
-func FinishRun(db *sql.DB, runID, jobID, status string, snapshotID, errorMessage *string, startedAt, completedAt time.Time) error {
+// snapshotID, errorMessage, and totalSize may be nil for the unused branch.
+func FinishRun(db *sql.DB, runID, jobID, status string, snapshotID, errorMessage *string, totalSize *int64, startedAt, completedAt time.Time) error {
 	durationSec := int64(completedAt.Sub(startedAt).Seconds())
 	const updateRun = `
 		UPDATE backup_runs
-		SET status = ?, completed_at = ?, duration = ?, snapshot_id = ?, error_message = ?
+		SET status = ?, completed_at = ?, duration = ?, total_size = ?, snapshot_id = ?, error_message = ?
 		WHERE id = ?
 	`
 	if _, err := db.Exec(updateRun, status, completedAt.UnixMilli(), durationSec,
+		nullableInt64(totalSize),
 		nullableString(snapshotID), nullableString(errorMessage), runID); err != nil {
 		return fmt.Errorf("update run: %w", err)
 	}
@@ -196,4 +197,11 @@ func nullableString(s *string) sql.NullString {
 		return sql.NullString{}
 	}
 	return sql.NullString{String: *s, Valid: true}
+}
+
+func nullableInt64(v *int64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
 }

--- a/services/backupos-pbs/internal/jobsync/jobsync_test.go
+++ b/services/backupos-pbs/internal/jobsync/jobsync_test.go
@@ -33,7 +33,7 @@ func openDB(t *testing.T) *sql.DB {
 		CREATE TABLE backup_runs (
 			id TEXT PRIMARY KEY, job_id TEXT, status TEXT, trigger TEXT,
 			started_at INTEGER, run_type TEXT,
-			completed_at INTEGER, duration INTEGER, snapshot_id TEXT, error_message TEXT
+			completed_at INTEGER, duration INTEGER, total_size INTEGER, snapshot_id TEXT, error_message TEXT
 		);
 	`)
 	if err != nil {
@@ -164,7 +164,7 @@ func TestFinishRun_Success(t *testing.T) {
 
 	snapID := "snap-abc"
 	completedAt := time.Unix(1735000060, 0)
-	if err := FinishRun(db, runID, jobID, "success", &snapID, nil, startedAt, completedAt); err != nil {
+	if err := FinishRun(db, runID, jobID, "success", &snapID, nil, nil, startedAt, completedAt); err != nil {
 		t.Fatal(err)
 	}
 
@@ -197,7 +197,7 @@ func TestFinishRun_Failed(t *testing.T) {
 
 	errMsg := "connection closed without /finish"
 	completedAt := time.Unix(1735000030, 0)
-	if err := FinishRun(db, runID, jobID, "failed", nil, &errMsg, startedAt, completedAt); err != nil {
+	if err := FinishRun(db, runID, jobID, "failed", nil, &errMsg, nil, startedAt, completedAt); err != nil {
 		t.Fatal(err)
 	}
 
@@ -223,7 +223,7 @@ func TestFinishRun_DurationCalculation(t *testing.T) {
 	completedAt := startedAt.Add(90 * time.Second)
 	runID, _ := InsertRunningRun(db, jobID, startedAt)
 
-	if err := FinishRun(db, runID, jobID, "success", nil, nil, startedAt, completedAt); err != nil {
+	if err := FinishRun(db, runID, jobID, "success", nil, nil, nil, startedAt, completedAt); err != nil {
 		t.Fatal(err)
 	}
 
@@ -335,4 +335,46 @@ func TestFireWebhook_AuthFailure_LogsButDoesntPanic(t *testing.T) {
 	SetWebhookConfig(srv.URL, "wrong-secret")
 	// Must not panic; non-2xx is logged and swallowed
 	fireWebhook("run-5", "success", nil)
+}
+
+func TestFinishRun_TotalSize(t *testing.T) {
+	db := openDB(t)
+	jobID := JobID("ds-1", namespace.Root(), "vm", "100")
+	if err := UpsertJob(db, "ds-1", namespace.Root(), "vm", "100"); err != nil {
+		t.Fatal(err)
+	}
+	startedAt := time.Unix(1735000000, 0)
+	completedAt := startedAt.Add(60 * time.Second)
+	runID, _ := InsertRunningRun(db, jobID, startedAt)
+
+	var size int64 = 1024 * 1024 * 512 // 512 MiB
+	if err := FinishRun(db, runID, jobID, "success", nil, nil, &size, startedAt, completedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	var got sql.NullInt64
+	_ = db.QueryRow(`SELECT total_size FROM backup_runs WHERE id = ?`, runID).Scan(&got)
+	if !got.Valid || got.Int64 != size {
+		t.Errorf("total_size: got %v, want %d", got, size)
+	}
+}
+
+func TestFinishRun_NilTotalSize(t *testing.T) {
+	db := openDB(t)
+	jobID := JobID("ds-1", namespace.Root(), "vm", "100")
+	if err := UpsertJob(db, "ds-1", namespace.Root(), "vm", "100"); err != nil {
+		t.Fatal(err)
+	}
+	startedAt := time.Unix(1735000000, 0)
+	runID, _ := InsertRunningRun(db, jobID, startedAt)
+
+	if err := FinishRun(db, runID, jobID, "failed", nil, nil, nil, startedAt, startedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	var got sql.NullInt64
+	_ = db.QueryRow(`SELECT total_size FROM backup_runs WHERE id = ?`, runID).Scan(&got)
+	if got.Valid {
+		t.Errorf("total_size: got valid %d, want NULL", got.Int64)
+	}
 }

--- a/services/backupos-pbs/internal/upgrade/handler.go
+++ b/services/backupos-pbs/internal/upgrade/handler.go
@@ -329,7 +329,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if updated && sessionCtx.RunID != "" {
 		errMsg := "connection closed without /finish"
 		if err := jobsync.FinishRun(h.db, sessionCtx.RunID, sessionCtx.JobID, "failed",
-			nil, &errMsg, sessionCtx.SessionStartedAt, time.Now()); err != nil {
+			nil, &errMsg, nil, sessionCtx.SessionStartedAt, time.Now()); err != nil {
 			slog.Error("upgrade: abort path FinishRun failed",
 				"error", err, "run_id", sessionCtx.RunID)
 		}

--- a/services/backupos-pbs/internal/wstate/wstate.go
+++ b/services/backupos-pbs/internal/wstate/wstate.go
@@ -119,6 +119,34 @@ func (s *State) RegisterFixedWriter(name string, index FixedIndexWriter, size *u
 	return wid, nil
 }
 
+// TotalBytes returns the cumulative content size in bytes across all
+// fixed and dynamic writers registered in this session. Used by /finish
+// to populate backup_runs.total_size and pbs_snapshots.total_size_bytes.
+//
+// For fixed writers: uses the declared Size (set at registration). Skips
+// writers where Size is nil (should not happen on the success path, but
+// defensive).
+//
+// For dynamic writers: uses Offset, which is the cumulative end offset
+// after the last AppendChunk and equals total data size at close.
+//
+// Safe to call at any session phase. Lock is taken; do not call while
+// holding s.mu.
+func (s *State) TotalBytes() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var total uint64
+	for _, w := range s.fixedWriters {
+		if w.Size != nil {
+			total += *w.Size
+		}
+	}
+	for _, w := range s.dynamicWriters {
+		total += w.Offset
+	}
+	return total
+}
+
 // LookupChunk returns the plaintext size of a previously uploaded chunk, if any.
 func (s *State) LookupChunk(digest [32]byte) (uint32, bool) {
 	s.mu.Lock()


### PR DESCRIPTION
## Summary

- Adds `TotalBytes()` method to `wstate.State` — sums fixed writer declared sizes and dynamic writer cumulative offsets
- Threads `totalSize *int64` through `FinishRun` and writes it to `backup_runs.total_size`
- Passes computed bytes to `insertSnapshot` so `pbs_snapshots.total_size_bytes` is populated on finish
- Nil-guards `WriterState` in the finish handler (reader sessions have no writer state)

## Test plan

- [ ] `TestFinishRun_TotalSize` — 512 MiB written, verified in DB
- [ ] `TestFinishRun_NilTotalSize` — nil size maps to SQL NULL
- [ ] Existing `TestFinishRun_Success/Failed/DurationCalculation` updated with nil sentinel and pass

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)