### PR TITLE
fix(pbs): store backup_runs.duration in milliseconds not seconds

### DIFF
--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -140,7 +140,7 @@ export const backupRuns = sqliteTable('backup_runs', {
   filesUnmodified: integer('files_unmodified'),
   dataAdded:       integer('data_added'),   // bytes
   totalSize:       integer('total_size'),   // bytes
-  duration:        integer('duration'),     // seconds
+  duration:        integer('duration'),     // milliseconds
 
   // Errors
   errorMessage: text('error_message'),

--- a/services/backupos-pbs/internal/jobsync/jobsync.go
+++ b/services/backupos-pbs/internal/jobsync/jobsync.go
@@ -103,13 +103,13 @@ func InsertRunningRun(db *sql.DB, jobID string, startedAt time.Time) (string, er
 // FinishRun marks a run as completed (success or failed) and updates the parent Job.
 // snapshotID, errorMessage, and totalSize may be nil for the unused branch.
 func FinishRun(db *sql.DB, runID, jobID, status string, snapshotID, errorMessage *string, totalSize *int64, startedAt, completedAt time.Time) error {
-	durationSec := int64(completedAt.Sub(startedAt).Seconds())
+	durationMs := completedAt.Sub(startedAt).Milliseconds()
 	const updateRun = `
 		UPDATE backup_runs
 		SET status = ?, completed_at = ?, duration = ?, total_size = ?, snapshot_id = ?, error_message = ?
 		WHERE id = ?
 	`
-	if _, err := db.Exec(updateRun, status, completedAt.UnixMilli(), durationSec,
+	if _, err := db.Exec(updateRun, status, completedAt.UnixMilli(), durationMs,
 		nullableInt64(totalSize),
 		nullableString(snapshotID), nullableString(errorMessage), runID); err != nil {
 		return fmt.Errorf("update run: %w", err)

--- a/services/backupos-pbs/internal/jobsync/jobsync_test.go
+++ b/services/backupos-pbs/internal/jobsync/jobsync_test.go
@@ -229,8 +229,8 @@ func TestFinishRun_DurationCalculation(t *testing.T) {
 
 	var duration int64
 	_ = db.QueryRow(`SELECT duration FROM backup_runs WHERE id = ?`, runID).Scan(&duration)
-	if duration != 90 {
-		t.Errorf("duration: got %d, want 90", duration)
+	if duration != 90000 {
+		t.Errorf("duration: got %d, want 90000", duration)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `FinishRun` was calling `.Seconds()` and casting to `int64`, writing seconds into `backup_runs.duration`
- Every other writer in the codebase (server.ts, alerts.ts) and every UI `fmtDuration` call treats this column as milliseconds
- Switches to `.Milliseconds()` so PBS-synced runs display correct durations

## Changes
- `services/backupos-pbs/internal/jobsync/jobsync.go`: `durationSec` → `durationMs`, `.Seconds()` → `.Milliseconds()`
- `packages/db/src/schema.ts`: comment `// seconds` → `// milliseconds`
- `services/backupos-pbs/internal/jobsync/jobsync_test.go`: assert `90000` instead of `90`

## Test plan
- [ ] `go test ./internal/jobsync/...` passes
- [ ] PBS backup run duration shows correctly in the UI (e.g. a 90s run shows ~1m 30s, not ~25h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)