### PR TITLE
feat(dr-mode): database wizard executes via snapshot-path lookup + two-stage restore

### DIFF
--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -3,12 +3,13 @@
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, backupJobs, alertChannels, eq, desc } from '@backupos/db'
+import type { ComposeProjectConfig } from '@backupos/agent-protocol'
 import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult, type NotifyDelivery, type DatabaseRestoreDelivery } from '@backupos/restore'
 import { requireAdmin } from '@/lib/user'
 import { dispatchToChannel, fireRestoreSucceeded, fireRestoreFailed } from '@/lib/alerts'
 import type { AlertType, AlertPayload } from '@/lib/alerts'
 import { decryptField } from '@/lib/repo-crypto'
-import { connectedAgentIds, requestFilesystemRestore, requestDatabaseRestore, dispatch } from '@/lib/ws-state'
+import { connectedAgentIds, requestFilesystemRestore, requestDatabaseRestore, requestSnapshotPaths, dispatch } from '@/lib/ws-state'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 import { appendLog } from '@/lib/logger'
 
@@ -370,6 +371,191 @@ export async function getLatestSnapshotForJob(
   }
 
   return { ok: true, snapshotId: latest.id, createdAt: latest.createdAt }
+}
+
+export interface ApphookService {
+  serviceName: string
+  apphookType: 'postgres' | 'mysql' | 'redis' | 'sqlite'
+  apphookConfig: NonNullable<import('@backupos/agent-protocol').ComposeServiceConfig['apphookConfig']>
+}
+
+export async function getApphookServicesForJob(
+  jobId: string,
+): Promise<{ ok: true; services: ApphookService[] } | { ok: false; error: string }> {
+  await requireAdmin()
+  const db = getDb()
+  const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, jobId)).limit(1)
+  if (!job) return { ok: false, error: 'Job not found' }
+
+  let config: ComposeProjectConfig
+  try {
+    config = JSON.parse(job.sourceConfig) as ComposeProjectConfig
+  } catch {
+    return { ok: false, error: 'Job source config is not valid JSON' }
+  }
+
+  if (!config.services) return { ok: false, error: 'Job has no compose services' }
+
+  const apphookServices: ApphookService[] = config.services
+    .filter(s => s.quiescence === 'apphook' && s.apphookType && s.apphookConfig)
+    .map(s => ({
+      serviceName:  s.serviceName,
+      apphookType:  s.apphookType!,
+      apphookConfig: s.apphookConfig!,
+    }))
+
+  return { ok: true, services: apphookServices }
+}
+
+export async function findDumpInSnapshot(
+  agentId: string,
+  snapshotId: string,
+  repositoryId: string,
+  serviceName: string,
+): Promise<{ ok: true; dumpPath: string } | { ok: false; error: string }> {
+  await requireAdmin()
+  const db = getDb()
+
+  const [repo] = await db.select().from(repositories).where(eq(repositories.id, repositoryId)).limit(1)
+  if (!repo) return { ok: false, error: 'Repository not found' }
+
+  let repoConfig: RepoConfigShape
+  try {
+    repoConfig = JSON.parse(decryptField(repo.config)) as RepoConfigShape
+  } catch (err) {
+    return { ok: false, error: `Failed to decrypt repository config: ${err instanceof Error ? err.message : String(err)}` }
+  }
+  const password = decryptField(repo.resticPassword)
+
+  const result = await requestSnapshotPaths(agentId, {
+    repoUrl:      repoConfig.repositoryUrl,
+    repoPassword: password,
+    envVars:      repoConfig.envVars,
+    snapshotId,
+    pattern:      `${serviceName}.dump`,
+  })
+
+  if (!result.ok) return { ok: false, error: result.error ?? 'list_snapshot_paths failed' }
+  if (!result.paths || result.paths.length === 0) {
+    return { ok: false, error: `No dump file found for service "${serviceName}" in snapshot` }
+  }
+
+  return { ok: true, dumpPath: result.paths[0]! }
+}
+
+async function waitForRestoreRun(
+  runId: string,
+  timeoutMs = 60_000,
+): Promise<{ ok: boolean; error?: string }> {
+  const db = getDb()
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 1_500))
+    const [run] = await db.select({ status: restoreRuns.status }).from(restoreRuns).where(eq(restoreRuns.id, runId)).limit(1)
+    if (!run) return { ok: false, error: 'Restore run disappeared from DB' }
+    if (run.status === 'success') return { ok: true }
+    if (run.status === 'failed') return { ok: false, error: 'Filesystem restore failed' }
+  }
+  return { ok: false, error: 'Timed out waiting for filesystem restore to complete' }
+}
+
+export async function triggerDatabaseRestore(
+  jobId: string,
+  serviceName: string,
+  targetDatabase: string,
+): Promise<{ ok: true; restoreId: string } | { ok: false; error: string }> {
+  await requireAdmin()
+  const db = getDb()
+
+  // 1. Look up the job to get the agent and apphook config
+  const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, jobId)).limit(1)
+  if (!job) return { ok: false, error: 'Job not found' }
+  if (!job.agentId) return { ok: false, error: 'Job has no agent assigned' }
+  if (!connectedAgentIds().includes(job.agentId)) {
+    return { ok: false, error: `Agent ${job.agentId} is not currently connected` }
+  }
+
+  const agentId = job.agentId
+
+  let composeConfig: ComposeProjectConfig
+  try {
+    composeConfig = JSON.parse(job.sourceConfig) as ComposeProjectConfig
+  } catch {
+    return { ok: false, error: 'Job source config is not valid JSON' }
+  }
+
+  const serviceConfig = composeConfig.services.find(s => s.serviceName === serviceName)
+  if (!serviceConfig) return { ok: false, error: `Service "${serviceName}" not found in job config` }
+  if (!serviceConfig.apphookType || !serviceConfig.apphookConfig) {
+    return { ok: false, error: `Service "${serviceName}" has no apphook configuration` }
+  }
+
+  // 2. Find the latest snapshot for this job
+  const snapshotResult = await getLatestSnapshotForJob(jobId)
+  if (!snapshotResult.ok) return { ok: false, error: snapshotResult.error }
+
+  const [snap] = await db.select().from(snapshots).where(eq(snapshots.id, snapshotResult.snapshotId)).limit(1)
+  if (!snap || !snap.repositoryId) return { ok: false, error: 'Snapshot has no associated repository' }
+
+  // 3. Locate the dump file in the snapshot
+  const dumpResult = await findDumpInSnapshot(agentId, snapshotResult.snapshotId, snap.repositoryId, serviceName)
+  if (!dumpResult.ok) return { ok: false, error: dumpResult.error }
+
+  // 4. Restore the dump file from snapshot to agent-local temp dir
+  const tempRoot = `/tmp/backupos-dbr-${crypto.randomUUID().slice(0, 8)}`
+  const fsRestoreResult = await restoreFromSnapshot({
+    snapshotId: snapshotResult.snapshotId,
+    sourcePath: dumpResult.dumpPath,
+    targetType: 'custom',
+    customPath: tempRoot,
+  })
+  if (!fsRestoreResult.ok) return { ok: false, error: fsRestoreResult.error }
+
+  // 5. Wait for the filesystem restore to complete
+  const waitResult = await waitForRestoreRun(fsRestoreResult.runId)
+  if (!waitResult.ok) return { ok: false, error: waitResult.error ?? 'Filesystem restore did not complete' }
+
+  // 6. Dispatch run_database_restore
+  const dumpFilePath = `${tempRoot}${dumpResult.dumpPath}`
+  const apphook = serviceConfig.apphookConfig
+  const app = serviceConfig.apphookType
+
+  if (app !== 'postgres' && app !== 'mysql' && app !== 'mariadb') {
+    return { ok: false, error: `Unsupported database type for DR restore: ${app}` }
+  }
+
+  const dbRestoreId = crypto.randomUUID()
+
+  await db.insert(restoreRuns).values({
+    id:        dbRestoreId,
+    specId:    null,
+    snapshotId: snapshotResult.snapshotId,
+    status:    'running',
+    trigger:   'manual',
+    startedAt: new Date(),
+  })
+
+  const requestId = crypto.randomUUID()
+  const sent = dispatch(agentId, {
+    type:            'run_database_restore',
+    requestId,
+    restoreId:       dbRestoreId,
+    app,
+    dumpFilePath,
+    targetContainer: serviceName,
+    targetDatabase:  targetDatabase || apphook.database,
+    targetUsername:  apphook.username,
+    targetHost:      apphook.host,
+    targetPort:      apphook.port,
+    passwordEnv:     apphook.passwordEnv,
+  })
+
+  if (!sent) {
+    await db.update(restoreRuns).set({ status: 'failed', completedAt: new Date() }).where(eq(restoreRuns.id, dbRestoreId))
+    return { ok: false, error: 'Agent disconnected before database restore could be dispatched' }
+  }
+
+  return { ok: true, restoreId: dbRestoreId }
 }
 
 export async function cancelRestore(restoreId: string): Promise<{ ok: boolean; error?: string }> {

--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -520,10 +520,6 @@ export async function triggerDatabaseRestore(
   const apphook = serviceConfig.apphookConfig
   const app = serviceConfig.apphookType
 
-  if (app !== 'postgres' && app !== 'mysql' && app !== 'mariadb') {
-    return { ok: false, error: `Unsupported database type for DR restore: ${app}` }
-  }
-
   const dbRestoreId = crypto.randomUUID()
 
   await db.insert(restoreRuns).values({
@@ -548,6 +544,7 @@ export async function triggerDatabaseRestore(
     targetHost:      apphook.host,
     targetPort:      apphook.port,
     passwordEnv:     apphook.passwordEnv,
+    targetDbPath:    apphook.dbPath,
   })
 
   if (!sent) {

--- a/apps/web/components/dr/restore-database-wizard.tsx
+++ b/apps/web/components/dr/restore-database-wizard.tsx
@@ -1,10 +1,12 @@
 // apps/web/components/dr/restore-database-wizard.tsx
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { CheckCircle, AlertTriangle } from 'lucide-react'
 import { logDrAction } from '@/app/actions/dr-audit'
 import { StepIndicator, WizardCard, WizardNav, escHtml } from '@/components/dr/restore-file-wizard'
+import { getApphookServicesForJob, triggerDatabaseRestore, getLatestSnapshotForJob } from '@/app/actions/restore'
+import type { ApphookService } from '@/app/actions/restore'
 
 interface Props {
   jobs: { id: string; name: string }[]
@@ -12,16 +14,58 @@ interface Props {
 }
 
 export function RestoreDatabaseWizard({ jobs, onDone }: Props) {
-  const [step, setStep]             = useState(0)
-  const [jobId, setJobId]           = useState('')
-  const [dbName, setDbName]         = useState('')
-  const [dryRunOk, setDryRunOk]     = useState(false)
-  const [submitting, setSubmitting] = useState(false)
-  const [done, setDone]             = useState(false)
+  const [step, setStep]                     = useState(0)
+  const [jobId, setJobId]                   = useState('')
+  const [serviceName, setServiceName]       = useState('')
+  const [services, setServices]             = useState<ApphookService[]>([])
+  const [loadingServices, setLoadingServices] = useState(false)
+  const [dbName, setDbName]                 = useState('')
+  const [dryRunOk, setDryRunOk]             = useState(false)
+  const [submitting, setSubmitting]         = useState(false)
+  const [done, setDone]                     = useState(false)
+  const [error, setError]                   = useState<string | null>(null)
+  const [latestSnapshot, setLatestSnapshot] = useState<{ snapshotId: string; createdAt: Date | null } | null>(null)
+  const [loadingSnapshot, setLoadingSnapshot] = useState(false)
+
+  useEffect(() => {
+    if (!jobId) { setServices([]); setServiceName(''); setDbName(''); return }
+    setLoadingServices(true)
+    setError(null)
+    getApphookServicesForJob(jobId).then(result => {
+      setLoadingServices(false)
+      if (!result.ok) { setError(result.error); setServices([]); return }
+      setServices(result.services)
+      if (result.services.length === 1) {
+        const svc = result.services[0]!
+        setServiceName(svc.serviceName)
+        setDbName(svc.apphookConfig.database ?? '')
+      } else {
+        setServiceName('')
+        setDbName('')
+      }
+    }).catch(err => { setLoadingServices(false); setError(String(err)) })
+  }, [jobId])
+
+  useEffect(() => {
+    if (step !== 2 || !jobId) return
+    setLoadingSnapshot(true)
+    getLatestSnapshotForJob(jobId).then(result => {
+      setLoadingSnapshot(false)
+      if (result.ok) setLatestSnapshot({ snapshotId: result.snapshotId, createdAt: result.createdAt })
+      else setLatestSnapshot(null)
+    }).catch(() => { setLoadingSnapshot(false); setLatestSnapshot(null) })
+  }, [step, jobId])
 
   async function execute() {
     setSubmitting(true)
-    await logDrAction({ action: 'restore_database', jobId, target: dbName, dryRun: false })
+    setError(null)
+    const result = await triggerDatabaseRestore(jobId, serviceName, dbName)
+    if (!result.ok) {
+      setError(result.error)
+      setSubmitting(false)
+      return
+    }
+    await logDrAction({ action: 'restore_database', jobId, target: dbName, dryRun: false, metadata: { restoreId: result.restoreId, serviceName, dbName } })
     setSubmitting(false)
     setDone(true)
   }
@@ -109,20 +153,47 @@ export function RestoreDatabaseWizard({ jobs, onDone }: Props) {
 
   return (
     <div style={{ maxWidth: 540, width: '100%' }}>
-      <StepIndicator current={step} labels={['Job', 'Database', 'Dry run', 'Execute']} />
+      <StepIndicator current={step} labels={['Job', 'Service', 'Database', 'Dry run', 'Execute']} />
+
+      {error && (
+        <div style={{ backgroundColor: 'var(--err-dim)', border: '1px solid color-mix(in srgb, var(--err) 25%, transparent)', borderRadius: 'var(--radius-sm)', padding: '10px 14px', marginBottom: 12, fontSize: 13, color: 'var(--err)' }}>
+          {error}
+        </div>
+      )}
 
       {step === 0 && (
         <WizardCard title="Which job contains the database backup?">
           <label style={labelStyle}>Backup job</label>
-          <select value={jobId} onChange={e => setJobId(e.target.value)} style={inputStyle}>
+          <select value={jobId} onChange={e => { setJobId(e.target.value); setError(null) }} style={inputStyle}>
             <option value="">— Select a job —</option>
             {jobs.map(j => <option key={j.id} value={j.id}>{j.name}</option>)}
           </select>
-          <WizardNav onBack={onDone} backLabel="Cancel" onNext={() => setStep(1)} nextDisabled={!jobId} />
+          <WizardNav onBack={onDone} backLabel="Cancel" onNext={() => setStep(1)} nextDisabled={!jobId || loadingServices} />
         </WizardCard>
       )}
 
       {step === 1 && (
+        <WizardCard title="Which service database needs to be restored?">
+          <label style={labelStyle}>Service</label>
+          {loadingServices ? (
+            <div style={{ fontSize: 13, color: 'var(--fg-mute)', padding: '8px 0' }}>Loading services…</div>
+          ) : services.length === 0 ? (
+            <div style={{ fontSize: 13, color: 'var(--fg-mute)', padding: '8px 0' }}>No apphook services found for this job.</div>
+          ) : (
+            <select value={serviceName} onChange={e => {
+              const svc = services.find(s => s.serviceName === e.target.value)
+              setServiceName(e.target.value)
+              setDbName(svc?.apphookConfig.database ?? '')
+            }} style={inputStyle}>
+              <option value="">— Select a service —</option>
+              {services.map(s => <option key={s.serviceName} value={s.serviceName}>{s.serviceName} ({s.apphookType})</option>)}
+            </select>
+          )}
+          <WizardNav onBack={() => setStep(0)} onNext={() => setStep(2)} nextDisabled={!serviceName} />
+        </WizardCard>
+      )}
+
+      {step === 2 && (
         <WizardCard title="Which database needs to be restored?">
           <label style={labelStyle}>Database name</label>
           <input
@@ -133,13 +204,13 @@ export function RestoreDatabaseWizard({ jobs, onDone }: Props) {
             style={inputStyle}
           />
           <div style={{ fontSize: 12, color: 'var(--fg-dim)', marginTop: 6 }}>
-            Must match the database name used in the backup job configuration.
+            Auto-filled from apphook config. Edit if you need to restore to a different database name.
           </div>
-          <WizardNav onBack={() => setStep(0)} onNext={() => setStep(2)} nextDisabled={!dbName.trim()} />
+          <WizardNav onBack={() => setStep(1)} onNext={() => setStep(3)} nextDisabled={!dbName.trim()} />
         </WizardCard>
       )}
 
-      {step === 2 && (
+      {step === 3 && (
         <WizardCard title="What will this touch?">
           <div style={{
             backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
@@ -148,11 +219,16 @@ export function RestoreDatabaseWizard({ jobs, onDone }: Props) {
           }}>
             <div style={{ color: 'var(--ok)', marginBottom: 4 }}>DRY RUN — no data will be written</div>
             <div>Job: <span style={{ color: 'var(--fg)' }}>{selectedJob?.name}</span></div>
+            <div>Service: <span style={{ color: 'var(--fg)' }}>{serviceName}</span></div>
             <div>Database: <span style={{ color: 'var(--fg)' }}>{dbName}</span></div>
-            <div style={{ marginTop: 8, color: 'var(--fg-dim)' }}>Snapshot: most recent successful</div>
-            <div style={{ marginTop: 4 }}>Dump size: ~420 MB (estimated)</div>
+            <div style={{ marginTop: 8, color: 'var(--fg-dim)' }}>
+              Snapshot: {loadingSnapshot ? 'loading…' : latestSnapshot ? (latestSnapshot.createdAt ? new Date(latestSnapshot.createdAt).toLocaleString() : latestSnapshot.snapshotId.slice(0, 8)) : 'most recent successful'}
+            </div>
+            {latestSnapshot && (
+              <div style={{ marginTop: 2, color: 'var(--fg-dim)' }}>Snapshot ID: <span style={{ color: 'var(--fg)' }}>{latestSnapshot.snapshotId.slice(0, 12)}</span></div>
+            )}
             <div style={{ marginTop: 8, color: 'var(--warn)' }}>
-              ⚠ The existing database will be dropped and recreated. Use a staging target first.
+              Warning: The existing database will be dropped and recreated. Use a staging target first.
             </div>
           </div>
           <label style={{ display: 'flex', alignItems: 'flex-start', gap: 8, cursor: 'pointer' }}>
@@ -161,11 +237,11 @@ export function RestoreDatabaseWizard({ jobs, onDone }: Props) {
               I have reviewed the dry-run output and understand what will be restored.
             </span>
           </label>
-          <WizardNav onBack={() => setStep(1)} onNext={() => setStep(3)} nextDisabled={!dryRunOk} nextLabel="Confirm and continue" />
+          <WizardNav onBack={() => setStep(2)} onNext={() => setStep(4)} nextDisabled={!dryRunOk} nextLabel="Confirm and continue" />
         </WizardCard>
       )}
 
-      {step === 3 && (
+      {step === 4 && (
         <WizardCard title="Ready to restore">
           <div style={{
             backgroundColor: 'var(--err-dim)',
@@ -174,7 +250,11 @@ export function RestoreDatabaseWizard({ jobs, onDone }: Props) {
           }}>
             <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)', marginBottom: 4 }}>Restore summary</div>
             <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>Job: {selectedJob?.name}</div>
+            <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>Service: {serviceName}</div>
             <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>Database: {dbName}</div>
+            {latestSnapshot && (
+              <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>Snapshot: {latestSnapshot.snapshotId.slice(0, 12)} ({latestSnapshot.createdAt ? new Date(latestSnapshot.createdAt).toLocaleString() : 'unknown date'})</div>
+            )}
           </div>
           <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: 20 }}>
             <AlertTriangle size={14} color="var(--warn)" style={{ flexShrink: 0, marginTop: 2 }} />
@@ -183,7 +263,7 @@ export function RestoreDatabaseWizard({ jobs, onDone }: Props) {
             </span>
           </div>
           <div style={{ display: 'flex', gap: 10 }}>
-            <button onClick={() => setStep(2)} style={{ padding: '8px 16px', fontSize: 13, cursor: 'pointer', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'none', color: 'var(--fg)' }}>Back</button>
+            <button onClick={() => setStep(3)} style={{ padding: '8px 16px', fontSize: 13, cursor: 'pointer', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'none', color: 'var(--fg)' }}>Back</button>
             <button
               onClick={execute}
               disabled={submitting}

--- a/apps/web/lib/ws-state.ts
+++ b/apps/web/lib/ws-state.ts
@@ -337,3 +337,44 @@ export function resolveDatabaseRestoreStarted(requestId: string): void {
 export function resolveDatabaseRestoreComplete(restoreId: string, result: DbRestoreResult): void {
   pendingDbRestoreComplete.get(restoreId)?.(result)
 }
+
+const pendingSnapshotPaths = new Map<string, (result: { ok: boolean; paths?: string[]; error?: string }) => void>()
+
+export function requestSnapshotPaths(
+  agentId: string,
+  args: { repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; pattern?: string },
+): Promise<{ ok: boolean; paths?: string[]; error?: string }> {
+  return new Promise((resolve, reject) => {
+    const requestId = crypto.randomUUID()
+    const timer = setTimeout(() => {
+      pendingSnapshotPaths.delete(requestId)
+      reject(new Error('Agent did not respond in time (60s) for list_snapshot_paths'))
+    }, 60_000)
+    pendingSnapshotPaths.set(requestId, (result) => {
+      clearTimeout(timer)
+      pendingSnapshotPaths.delete(requestId)
+      resolve(result)
+    })
+    const sent = dispatch(agentId, {
+      type:         'list_snapshot_paths',
+      requestId,
+      repoUrl:      args.repoUrl,
+      repoPassword: args.repoPassword,
+      envVars:      args.envVars,
+      snapshotId:   args.snapshotId,
+      pattern:      args.pattern,
+    })
+    if (!sent) {
+      clearTimeout(timer)
+      pendingSnapshotPaths.delete(requestId)
+      reject(new Error('Agent not connected'))
+    }
+  })
+}
+
+export function resolveSnapshotPaths(
+  requestId: string,
+  result: { ok: boolean; paths?: string[]; error?: string },
+): void {
+  pendingSnapshotPaths.get(requestId)?.(result)
+}

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -10,7 +10,7 @@ import type { WebSocket } from 'ws'
 import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, verificationRuns, verificationTests, snapshots, eq, and, desc } from '@backupos/db'
 import { ResticEngine } from '@backupos/engine'
 import { parseExpression } from 'cron-parser'
-import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, requestInitRepository, resolveInitRepository, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository, resolveFilesystemRestoreStarted, resolveDatabaseRestoreStarted, resolveDatabaseRestoreComplete } from './lib/ws-state'
+import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, requestInitRepository, resolveInitRepository, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository, resolveFilesystemRestoreStarted, resolveDatabaseRestoreStarted, resolveDatabaseRestoreComplete, resolveSnapshotPaths } from './lib/ws-state'
 import { ensureRepoMountedOnAgent } from './lib/repo-mount'
 import { loadOrCreateInternalToken } from './lib/internal-token'
 import { decryptField } from './lib/repo-crypto'
@@ -819,6 +819,9 @@ void app.prepare().then(async () => {
             error:       msg.error,
             durationSec: msg.durationSec,
           })
+
+        } else if (msg.type === 'list_snapshot_paths_result') {
+          resolveSnapshotPaths(msg.requestId, { ok: msg.ok, paths: msg.paths, error: msg.error })
 
         } else if (msg.type === 'filesystem_restore_started' && agentId) {
           console.log(`[restore] filesystem_restore_started restoreId=${msg.restoreId} agentId=${agentId}`)

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -165,6 +165,7 @@ export type AgentMessage =
   | { type: 'filesystem_restore_cancelled'; restoreId: string; reason: 'user_requested' | 'not_running' }
   | { type: 'database_restore_started'; requestId: string; restoreId: string }
   | { type: 'database_restore_complete'; restoreId: string; success: boolean; output?: string; error?: string; durationSec?: number }
+  | { type: 'list_snapshot_paths_result'; requestId: string; ok: boolean; paths?: string[]; error?: string }
 
 export interface DetectedResources {
   dockerVolumes?: string[]
@@ -192,3 +193,4 @@ export type ServerMessage =
   | { type: 'run_filesystem_restore'; requestId: string; restoreId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; targetPath: string; sourcePath: string; targetIsAgentLocal: boolean }
   | { type: 'cancel_filesystem_restore'; restoreId: string }
   | { type: 'run_database_restore'; requestId: string; restoreId: string; app: 'postgres' | 'mysql' | 'mariadb' | 'sqlite' | 'redis'; dumpFilePath: string; targetContainer?: string; targetDatabase?: string; targetUsername?: string; targetHost?: string; targetPort?: number; passwordEnv?: string; targetDbPath?: string }
+  | { type: 'list_snapshot_paths'; requestId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; pattern?: string }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -14,6 +14,7 @@ import { runInitRepository } from './handlers/initRepository'
 import { runTestMount } from './handlers/testMount'
 import { handleFilesystemRestore } from './handlers/filesystemRestore'
 import { handleDatabaseRestore } from './handlers/databaseRestore'
+import { handleListSnapshotPaths } from './handlers/listSnapshotPaths'
 
 function requireEnv(name: string): string {
   const v = process.env[name]
@@ -273,6 +274,9 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
       restore.ctrl.abort()
       send({ type: 'filesystem_restore_cancelled', restoreId: msg.restoreId, reason: 'user_requested' })
     }
+
+  } else if (msg.type === 'list_snapshot_paths') {
+    void handleListSnapshotPaths(msg, send)
 
   } else if (msg.type === 'run_database_restore') {
     void handleDatabaseRestore(msg, send)

--- a/packages/agent/src/handlers/listSnapshotPaths.ts
+++ b/packages/agent/src/handlers/listSnapshotPaths.ts
@@ -1,0 +1,38 @@
+import { ResticEngine } from '@backupos/engine'
+import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
+
+type SendFn = (msg: AgentMessage) => void
+type RequestMsg = Extract<ServerMessage, { type: 'list_snapshot_paths' }>
+
+export async function handleListSnapshotPaths(
+  msg: RequestMsg,
+  send: SendFn,
+): Promise<void> {
+  const { requestId, repoUrl, repoPassword, envVars, snapshotId, pattern } = msg
+
+  console.log(`[agent] list_snapshot_paths received: snapshotId=${snapshotId} pattern=${pattern ?? '(none)'}`)
+
+  try {
+    const engine = new ResticEngine({
+      repositoryUrl: repoUrl,
+      password:      repoPassword,
+      envVars:       envVars ?? {},
+    })
+
+    const files = await engine.ls(snapshotId)
+
+    let paths: string[] = files
+      .filter(f => f.type === 'file')
+      .map(f => f.path)
+
+    if (pattern && pattern.length > 0) {
+      paths = paths.filter(p => p.includes(pattern))
+    }
+
+    send({ type: 'list_snapshot_paths_result', requestId, ok: true, paths })
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    console.error(`[agent] list_snapshot_paths failed: ${error}`)
+    send({ type: 'list_snapshot_paths_result', requestId, ok: false, error })
+  }
+}


### PR DESCRIPTION
## Summary
- DR Mode database wizard was a no-op; wires full two-stage pipeline
- New `list_snapshot_paths` agent message + handler to locate dump files inside snapshots
- `requestSnapshotPaths`/`resolveSnapshotPaths` server-side waiter pattern (mirrors pendingDetects)
- `triggerDatabaseRestore`: find snapshot → locate dump → fs-restore to temp → wait → dispatch run_database_restore
- `getApphookServicesForJob`: wizard service picker
- Wizard: service picker step, auto-fill dbName, snapshot preview on confirmation

## Review checklist
- [ ] list_snapshot_paths request + result in agent-protocol
- [ ] handleListSnapshotPaths agent handler
- [ ] Agent router wires new handler
- [ ] pendingSnapshotPaths/requestSnapshotPaths/resolveSnapshotPaths in ws-state
- [ ] server.ts routes list_snapshot_paths_result
- [ ] findDumpInSnapshot, triggerDatabaseRestore, getApphookServicesForJob server actions
- [ ] waitForRestoreRun helper
- [ ] Wizard service picker, auto-fill, snapshot preview, real execute()

🤖 Generated with [Claude Code](https://claude.com/claude-code)