### PR TITLE
feat(error-pages): restore branded not-found.tsx

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link'
+import { LogoMark } from '@/components/ui/logo-mark'
+
+export default function NotFound() {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: 'var(--bg)',
+        color: 'var(--fg)',
+        fontFamily: 'var(--font-sans)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 'var(--space-6)',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 480,
+          background: 'var(--surf)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius)',
+          padding: 'var(--space-8)',
+          boxShadow: 'var(--shadow)',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)', marginBottom: 'var(--space-6)' }}>
+          <LogoMark size={40} />
+          <span style={{ fontSize: 16, fontWeight: 600, color: 'var(--fg)' }}>BackupOS</span>
+        </div>
+
+        <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginBottom: 'var(--space-3)' }}>
+          Page not found
+        </h1>
+
+        <p style={{ fontSize: 14, color: 'var(--fg-mute)', lineHeight: 1.5, marginBottom: 'var(--space-6)' }}>
+          The page you were looking for does not exist or has been moved.
+        </p>
+
+        <Link
+          href="/"
+          style={{
+            background: 'var(--accent)',
+            color: 'var(--accent-fg)',
+            border: 'none',
+            borderRadius: 'var(--radius-sm)',
+            padding: '10px 16px',
+            fontSize: 14,
+            fontWeight: 500,
+            textDecoration: 'none',
+            display: 'inline-flex',
+            alignItems: 'center',
+          }}
+        >
+          Go to dashboard
+        </Link>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #192

## Summary
- PR #190 removed `apps/web/app/not-found.tsx` due to a Next.js 15.5 bug (vercel/next.js#82229) causing `InvariantError: Expected clientReferenceManifest` at runtime when `not-found.tsx` coexisted with route groups
- Empirical build test on 2026-05-05 with Next.js 15.5.15 shows the file bundles cleanly to `/_not-found` (243 B) with no `InvariantError` in output
- Restores the original file verbatim from PR #189 commit `1900594`

## Changes
- `apps/web/app/not-found.tsx`: restored (1822 bytes, uses `LogoMark`, design system tokens)

## Test plan
- [ ] `grep -c "LogoMark\|Page not found" apps/web/app/not-found.tsx` returns 2
- [ ] `pnpm --filter @backupos/web build` exits cleanly, no `InvariantError`
- [ ] Navigate to `/this-does-not-exist` — branded 404 renders
- [ ] Navigate back to `/dashboard` — sibling routes still work
- [ ] Hard-reload `/jobs` — no `InvariantError` in `journalctl -u backupos`

**If runtime `InvariantError` reappears**: revert this commit, redeploy, reopen #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)