### PR TITLE
fix(ui): empty-state on agents page links to enroll page (closes #346)

### DIFF
--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -82,14 +82,22 @@ export default async function AgentsPage() {
             description="Install the BackupOS agent on your Linux or Windows hosts to start backing up."
           />
           <div style={{ padding: '0 24px 32px', display: 'flex', justifyContent: 'center' }}>
-            <code style={{
-              display: 'block',
-              backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
-              borderRadius: 'var(--radius-sm)', padding: '10px 16px',
-              fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg)',
-            }}>
-              curl -fsSL http://localhost:3000/install.sh | bash
-            </code>
+            <Link
+              href="/agents/new"
+              style={{
+                display: 'inline-block',
+                padding: '10px 20px',
+                background: 'var(--accent)',
+                color: 'var(--bg)',
+                border: '1px solid var(--accent)',
+                borderRadius: 'var(--radius-sm)',
+                fontSize: 14,
+                fontWeight: 500,
+                textDecoration: 'none',
+              }}
+            >
+              Enroll your first agent
+            </Link>
           </div>
         </div>
       ) : (


### PR DESCRIPTION
## Summary

- Removes a hardcoded `curl` one-liner that was structurally broken: wrong port (3000 vs 3093), missing `BACKUPOS_TOKEN`, missing `sudo`, and pointing at `localhost` which is unreachable from any other machine
- The token only exists after enrolling an agent, so the empty state can never show a working install command — the agent detail page is the correct place for that
- Replaces the broken code block with a CTA button linking to `/agents/new`, which generates the token and redirects to the agent detail page showing the real working install command

Closes #346
🤖 Generated with [Claude Code](https://claude.com/claude-code)