### PR TITLE
fix(agent): detect apphook capabilities by what hooks actually need (closes #25)

### DIFF
--- a/packages/agent/src/capabilities.ts
+++ b/packages/agent/src/capabilities.ts
@@ -65,12 +65,21 @@ export async function detectCapabilities(): Promise<Capability[]> {
   const caps: Capability[] = []
 
   if (canReadFilesystem()) caps.push('filesystem')
-  if (await canReachDocker()) caps.push('docker')
+
+  const dockerOk = await canReachDocker()
+  if (dockerOk) caps.push('docker')
+
   if (process.platform === 'win32') caps.push('vss')
-  if (await binaryExists('pg_dump'))   caps.push('apphook:postgres')
-  if (await binaryExists('mysqldump')) caps.push('apphook:mysql')
-  if (await binaryExists('redis-cli')) caps.push('apphook:redis')
-  if (await binaryExists('sqlite3'))   caps.push('apphook:sqlite')
+
+  // Postgres / MySQL: host binary OR a reachable Docker daemon (hook code already
+  // branches on config.containerName to choose docker exec vs direct invocation).
+  if (await binaryExists('pg_dump')   || dockerOk) caps.push('apphook:postgres')
+  if (await binaryExists('mysqldump') || dockerOk) caps.push('apphook:mysql')
+
+  // Redis hook uses ioredis over TCP — no host binary required.
+  // Sqlite hook uses better-sqlite3 native library — no host binary required.
+  caps.push('apphook:redis')
+  caps.push('apphook:sqlite')
 
   return caps
 }


### PR DESCRIPTION
## Summary

`capabilities.ts` was gating each apphook on a host CLI binary, but the hook implementations don't all require them:

| Apphook  | Was checking for | Actually needs |
|----------|-----------------|----------------|
| postgres | `pg_dump` binary | host `pg_dump` **OR** Docker daemon (hook already uses `docker exec`) |
| mysql    | `mysqldump` binary | host `mysqldump` **OR** Docker daemon |
| redis    | `redis-cli` binary | nothing — uses `ioredis` Node client over TCP |
| sqlite   | `sqlite3` binary | nothing — uses `better-sqlite3` native library |

## Changes

Single file: `packages/agent/src/capabilities.ts`

- Capture `dockerOk` once (avoids re-running the Docker socket check per apphook)
- `apphook:postgres` and `apphook:mysql` advertised when host binary **or** Docker reachable
- `apphook:redis` and `apphook:sqlite` advertised unconditionally
- Hook implementations (`packages/app-hooks/src/{postgres,mysql}.ts`) are unchanged — they already branch on `config.containerName`

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)