### PR TITLE
fix(deploy): flush OS write buffers before service restart (closes #360)

### DIFF
--- a/scripts/server-install.sh
+++ b/scripts/server-install.sh
@@ -465,6 +465,13 @@ PBSSVCEOF
 
 systemctl daemon-reload
 systemctl enable "$SERVICE_NAME" "$SERVICE_NAME-pbs"
+
+# Flush all OS write buffers before starting the service. Without this the
+# Next.js process can start reading .next/ before the kernel has written the
+# clientReferenceManifest files, causing a 500 for ~5-30 seconds. See #360.
+sync
+sleep 2
+
 systemctl restart "$SERVICE_NAME"
 systemctl restart "$SERVICE_NAME-pbs"
 


### PR DESCRIPTION
## Summary

Adds `sync && sleep 2` between the Next.js build completing and `systemctl restart` in `scripts/server-install.sh`.

Without this, the Node process could start reading `.next/` before the kernel had fully written the `clientReferenceManifest` files to disk, causing HTTP 500 on `/dashboard` for 5–30 seconds post-deploy.

## Root cause

The `clientReferenceManifest` is part of the Next.js 15 production build output at `.next/server/app/...-manifest.json`. On in-place deploys, OS write buffers aren't guaranteed to be flushed before the service process starts. `sync` flushes all pending writes; `sleep 2` gives the kernel a moment to settle before the new process opens the directory.

## Fix chosen

Option A (1-line `sync` + `sleep 2`) — sufficient for P2 severity. Option B (atomic `.next.new` rename) would be more robust but is considerably more invasive for a low-severity issue.

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)