### PR TITLE
chore(docs): delete orphaned PlanComparison component (closes #348)

### DIFF
--- a/apps/docs/app/[...slug]/page.tsx
+++ b/apps/docs/app/[...slug]/page.tsx
@@ -16,7 +16,6 @@ const HealthFactors   = makeStub('HealthFactors')
 const HealthGrades    = makeStub('HealthGrades')
 const JobPhases       = makeStub('JobPhases')
 const OtherBackends   = makeStub('OtherBackends')
-const PlanComparison  = makeStub('PlanComparison')
 const RepoFields      = makeStub('RepoFields')
 const RetentionPolicy = makeStub('RetentionPolicy')
 const RunPhases       = makeStub('RunPhases')
@@ -27,7 +26,7 @@ const mdxComponents = {
   Note, Tip, FeatureComparison, GlossaryTable,
   Warning,
   AlertTriggers, HealthFactors, HealthGrades, JobPhases, OtherBackends,
-  PlanComparison, RepoFields, RetentionPolicy, RunPhases, SourceTypes, StepTypes,
+  RepoFields, RetentionPolicy, RunPhases, SourceTypes, StepTypes,
 }
 
 const DOCS_ROOT = resolve(process.cwd(), '../../packages/docs-content/content')

--- a/apps/web/app/(dashboard)/docs/mdx-components.tsx
+++ b/apps/web/app/(dashboard)/docs/mdx-components.tsx
@@ -278,22 +278,6 @@ export function FeatureComparison() {
   )
 }
 
-export function PlanComparison() {
-  return (
-    <PlanTable
-      highlight="Teams"
-      headers={['', 'Solo', 'Teams']}
-      rows={[
-        ['Agents',              'Up to 5',  'Unlimited'],
-        ['Users',               '1',        'Up to 20'],
-        ['Audit log retention', '90 days',  '7 years'],
-        ['SSO',                 '❌',       '✅'],
-        ['Price',               'Free',     '$12/month'],
-      ]}
-    />
-  )
-}
-
 export function JobPhases() {
   return (
     <PhaseList
@@ -669,7 +653,7 @@ export function getMdxComponents(): Record<string, any> {
   return {
     Tip, Warning, Danger, Note, Steps,
     ComparisonTable, PlanTable, PhaseList, SourceGrid,
-    FeatureComparison, PlanComparison, JobPhases, SourceTypes,
+    FeatureComparison, JobPhases, SourceTypes,
     GlossaryTable, RunPhases, StepTypes,
     HealthFactors, HealthGrades,
     RetentionPolicy, AlertTriggers, RepoFields, OtherBackends,


### PR DESCRIPTION
## Summary

- Removes `PlanComparison` function from `apps/web/app/(dashboard)/docs/mdx-components.tsx` — it was never referenced by any `.mdx` file and described a stale plan model (Solo/Teams, $12/month) contradicting `docs/design/licensing.md`
- Removes `makeStub('PlanComparison')` and map registration from `apps/docs/app/[...slug]/page.tsx`
- `PlanTable` (lower-level building block) is preserved

Pricing tables belong on the marketing site and Lemon Squeezy storefront, not in product docs.

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)