### PR TITLE
feat(dr-mode): host wizard executes compose restore

### DIFF
--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, backupJobs, alertChannels, eq, desc } from '@backupos/db'
+import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, backupJobs, backupRuns, alertChannels, eq, desc, and } from '@backupos/db'
 import type { ComposeProjectConfig } from '@backupos/agent-protocol'
 import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult, type NotifyDelivery, type DatabaseRestoreDelivery } from '@backupos/restore'
 import { requireAdmin } from '@/lib/user'
@@ -553,6 +553,46 @@ export async function triggerDatabaseRestore(
   }
 
   return { ok: true, restoreId: dbRestoreId }
+}
+
+export async function getLatestRunForJob(
+  jobId: string,
+): Promise<{ ok: true; runId: string; createdAt: Date | null } | { ok: false; error: string }> {
+  await requireAdmin()
+  const db = getDb()
+
+  const [latest] = await db
+    .select({ id: backupRuns.id, createdAt: backupRuns.startedAt })
+    .from(backupRuns)
+    .where(and(
+      eq(backupRuns.jobId, jobId),
+      eq(backupRuns.status, 'success'),
+    ))
+    .orderBy(desc(backupRuns.startedAt))
+    .limit(1)
+    .all()
+
+  if (!latest) {
+    return { ok: false, error: 'No successful backup runs found for this job. Run a successful backup first.' }
+  }
+
+  return { ok: true, runId: latest.id, createdAt: latest.createdAt }
+}
+
+export async function getJobComposeProjectName(
+  jobId: string,
+): Promise<{ ok: true; projectName: string } | { ok: false; error: string }> {
+  await requireAdmin()
+  const db = getDb()
+  const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, jobId)).limit(1)
+  if (!job?.sourceConfig) return { ok: false, error: 'Job has no source config' }
+  try {
+    const cfg = JSON.parse(job.sourceConfig) as ComposeProjectConfig
+    if (!cfg.projectName) return { ok: false, error: 'Compose config has no project name' }
+    return { ok: true, projectName: cfg.projectName }
+  } catch {
+    return { ok: false, error: 'Compose config is malformed' }
+  }
 }
 
 export async function cancelRestore(restoreId: string): Promise<{ ok: boolean; error?: string }> {

--- a/apps/web/components/dr-mode-overlay.tsx
+++ b/apps/web/components/dr-mode-overlay.tsx
@@ -29,8 +29,8 @@ const CARDS = [
   {
     type:  'host' as const,
     icon:  Server,
-    title: 'Restore a whole host',
-    desc:  'Full-system restore from a backup snapshot. Requires pre-restore dry-run.',
+    title: 'Restore a compose stack',
+    desc:  'In-place restore of a docker-compose project from the latest successful backup run.',
   },
 ]
 

--- a/apps/web/components/dr/restore-host-wizard.tsx
+++ b/apps/web/components/dr/restore-host-wizard.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { CheckCircle, AlertTriangle } from 'lucide-react'
 import { logDrAction } from '@/app/actions/dr-audit'
+import { getJobComposeProjectName, getLatestRunForJob } from '@/app/actions/restore'
+import { triggerComposeRestore } from '@/app/actions/compose-restore'
 import { StepIndicator, WizardCard, WizardNav, escHtml } from '@/components/dr/restore-file-wizard'
 
 interface Props {
@@ -11,19 +13,82 @@ interface Props {
 }
 
 export function RestoreHostWizard({ jobs, onDone }: Props) {
-  const [step, setStep]               = useState(0)
-  const [jobId, setJobId]             = useState('')
-  const [targetHost, setTargetHost]   = useState('')
-  const [dryRunOk, setDryRunOk]       = useState(false)
-  const [confirmed, setConfirmed]     = useState(false)
-  const [submitting, setSubmitting]   = useState(false)
-  const [done, setDone]               = useState(false)
+  const [step, setStep]             = useState(0)
+  const [jobId, setJobId]           = useState('')
+  const [projectName, setProjectName]     = useState('')
+  const [latestRunId, setLatestRunId]     = useState('')
+  const [latestRunDate, setLatestRunDate] = useState<Date | null>(null)
+  const [confirmText, setConfirmText]     = useState('')
+  const [error, setError]           = useState<string | null>(null)
+  const [loading, setLoading]       = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [done, setDone]             = useState(false)
+
+  useEffect(() => {
+    if (!jobId) return
+    setLoading(true)
+    setError(null)
+    setProjectName('')
+    setLatestRunId('')
+    setLatestRunDate(null)
+
+    Promise.all([
+      getJobComposeProjectName(jobId),
+      getLatestRunForJob(jobId),
+    ]).then(([nameResult, runResult]) => {
+      if (!nameResult.ok) {
+        setError(nameResult.error)
+      } else {
+        setProjectName(nameResult.projectName)
+      }
+      if (!runResult.ok) {
+        setError(prev => prev ? `${prev}; ${runResult.error}` : runResult.error)
+      } else {
+        setLatestRunId(runResult.runId)
+        setLatestRunDate(runResult.createdAt)
+      }
+    }).catch(err => {
+      setError(err instanceof Error ? err.message : 'Failed to load job details')
+    }).finally(() => {
+      setLoading(false)
+    })
+  }, [jobId])
 
   async function execute() {
     setSubmitting(true)
-    await logDrAction({ action: 'restore_host', jobId, target: targetHost, dryRun: false })
-    setSubmitting(false)
-    setDone(true)
+    setError(null)
+    try {
+      if (confirmText !== projectName) {
+        setError(`Type the project name "${projectName}" to confirm.`)
+        setSubmitting(false)
+        return
+      }
+      const fd = new FormData()
+      fd.set('jobId',                jobId)
+      fd.set('sourceRunId',          latestRunId)
+      fd.set('mode',                 'in_place')
+      fd.set('restoreComposeFile',   '1')
+      fd.set('confirmedProjectName', projectName)
+      try {
+        await triggerComposeRestore(fd)
+      } catch (err) {
+        const isRedirect = err && typeof err === 'object' && 'digest' in err
+          && typeof (err as { digest?: string }).digest === 'string'
+          && (err as { digest: string }).digest.startsWith('NEXT_REDIRECT')
+        if (!isRedirect) throw err
+      }
+      await logDrAction({
+        action:   'restore_host',
+        jobId,
+        target:   projectName,
+        dryRun:   false,
+        metadata: { sourceRunId: latestRunId, projectName, mode: 'in_place' },
+      })
+      setDone(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong. Please try again.')
+      setSubmitting(false)
+    }
   }
 
   function printRunbook() {
@@ -31,7 +96,7 @@ export function RestoreHostWizard({ jobs, onDone }: Props) {
     const html = `<!DOCTYPE html>
 <html>
 <head>
-  <title>DR Runbook — Host Restore — ${escHtml(jobName)}</title>
+  <title>DR Runbook — Compose Stack Restore — ${escHtml(jobName)}</title>
   <style>
     body { font-family: sans-serif; max-width: 700px; margin: 40px auto; color: #111; }
     h1 { font-size: 22px; }
@@ -43,29 +108,27 @@ export function RestoreHostWizard({ jobs, onDone }: Props) {
 </head>
 <body>
   <h1>Disaster Recovery Runbook</h1>
-  <p><strong>Type:</strong> Full Host Restore</p>
+  <p><strong>Type:</strong> Docker-Compose Stack Restore (in-place)</p>
   <p><strong>Job:</strong> ${escHtml(jobName)}</p>
-  <p><strong>Target host:</strong> <code>${escHtml(targetHost)}</code></p>
+  <p><strong>Project:</strong> <code>${escHtml(projectName)}</code></p>
+  <p><strong>Source run:</strong> <code>${escHtml(latestRunId)}</code>${latestRunDate ? ` (${latestRunDate.toISOString()})` : ''}</p>
   <p><strong>Generated:</strong> ${new Date().toISOString()}</p>
   <h2>WARNING</h2>
-  <p class="danger">Full host restore COMPLETELY OVERWRITES the target system. Do not use the production host as the target unless you have no alternative.</p>
+  <p class="danger">In-place restore stops all containers in the compose project, overwrites volumes, and restarts. The project will be UNAVAILABLE during the restore.</p>
   <h2>Steps</h2>
   <ol>
-    <li>Boot target host from the BackupOS restore media (USB or network boot).</li>
-    <li>Ensure target has sufficient disk space to receive the restore.</li>
-    <li>Connect target host to the network and verify BackupOS agent can reach it.</li>
-    <li>In BackupOS, navigate to Jobs → <strong>${escHtml(jobName)}</strong> → Snapshots.</li>
-    <li>Select the most recent successful snapshot.</li>
-    <li>Click Restore → Host. Confirm target: <code>${escHtml(targetHost)}</code></li>
-    <li>Run the dry-run. Review the volume list, total size, and estimated restore time.</li>
-    <li>Execute the restore. Do not interrupt — data loss may result.</li>
-    <li>Reboot target host once restore completes.</li>
-    <li>Verify services are running and data is intact.</li>
+    <li>Ensure the BackupOS agent for job <strong>${escHtml(jobName)}</strong> is connected and reachable.</li>
+    <li>Confirm the compose project <code>${escHtml(projectName)}</code> is the correct target.</li>
+    <li>In BackupOS DR Mode, open "Restore a compose stack" and select the job.</li>
+    <li>Verify the latest successful backup run is the one shown (run ID: <code>${escHtml(latestRunId)}</code>).</li>
+    <li>Type the project name to confirm: <code>${escHtml(projectName)}</code></li>
+    <li>Click "Execute restore". BackupOS will stop the stack, restore volumes from the backup run, and restart.</li>
+    <li>Monitor agent logs for progress. Do not interrupt the restore.</li>
   </ol>
   <h2>Verification</h2>
-  <p>After reboot, confirm core services start successfully, check application health endpoints, and verify data integrity with application-level checks before routing production traffic.</p>
+  <p>After the restore completes, verify containers are running (<code>docker compose ps</code>), check application health endpoints, and confirm data integrity before routing production traffic.</p>
   <h2>Rollback</h2>
-  <p>If restore fails mid-way, the target host may be in an indeterminate state. Boot from rescue media and re-run the restore from scratch.</p>
+  <p>If the restore fails, the compose project may be in a stopped state. Check agent logs for the failure point, then either re-run the restore or start the stack manually from a known-good image.</p>
 </body>
 </html>`
     const blob = new Blob([html], { type: 'text/html' })
@@ -99,7 +162,7 @@ export function RestoreHostWizard({ jobs, onDone }: Props) {
         <CheckCircle size={48} color="var(--ok)" style={{ marginBottom: 16 }} />
         <div style={{ fontSize: 20, fontWeight: 600, color: 'var(--fg)', marginBottom: 8 }}>Restore initiated</div>
         <div style={{ fontSize: 14, color: 'var(--fg-mute)', marginBottom: 32 }}>
-          The host restore task has been queued. Monitor progress in the agent logs. This may take 30–120 minutes.
+          The compose stack restore has been queued. Monitor progress in the agent logs.
         </div>
         <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
           <button onClick={printRunbook} style={{ padding: '8px 16px', fontSize: 13, cursor: 'pointer', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'none', color: 'var(--fg)' }}>
@@ -115,21 +178,58 @@ export function RestoreHostWizard({ jobs, onDone }: Props) {
 
   return (
     <div style={{ maxWidth: 540, width: '100%' }}>
-      <StepIndicator current={step} labels={['Job', 'Target host', 'Dry run', 'Execute']} />
+      <StepIndicator current={step} labels={['Job', 'Confirm']} />
 
       {step === 0 && (
-        <WizardCard title="Which job should we restore from?">
+        <WizardCard title="Which compose stack should we restore?">
           <label style={labelStyle}>Backup job</label>
           <select value={jobId} onChange={e => setJobId(e.target.value)} style={inputStyle}>
             <option value="">— Select a job —</option>
             {jobs.map(j => <option key={j.id} value={j.id}>{j.name}</option>)}
           </select>
-          <WizardNav onBack={onDone} backLabel="Cancel" onNext={() => setStep(1)} nextDisabled={!jobId} />
+          {loading && (
+            <div style={{ fontSize: 12, color: 'var(--fg-dim)', marginTop: 8 }}>Loading job details…</div>
+          )}
+          {error && !loading && (
+            <div style={{ fontSize: 12, color: 'var(--err)', marginTop: 8 }}>{error}</div>
+          )}
+          {jobId && !loading && !error && projectName && (
+            <div style={{
+              marginTop: 12,
+              backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+              borderRadius: 'var(--radius-sm)', padding: '10px 14px',
+              fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg-mute)', lineHeight: 1.7,
+            }}>
+              <div>Project: <span style={{ color: 'var(--fg)' }}>{projectName}</span></div>
+              {latestRunDate && (
+                <div>Latest run: <span style={{ color: 'var(--fg)' }}>{latestRunDate.toLocaleString()}</span></div>
+              )}
+            </div>
+          )}
+          <WizardNav
+            onBack={onDone}
+            backLabel="Cancel"
+            onNext={() => { setError(null); setStep(1) }}
+            nextDisabled={!jobId || loading || !!error || !projectName || !latestRunId}
+          />
         </WizardCard>
       )}
 
       {step === 1 && (
-        <WizardCard title="Where should we restore to?">
+        <WizardCard title="Final confirmation — this cannot be undone">
+          <div style={{
+            backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+            borderRadius: 'var(--radius-sm)', padding: '12px 16px', marginBottom: 16,
+            fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg-mute)', lineHeight: 1.7,
+          }}>
+            <div>Job: <span style={{ color: 'var(--fg)' }}>{selectedJob?.name}</span></div>
+            <div>Project: <span style={{ color: 'var(--fg)' }}>{projectName}</span></div>
+            <div>Source run: <span style={{ color: 'var(--fg)' }}>{latestRunId.slice(0, 8)}…</span>
+              {latestRunDate && <span style={{ color: 'var(--fg-dim)' }}> ({latestRunDate.toLocaleString()})</span>}
+            </div>
+            <div>Mode: <span style={{ color: 'var(--fg)' }}>in_place</span></div>
+          </div>
+
           <div style={{
             display: 'flex', alignItems: 'flex-start', gap: 8,
             backgroundColor: 'var(--err-dim)',
@@ -138,84 +238,43 @@ export function RestoreHostWizard({ jobs, onDone }: Props) {
           }}>
             <AlertTriangle size={14} color="var(--err)" style={{ flexShrink: 0, marginTop: 1 }} />
             <span style={{ fontSize: 12, color: 'var(--err)' }}>
-              Full host restore overwrites all data on the target. Use a staging host, not production.
+              In-place restore will <strong>stop all containers</strong> in the <code style={{ fontSize: 11 }}>{projectName}</code> stack, overwrite volumes from backup, then restart. The stack will be unavailable during the restore.
             </span>
           </div>
-          <label style={labelStyle}>Target hostname or IP</label>
+
+          <label style={labelStyle}>Type <code style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>{projectName}</code> to confirm</label>
           <input
             type="text"
-            value={targetHost}
-            onChange={e => setTargetHost(e.target.value)}
-            placeholder="e.g. 192.168.1.50 or staging-host"
+            value={confirmText}
+            onChange={e => setConfirmText(e.target.value)}
+            placeholder={projectName}
             style={inputStyle}
+            autoFocus
           />
-          <div style={{ fontSize: 12, color: 'var(--fg-dim)', marginTop: 6 }}>
-            The BackupOS agent must be running on this host and reachable from the server.
-          </div>
-          <WizardNav onBack={() => setStep(0)} onNext={() => setStep(2)} nextDisabled={!targetHost.trim()} />
-        </WizardCard>
-      )}
 
-      {step === 2 && (
-        <WizardCard title="What will this touch?">
-          <div style={{
-            backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
-            borderRadius: 'var(--radius-sm)', padding: '12px 16px', marginBottom: 16,
-            fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg-mute)', lineHeight: 1.7,
-          }}>
-            <div style={{ color: 'var(--ok)', marginBottom: 4 }}>DRY RUN — no data will be written</div>
-            <div>Job: <span style={{ color: 'var(--fg)' }}>{selectedJob?.name}</span></div>
-            <div>Target: <span style={{ color: 'var(--fg)' }}>{targetHost}</span></div>
-            <div style={{ marginTop: 8, color: 'var(--fg-dim)' }}>Snapshot: most recent successful</div>
-            <div style={{ marginTop: 4 }}>Total size: ~84 GB (estimated)</div>
-            <div style={{ marginTop: 4 }}>Volumes: /, /home, /var</div>
-            <div style={{ marginTop: 4 }}>Estimated time: 45–90 minutes</div>
-            <div style={{ marginTop: 8, color: 'var(--err)', fontWeight: 600 }}>
-              ⛔ ALL DATA ON {targetHost.toUpperCase()} WILL BE OVERWRITTEN.
-            </div>
-          </div>
-          <label style={{ display: 'flex', alignItems: 'flex-start', gap: 8, cursor: 'pointer' }}>
-            <input type="checkbox" checked={dryRunOk} onChange={e => setDryRunOk(e.target.checked)} style={{ marginTop: 2, flexShrink: 0 }} />
-            <span style={{ fontSize: 13, color: 'var(--fg-mute)' }}>
-              I have reviewed the dry-run output and understand what will be restored.
-            </span>
-          </label>
-          <WizardNav onBack={() => setStep(1)} onNext={() => setStep(3)} nextDisabled={!dryRunOk} nextLabel="Confirm and continue" />
-        </WizardCard>
-      )}
+          {error && (
+            <div style={{ fontSize: 12, color: 'var(--err)', marginTop: 8 }}>{error}</div>
+          )}
 
-      {step === 3 && (
-        <WizardCard title="Final confirmation — this cannot be undone">
-          <div style={{
-            backgroundColor: 'var(--err-dim)',
-            border: '1px solid color-mix(in srgb, var(--err) 25%, transparent)',
-            borderRadius: 'var(--radius-sm)', padding: '14px 16px', marginBottom: 16,
-          }}>
-            <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)', marginBottom: 4 }}>Restore summary</div>
-            <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>Job: {selectedJob?.name}</div>
-            <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>Target: {targetHost}</div>
-            <div style={{ fontSize: 12, color: 'var(--fg-mute)' }}>Estimated size: ~84 GB</div>
-          </div>
-          <label style={{ display: 'flex', alignItems: 'flex-start', gap: 8, cursor: 'pointer', marginBottom: 20 }}>
-            <input type="checkbox" checked={confirmed} onChange={e => setConfirmed(e.target.checked)} style={{ marginTop: 2, flexShrink: 0 }} />
-            <span style={{ fontSize: 13, color: 'var(--err)' }}>
-              I confirm that <strong>{targetHost}</strong> is not a live production host and I understand all its data will be overwritten.
-            </span>
-          </label>
-          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: 20 }}>
-            <AlertTriangle size={14} color="var(--warn)" style={{ flexShrink: 0, marginTop: 2 }} />
-            <span style={{ fontSize: 12, color: 'var(--warn)' }}>
-              This action will be recorded in the audit log with DR mode flag.
-            </span>
-          </div>
-          <div style={{ display: 'flex', gap: 10 }}>
-            <button onClick={() => setStep(2)} style={{ padding: '8px 16px', fontSize: 13, cursor: 'pointer', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'none', color: 'var(--fg)' }}>Back</button>
+          <div style={{ display: 'flex', gap: 10, marginTop: 20 }}>
+            <button
+              onClick={() => { setError(null); setConfirmText(''); setStep(0) }}
+              style={{ padding: '8px 16px', fontSize: 13, cursor: 'pointer', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'none', color: 'var(--fg)' }}
+            >
+              Back
+            </button>
             <button
               onClick={execute}
-              disabled={submitting || !confirmed}
-              style={{ padding: '8px 20px', fontSize: 13, cursor: (submitting || !confirmed) ? 'not-allowed' : 'pointer', borderRadius: 'var(--radius-sm)', border: 'none', background: 'var(--err)', color: '#fff', opacity: (submitting || !confirmed) ? 0.4 : 1 }}
+              disabled={submitting || confirmText !== projectName}
+              style={{
+                padding: '8px 20px', fontSize: 13,
+                cursor: (submitting || confirmText !== projectName) ? 'not-allowed' : 'pointer',
+                borderRadius: 'var(--radius-sm)', border: 'none',
+                background: 'var(--err)', color: '#fff',
+                opacity: (submitting || confirmText !== projectName) ? 0.4 : 1,
+              }}
             >
-              {submitting ? 'Initiating…' : 'Execute full host restore'}
+              {submitting ? 'Initiating…' : 'Execute compose restore'}
             </button>
           </div>
         </WizardCard>


### PR DESCRIPTION
Closes the DR Mode wizard trio (file #379, database #382).

## Summary
- Wires the DR Mode host wizard to `triggerComposeRestore` with `mode: in_place`
- Honestly relabels "Restore a whole host" → "Restore a compose stack"
- New `getLatestRunForJob` action (compose restore needs a run, not a snapshot)
- New `getJobComposeProjectName` action (parses sourceConfig for project name)
- Type-the-project-name confirmation before execute
- NEXT_REDIRECT from triggerComposeRestore caught and treated as success

## Review checklist
- [ ] getLatestRunForJob and getJobComposeProjectName server actions
- [ ] Wizard removes targetHost, adds project name + run date display
- [ ] Type-to-confirm enforced before execute button enables
- [ ] execute() builds FormData with all required fields
- [ ] NEXT_REDIRECT handling
- [ ] Audit log includes sourceRunId, projectName, mode
- [ ] Card description updated in dr-mode-overlay.tsx
- [ ] Runbook updated for compose restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)