### PR TITLE
fix(rbac): redirect to access-denied page instead of throwing (closes #362)

### DIFF
--- a/apps/web/app/(dashboard)/access-denied/page.tsx
+++ b/apps/web/app/(dashboard)/access-denied/page.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { getCurrentUser } from '@/lib/user'
+
+export const metadata = { title: 'Access denied — BackupOS' }
+
+export default async function AccessDeniedPage() {
+  const u = await getCurrentUser()
+  if (!u) redirect('/login')
+  if (u.role === 'admin') redirect('/dashboard')
+
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      minHeight: '60vh',
+    }}>
+      <div style={{
+        maxWidth: 480, width: '100%',
+        backgroundColor: 'var(--surf)', border: '1px solid var(--border)',
+        borderRadius: 'var(--radius)', padding: 40,
+      }}>
+        <h1 style={{ fontSize: 20, fontWeight: 600, color: 'var(--fg)', marginBottom: 12 }}>
+          Access denied
+        </h1>
+        <p style={{ fontSize: 14, color: 'var(--fg-mute)', lineHeight: 1.6, marginBottom: 24 }}>
+          This page requires admin role. You&apos;re signed in as{' '}
+          <strong style={{ color: 'var(--fg)' }}>{u.email}</strong>.
+        </p>
+        <Link
+          href="/dashboard"
+          style={{
+            display: 'inline-block',
+            padding: '9px 18px',
+            backgroundColor: 'var(--accent)',
+            color: 'var(--bg)',
+            border: '1px solid var(--accent)',
+            borderRadius: 'var(--radius-sm)',
+            fontSize: 14, fontWeight: 500, textDecoration: 'none',
+          }}
+        >
+          Go to dashboard
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -96,7 +96,7 @@ export default function ErrorPage({ error, reset }: Props) {
           {body}
         </p>
 
-        {error.digest && (
+        {error.digest && kind !== 'permission' && (
           <div
             style={{
               fontSize: 12,
@@ -114,22 +114,24 @@ export default function ErrorPage({ error, reset }: Props) {
         )}
 
         <div style={{ display: 'flex', gap: 'var(--space-3)', flexWrap: 'wrap' }}>
-          <button
-            onClick={reset}
-            style={{
-              background: 'var(--accent)',
-              color: 'var(--accent-fg)',
-              border: 'none',
-              borderRadius: 'var(--radius-sm)',
-              padding: '10px 16px',
-              fontSize: 14,
-              fontWeight: 500,
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-            }}
-          >
-            Try again
-          </button>
+          {kind !== 'permission' && (
+            <button
+              onClick={reset}
+              style={{
+                background: 'var(--accent)',
+                color: 'var(--accent-fg)',
+                border: 'none',
+                borderRadius: 'var(--radius-sm)',
+                padding: '10px 16px',
+                fontSize: 14,
+                fontWeight: 500,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              Try again
+            </button>
+          )}
 
           <Link
             href="/"

--- a/apps/web/lib/user.ts
+++ b/apps/web/lib/user.ts
@@ -18,7 +18,7 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
 export async function requireAdmin(): Promise<AuthUser> {
   const u = await getCurrentUser()
   if (!u) redirect('/login')
-  if (u.role !== 'admin') throw new Error('Forbidden: admin role required')
+  if (u.role !== 'admin') redirect('/access-denied')
   return u
 }
 


### PR DESCRIPTION
## Summary

`requireAdmin()` was throwing `Error('Forbidden: admin role required')` which bubbled to the global error boundary. In Next.js production, server component error messages are redacted — so `classifyError()` always fell back to `'generic'`, showing "Something went wrong" and an Error ID for a routine permission denial.

## Changes

- **`lib/user.ts`**: `requireAdmin()` now calls `redirect('/access-denied')` instead of throwing. `redirect()` is a Next.js navigation primitive that works reliably in production.
- **`app/(dashboard)/access-denied/page.tsx`** (new): Server component inside the dashboard layout. Shows "Access denied" with the user's email and a "Go to dashboard" CTA. Admins who land on it directly are bounced back to `/dashboard`.
- **`app/error.tsx`**: Suppresses the Error ID block and "Try again" button for `'permission'`-classified errors (dev-mode defence-in-depth, keeps the existing classification logic useful).

## Why not Option B (custom error class)?

In Next.js 15 production, server component error messages and class names are redacted before reaching the client error boundary. A custom `ForbiddenError` class wouldn't survive the server→client boundary. `redirect()` is the correct primitive for expected navigation outcomes like access control.

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)