### PR TITLE
fix(2fa): reset user.two_factor_enabled flag on disable (closes #113)

### DIFF
--- a/apps/web/app/(dashboard)/settings/security/client.tsx
+++ b/apps/web/app/(dashboard)/settings/security/client.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from 'react'
 import { TotpSetupModal } from '@/components/totp-setup-modal'
 import { changePassword }  from '@/app/actions/user'
+import { resetTwoFactorFlag } from '@/app/actions/two-factor'
 import { authClient }      from '@/lib/auth-client'
 
 interface Props {
@@ -38,6 +39,15 @@ export function SecurityClient({ twoFactorEnabled }: Props) {
     startDisableTransition(async () => {
       const result = await authClient.twoFactor.disable({ password: disablePassword })
       if (result.error) { setDisableError(result.error.message ?? 'Failed to disable 2FA'); return }
+
+      // better-auth removed the two_factor row but didn't reset
+      // user.two_factor_enabled. Do it server-side now.
+      const flagResult = await resetTwoFactorFlag()
+      if (flagResult.error) {
+        setDisableError(flagResult.error)
+        return
+      }
+
       setTfEnabled(false)
       setDisablePassword('')
     })

--- a/apps/web/app/actions/two-factor.ts
+++ b/apps/web/app/actions/two-factor.ts
@@ -1,0 +1,27 @@
+'use server'
+
+import { headers } from 'next/headers'
+import { revalidatePath } from 'next/cache'
+import { getDb, user, eq } from '@backupos/db'
+import { appendAuditEntry } from '@/lib/audit'
+
+export async function resetTwoFactorFlag(): Promise<{ ok?: true; error?: string }> {
+  const { auth } = await import('@/lib/auth')
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) return { error: 'Not authenticated' }
+
+  const db = getDb()
+  await db.update(user)
+    .set({ twoFactorEnabled: false })
+    .where(eq(user.id, session.user.id))
+
+  await appendAuditEntry({
+    action:       'totp.disabled',
+    resourceType: 'user',
+    resourceId:   session.user.id,
+    actor:        session.user.id,
+  })
+
+  revalidatePath('/settings/security')
+  return { ok: true }
+}


### PR DESCRIPTION
## Summary

- `authClient.twoFactor.disable()` deletes the `two_factor` row but doesn't touch `user.two_factor_enabled`, leaving the DB inconsistent
- The plugin doesn't expose an `afterDisable` hook in the version this codebase uses (same limitation as the post-login hook in `lib/auth.ts`)
- Adds a `resetTwoFactorFlag` server action (Pattern C wrapper) that resets the flag, writes a `totp.disabled` audit entry, and revalidates the security page
- Client calls it immediately after the better-auth plugin call succeeds

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)