### PR TITLE
feat(restore): populate stats from restic output

### DIFF
--- a/packages/agent/src/handlers/composeRestore.ts
+++ b/packages/agent/src/handlers/composeRestore.ts
@@ -36,6 +36,7 @@ export async function runComposeRestore(
 
   const logLines: string[] = []
   const tmpDir = path.join(os.tmpdir(), 'backupos-restore', jobId)
+  const restoreStats = { filesRestored: 0, bytesRestored: 0, durationMs: 0 }
 
   const setPhase = (phase: string): void => {
     const j = activeJobs.get(jobId)
@@ -102,7 +103,10 @@ export async function runComposeRestore(
         const sourcePath = `/var/lib/docker/volumes/${origVolName}/_data`
 
         if (mode === 'in_place') {
-          await makeEngine().restore(snapshotId, '/', [sourcePath], ctrl.signal)
+          const r = await makeEngine().restore(snapshotId, '/', [sourcePath], ctrl.signal)
+          restoreStats.filesRestored += r.filesRestored
+          restoreStats.bytesRestored += r.totalSize
+          restoreStats.durationMs    += r.durationMs
           logLines.push(`[restore] restored "${service.serviceName}" vol ${origVolName} (in-place)`)
         } else {
           // side_by_side: restore to tmpDir, create new volume, copy contents
@@ -118,7 +122,10 @@ export async function runComposeRestore(
 
           await spawnAllowed('docker', ['volume', 'create', newVolName])
 
-          await makeEngine().restore(snapshotId, tmpDir, [sourcePath], ctrl.signal)
+          const r = await makeEngine().restore(snapshotId, tmpDir, [sourcePath], ctrl.signal)
+          restoreStats.filesRestored += r.filesRestored
+          restoreStats.bytesRestored += r.totalSize
+          restoreStats.durationMs    += r.durationMs
 
           // tmpDir/<sourcePath> contains the restored files
           const restoreDest = path.join(tmpDir, 'var', 'lib', 'docker', 'volumes', origVolName, '_data')
@@ -133,7 +140,10 @@ export async function runComposeRestore(
     // Optional compose file restore
     if (composeFileSnapshotId && composeConfig.composeFilePath) {
       if (mode === 'in_place') {
-        await makeEngine().restore(composeFileSnapshotId, '/', [composeConfig.composeFilePath], ctrl.signal)
+        const r = await makeEngine().restore(composeFileSnapshotId, '/', [composeConfig.composeFilePath], ctrl.signal)
+        restoreStats.filesRestored += r.filesRestored
+        restoreStats.bytesRestored += r.totalSize
+        restoreStats.durationMs    += r.durationMs
         logLines.push(`[restore] restored compose file to ${composeConfig.composeFilePath}`)
       } else {
         logLines.push(`[restore] NOTE: compose file restore skipped for side-by-side mode — original file unchanged`)
@@ -166,9 +176,9 @@ export async function runComposeRestore(
         filesChanged:        0,
         filesUnmodified:     0,
         dataAdded:           0,
-        totalFilesProcessed: 0,
-        totalBytesProcessed: 0,
-        durationMs:          0,
+        totalFilesProcessed: restoreStats.filesRestored,
+        totalBytesProcessed: restoreStats.bytesRestored,
+        durationMs:          restoreStats.durationMs,
       },
       log: logLines.join('\n').slice(0, 1_000_000) || undefined,
     })

--- a/packages/agent/src/handlers/filesystemRestore.ts
+++ b/packages/agent/src/handlers/filesystemRestore.ts
@@ -39,13 +39,13 @@ export async function handleFilesystemRestore(
     })
     const shortId = snapshotId.slice(0, 8)
     const result = await engine.restore(shortId, prefixedTargetPath, [prefixedSourcePath], ctrl.signal)
-    console.log(`[agent] engine.restore returned: filesRestored=${result.filesRestored} duration=${result.duration} totalSize=${result.totalSize}`)
+    console.log(`[agent] engine.restore returned: filesRestored=${result.filesRestored} durationMs=${result.durationMs} totalSize=${result.totalSize}`)
     send({
       type:          'filesystem_restore_complete',
       restoreId,
       success:       true,
       filesRestored: result.filesRestored,
-      durationSec:   result.duration,
+      durationSec:   Math.round(result.durationMs / 1000),
       targetPath,
       sourcePath,
     })

--- a/packages/engine/src/restic.ts
+++ b/packages/engine/src/restic.ts
@@ -229,7 +229,7 @@ export class ResticEngine {
     return {
       filesRestored,
       totalSize,
-      duration: Math.round((Date.now() - before) / 1000),
+      durationMs: Date.now() - before,
     }
   }
 

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -83,7 +83,7 @@ export interface ForgetResult {
 export interface RestoreResult {
   filesRestored: number
   totalSize: number   // bytes
-  duration: number    // seconds
+  durationMs: number  // milliseconds
 }
 
 export interface RepoStats {


### PR DESCRIPTION
Closes #30

## Summary
- `runComposeRestore` was sending `backup_complete` with all stats zeroed — `ResticEngine.restore()` already parsed restic's JSON summary but the return value wasn't captured
- Renamed `RestoreResult.duration` → `durationMs` to match codebase convention (#298)
- Aggregated `filesRestored`, `bytesRestored`, `durationMs` across all three `restore()` call sites in `composeRestore.ts`
- Updated `filesystemRestore.ts` to read `durationMs` (converts to seconds for the `durationSec` wire field)

## Changes
- `packages/engine/src/types.ts`: `RestoreResult.duration: number // seconds` → `durationMs: number // milliseconds`
- `packages/engine/src/restic.ts`: return `durationMs: Date.now() - before` (remove `/1000`)
- `packages/agent/src/handlers/composeRestore.ts`: add `restoreStats` aggregator, capture all 3 `restore()` returns, populate `totalFilesProcessed`/`totalBytesProcessed`/`durationMs`
- `packages/agent/src/handlers/filesystemRestore.ts`: `result.duration` → `Math.round(result.durationMs / 1000)` for `durationSec`

## Test plan
- [ ] `grep -A 3 "interface RestoreResult" packages/engine/src/types.ts` shows `durationMs`
- [ ] `grep "durationMs" packages/engine/src/restic.ts` shows no `/1000`
- [ ] `grep "restoreStats\." packages/agent/src/handlers/composeRestore.ts` shows declaration + 9 aggregation lines + 3 stats uses
- [ ] Smoke: complete a compose restore, confirm run-detail shows non-zero Files Processed, Total Bytes, Duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)