### PR TITLE
feat(jobs): wire cancel button for running backup runs (closes #53)

### DIFF
--- a/apps/web/app/(dashboard)/jobs/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/[id]/page.tsx
@@ -10,7 +10,7 @@ import { fmtLimit } from '@/lib/bandwidth'
 import { PreflightButton } from '@/components/preflight-modal'
 import { togglePreflight } from '@/app/actions/preflight'
 import { PreflightToggle } from '@/components/preflight-toggle'
-import { triggerJob, saveJobRetention, cancelJob, retryRun } from '@/app/actions/jobs'
+import { triggerJob, saveJobRetention, cancelJobFormAction, retryRun } from '@/app/actions/jobs'
 import { validateCron } from '@/lib/cron-validate'
 import { BreadcrumbOverride } from '@/components/breadcrumb-override'
 
@@ -96,7 +96,7 @@ export default async function JobDetailPage({ params }: { params: Promise<{ id: 
           </button>
         </form>
         {activeRun && (
-          <form action={cancelJob.bind(null, job.id)}>
+          <form action={cancelJobFormAction.bind(null, job.id)}>
             <button
               type="submit"
               style={{

--- a/apps/web/app/(dashboard)/jobs/[id]/runs/[runId]/CancelRunButton.tsx
+++ b/apps/web/app/(dashboard)/jobs/[id]/runs/[runId]/CancelRunButton.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { cancelJob } from '@/app/actions/jobs'
+
+export function CancelRunButton({ jobId }: { jobId: string }) {
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle')
+  const [errorMessage, setErrorMessage] = useState<string>('')
+  const [isPending, startTransition] = useTransition()
+
+  function handleCancel() {
+    if (!confirm('Cancel this run? The running backup will be aborted.')) return
+    startTransition(async () => {
+      const result = await cancelJob(jobId)
+      if (result.ok) {
+        setStatus('success')
+        if (result.error) setErrorMessage(result.error)
+      } else {
+        setStatus('error')
+        setErrorMessage(result.error ?? 'Unknown error')
+      }
+    })
+  }
+
+  if (status === 'success') {
+    return (
+      <span
+        style={{ fontSize: 12, color: 'var(--ok)' }}
+        title={errorMessage || undefined}
+      >
+        Cancel sent
+      </span>
+    )
+  }
+  if (status === 'error') {
+    return (
+      <span style={{ fontSize: 12, color: 'var(--err)' }} title={errorMessage}>
+        Failed
+      </span>
+    )
+  }
+  return (
+    <button
+      type="button"
+      onClick={handleCancel}
+      disabled={isPending}
+      style={{
+        fontSize: 12, padding: '4px 10px',
+        backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+        borderRadius: 'var(--radius-sm)', color: 'var(--fg)', cursor: 'pointer',
+      }}
+    >
+      {isPending ? 'Cancelling…' : 'Cancel'}
+    </button>
+  )
+}

--- a/apps/web/app/(dashboard)/jobs/[id]/runs/[runId]/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/[id]/runs/[runId]/page.tsx
@@ -5,6 +5,7 @@ import { PhaseTimeline }   from '@/components/phase-timeline'
 import { CopyCommandButton } from '@/components/copy-command-button'
 import { AutoRefresh }     from '@/components/ui/auto-refresh'
 import type { PhaseData }  from '@/app/actions/runs'
+import { CancelRunButton } from './CancelRunButton'
 
 const STATUS_COLORS: Record<string, string> = {
   running:   'var(--accent)',
@@ -85,6 +86,7 @@ export default async function RunDetailPage({ params }: { params: Promise<{ id: 
             }}>
               {run.status}
             </span>
+            {run.status === 'running' && <CancelRunButton jobId={jobId} />}
           </div>
         </div>
         <div style={{ flex: 1 }} />

--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -362,7 +362,8 @@ export async function retryRun(jobId: string): Promise<void> {
   redirect(`/jobs/${jobId}`)
 }
 
-export async function cancelJob(jobId: string): Promise<void> {
+export async function cancelJob(jobId: string): Promise<{ ok: boolean; error?: string }> {
+  await requireAdmin()
   const db = getDb()
   const [run] = await db
     .select()
@@ -370,14 +371,14 @@ export async function cancelJob(jobId: string): Promise<void> {
     .where(and(eq(backupRuns.jobId, jobId), eq(backupRuns.status, 'running')))
     .limit(1)
 
-  if (!run) { revalidatePath(`/jobs/${jobId}`); return }
+  if (!run) { revalidatePath(`/jobs/${jobId}`); return { ok: true } }
 
   if (!run.agentId) {
     // Local run (no agent) — cancel directly
     await db.update(backupRuns).set({ status: 'cancelled', completedAt: new Date() }).where(eq(backupRuns.id, run.id))
     await db.update(backupJobs).set({ lastRunStatus: 'cancelled' }).where(eq(backupJobs.id, jobId))
     revalidatePath(`/jobs/${jobId}`)
-    return
+    return { ok: true }
   }
 
   // Agent run: dispatch cancel and let the agent's backup_cancelled response update the DB
@@ -389,9 +390,18 @@ export async function cancelJob(jobId: string): Promise<void> {
       errorMessage: `cancel: agent unreachable (${result.reason ?? 'unknown'})`,
     }).where(eq(backupRuns.id, run.id))
     await db.update(backupJobs).set({ lastRunStatus: 'cancelled' }).where(eq(backupJobs.id, jobId))
+    revalidatePath(`/jobs/${jobId}`)
+    return { ok: true, error: 'Agent unreachable — run marked cancelled locally' }
   }
 
   revalidatePath(`/jobs/${jobId}`)
+  return { ok: true }
+}
+
+// Form-action wrapper — discards the return value so it can be used as
+// `<form action={cancelJobFormAction.bind(null, id)}>` in server components.
+export async function cancelJobFormAction(jobId: string): Promise<void> {
+  await cancelJob(jobId)
 }
 
 export async function saveJobRetention(id: string, formData: FormData): Promise<void> {

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -369,37 +369,7 @@ void app.prepare().then(async () => {
       return
     }
 
-    // Cancel a run by runId
-    const cancelRunMatch = parsed.pathname?.match(/^\/api\/runs\/([^/]+)\/cancel$/)
-    if (req.method === 'POST' && cancelRunMatch) {
-      void (async () => {
-        const session = await requireSession(req)
-        if (!session) {
-          res.writeHead(401, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ error: 'unauthorized' }))
-          return
-        }
-        const runId = cancelRunMatch[1]!
-        const db2   = getDb()
-        const [run] = await db2.select().from(backupRuns).where(eq(backupRuns.id, runId)).limit(1)
-        if (!run || run.status !== 'running') {
-          res.writeHead(200, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ ok: true, note: 'run not active' }))
-          return
-        }
-        if (run.agentId) {
-          const sent = dispatch(run.agentId, { type: 'cancel_backup', jobId: run.jobId!, runId: run.id })
-          if (!sent) {
-            await db2.update(backupRuns).set({ status: 'cancelled', completedAt: new Date(), errorMessage: 'cancel: agent unreachable' }).where(eq(backupRuns.id, runId))
-          }
-        } else {
-          await db2.update(backupRuns).set({ status: 'cancelled', completedAt: new Date() }).where(eq(backupRuns.id, runId))
-        }
-        res.writeHead(200, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ ok: true }))
-      })()
-      return
-    }
+
 
     // Repository init-state — used by agent to check/set initializedAt (Fix A)
     if (req.method === 'GET' && /^\/internal\/repository\/[^/]+\/state$/.test(parsed.pathname ?? '')) {


### PR DESCRIPTION
## Summary

Two parallel cancel implementations for backup runs existed, both unwired. Restore runs already had a working cancel flow. This brings backup-run cancel to parity.

## Changes

- **`server.ts`**: Delete the redundant `POST /api/runs/:id/cancel` HTTP handler — server actions are the canonical pattern
- **`actions/jobs.ts`**: Change `cancelJob` to return `{ ok: boolean; error?: string }` matching `cancelRestore`'s signature; add missing `requireAdmin()` gate; add `cancelJobFormAction` void wrapper for the existing form on the job-detail page
- **`CancelRunButton.tsx`** (new): Client component mirroring the restore version — confirm dialog, pending/success/error states, takes `jobId`
- **`jobs/[id]/runs/[runId]/page.tsx`**: Import and render `<CancelRunButton jobId={jobId} />` next to the status badge, gated on `run.status === 'running'`

## Notes

The button disappears automatically on the next `AutoRefresh` tick (3s) once the run is no longer `running`. A build-time type error from the existing form action was resolved by introducing `cancelJobFormAction` — the new `cancelJob` return type was incompatible with Next.js's `<form action>` constraint.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)