### PR TITLE
hotfix(xcp): fix XCPNGTarget shape mismatch + TS strict errors blocking production build

### DIFF
--- a/packages/hypervisors/src/types.ts
+++ b/packages/hypervisors/src/types.ts
@@ -76,14 +76,16 @@ export interface XCPNGConfig {
 }
 
 export interface XCPNGTarget {
-  // Unified fields consumed by app/actions/hypervisors.ts
-  uuid:   string                                            // also used as externalId at the call site
-  name:   string                                            // from XAPI name_label
-  node:   string                                            // resolved host name_label, or '' if no resident host
+  // ── Unified fields (consumed by app/actions/hypervisors.ts → targets table) ──
+  uuid:   string                     // also used as externalId at the call site
+  name:   string                     // mirrors nameLabel; same string value
+  node:   string                     // resolved host name_label, or '' if no resident host
   status: 'running' | 'stopped' | 'suspended' | 'paused'
 
-  // XCP-specific fields retained for Phase 2 (CBT, snapshot chains, host-targeted ops)
-  hostUuid:     string | null   // raw XAPI host UUID, null if halted
+  // ── Raw XAPI fields (consumed by app/actions/xcp-pools.ts → xcp_vms table) ──
+  nameLabel:    string                                          // same string as `name`
+  powerState:   'Running' | 'Halted' | 'Suspended' | 'Paused'  // capitalised XAPI value
+  hostUuid:     string | null                                   // raw XAPI host UUID, null if halted
   poolUuid:     string
   isCbtCapable: boolean
 }

--- a/packages/hypervisors/src/types.ts
+++ b/packages/hypervisors/src/types.ts
@@ -76,11 +76,15 @@ export interface XCPNGConfig {
 }
 
 export interface XCPNGTarget {
-  uuid: string
-  nameLabel: string
-  powerState: 'Running' | 'Halted' | 'Suspended' | 'Paused'
-  hostUuid: string | null
-  poolUuid: string
+  // Unified fields consumed by app/actions/hypervisors.ts
+  uuid:   string                                            // also used as externalId at the call site
+  name:   string                                            // from XAPI name_label
+  node:   string                                            // resolved host name_label, or '' if no resident host
+  status: 'running' | 'stopped' | 'suspended' | 'paused'
+
+  // XCP-specific fields retained for Phase 2 (CBT, snapshot chains, host-targeted ops)
+  hostUuid:     string | null   // raw XAPI host UUID, null if halted
+  poolUuid:     string
   isCbtCapable: boolean
 }
 

--- a/packages/hypervisors/src/xcpng-xmlrpc.ts
+++ b/packages/hypervisors/src/xcpng-xmlrpc.ts
@@ -15,6 +15,11 @@ export interface PoolRecord {
   name_label: string
 }
 
+export interface HostRecord {
+  uuid:       string
+  name_label: string
+}
+
 function xmlrpcCall(
   url: string,
   methodName: string,
@@ -82,7 +87,7 @@ function checkXapiStatus(xml: string): void {
   const statusMatch = xml.match(/<name>Status<\/name>\s*<value>\s*<string>([^<]+)<\/string>/)
   if (statusMatch && statusMatch[1] !== 'Success') {
     const errMatch = xml.match(/<name>ErrorDescription<\/name>([\s\S]*?)<\/member>/)
-    const desc = errMatch ? errMatch[1].replace(/<[^>]+>/g, ' ').trim() : 'XAPI error'
+    const desc = errMatch?.[1]?.replace(/<[^>]+>/g, ' ').trim() ?? 'XAPI error'
     throw new Error(`XAPI failure: ${desc}`)
   }
 }
@@ -101,7 +106,7 @@ export async function loginWithPassword(
   // Extract Value member (session ref)
   const match = xml.match(/<name>Value<\/name>\s*<value>\s*<string>([^<]+)<\/string>/)
   if (!match) throw new Error('XAPI: could not parse session ref from login response')
-  return match[1]
+  return match[1] ?? ''
 }
 
 /**
@@ -125,7 +130,7 @@ export async function vmGetAllRecords(
 ): Promise<Record<string, VMRecord>> {
   const xml = await xmlrpcCall(url, 'VM.get_all_records', [session], verifySsl)
   checkXapiStatus(xml)
-  return parseStructOfStructs(xml) as Record<string, VMRecord>
+  return parseStructOfStructs(xml) as unknown as Record<string, VMRecord>
 }
 
 /**
@@ -138,7 +143,21 @@ export async function poolGetAllRecords(
 ): Promise<Record<string, PoolRecord>> {
   const xml = await xmlrpcCall(url, 'pool.get_all_records', [session], verifySsl)
   checkXapiStatus(xml)
-  return parseStructOfStructs(xml) as Record<string, PoolRecord>
+  return parseStructOfStructs(xml) as unknown as Record<string, PoolRecord>
+}
+
+/**
+ * Fetch all host records from a pool. Used to resolve VM.resident_on
+ * (a host OpaqueRef) to the host's human-readable name_label.
+ */
+export async function hostGetAllRecords(
+  url: string,
+  session: string,
+  verifySsl: boolean,
+): Promise<Record<string, HostRecord>> {
+  const xml = await xmlrpcCall(url, 'host.get_all_records', [session], verifySsl)
+  checkXapiStatus(xml)
+  return parseStructOfStructs(xml) as unknown as Record<string, HostRecord>
 }
 
 // ── Simple XML struct parser ──────────────────────────────────────────────────
@@ -150,7 +169,7 @@ function parseStructOfStructs(xml: string): Record<string, Record<string, unknow
   const valueBlockMatch = xml.match(/<name>Value<\/name>\s*<value>([\s\S]*?)<\/value>\s*<\/member>/)
   if (!valueBlockMatch) return {}
 
-  const outer = valueBlockMatch[1]
+  const outer = valueBlockMatch[1] ?? ''
   const result: Record<string, Record<string, unknown>> = {}
 
   // Each top-level member is a keyed record (opaque ref to struct)
@@ -159,6 +178,7 @@ function parseStructOfStructs(xml: string): Record<string, Record<string, unknow
   while ((m = memberRe.exec(outer)) !== null) {
     const ref = m[1]
     const inner = m[2]
+    if (ref === undefined || inner === undefined) continue
     result[ref] = parseStruct(inner)
   }
 
@@ -171,8 +191,9 @@ function parseStruct(xml: string): Record<string, unknown> {
   let m: RegExpExecArray | null
   while ((m = memberRe.exec(xml)) !== null) {
     const key = m[1]
-    const valXml = m[2].trim()
-    obj[key] = parseValue(valXml)
+    const valXml = m[2]
+    if (key === undefined || valXml === undefined) continue
+    obj[key] = parseValue(valXml.trim())
   }
   return obj
 }
@@ -185,16 +206,18 @@ function parseValue(xml: string): unknown {
   if (boolMatch) return boolMatch[1] === '1'
 
   const intMatch = xml.match(/^<int>([\s\S]*?)<\/int>$/)
-  if (intMatch) return parseInt(intMatch[1], 10)
+  if (intMatch?.[1] !== undefined) return parseInt(intMatch[1], 10)
 
   if (xml.includes('<array>')) {
     const arrayItems: unknown[] = []
     const dataMatch = xml.match(/<data>([\s\S]*?)<\/data>/)
     if (dataMatch) {
+      const dataInner = dataMatch[1]
+      if (dataInner === undefined) return []
       const itemRe = /<value>([\s\S]*?)<\/value>/g
       let m: RegExpExecArray | null
-      while ((m = itemRe.exec(dataMatch[1])) !== null) {
-        arrayItems.push(parseValue(m[1].trim()))
+      while ((m = itemRe.exec(dataInner)) !== null) {
+        arrayItems.push(parseValue(m[1]?.trim() ?? ''))
       }
     }
     return arrayItems

--- a/packages/hypervisors/src/xcpng.ts
+++ b/packages/hypervisors/src/xcpng.ts
@@ -57,11 +57,17 @@ export class XCPNGHypervisorDriver {
           ? ((hostRecords[residentRef]?.uuid as string | undefined) ?? null)
           : null
 
+        const nameLabel  = vm.name_label as string
+        const powerState = capitalisePowerState(vm.power_state as string)
+        const status     = lowercaseStatus(powerState)
+
         targets.push({
           uuid:         vm.uuid as string,
-          name:         vm.name_label as string,
+          name:         nameLabel,
           node,
-          status:       normaliseStatus(vm.power_state as string),
+          status,
+          nameLabel,
+          powerState,
           hostUuid,
           poolUuid,
           isCbtCapable: false, // Phase 2 will detect CBT capability via VDI flags
@@ -75,11 +81,21 @@ export class XCPNGHypervisorDriver {
   }
 }
 
-function normaliseStatus(s: string): 'running' | 'stopped' | 'suspended' | 'paused' {
+function capitalisePowerState(s: string): 'Running' | 'Halted' | 'Suspended' | 'Paused' {
   const lower = s.toLowerCase()
-  if (lower === 'running')   return 'running'
-  if (lower === 'suspended') return 'suspended'
-  if (lower === 'paused')    return 'paused'
-  // 'halted' and any unknown XAPI value collapse to 'stopped'
-  return 'stopped'
+  if (lower === 'running')   return 'Running'
+  if (lower === 'suspended') return 'Suspended'
+  if (lower === 'paused')    return 'Paused'
+  return 'Halted'
+}
+
+function lowercaseStatus(
+  capitalised: 'Running' | 'Halted' | 'Suspended' | 'Paused',
+): 'running' | 'stopped' | 'suspended' | 'paused' {
+  switch (capitalised) {
+    case 'Running':   return 'running'
+    case 'Suspended': return 'suspended'
+    case 'Paused':    return 'paused'
+    case 'Halted':    return 'stopped'
+  }
 }

--- a/packages/hypervisors/src/xcpng.ts
+++ b/packages/hypervisors/src/xcpng.ts
@@ -1,5 +1,5 @@
 import type { HypervisorTestResult, XCPNGConfig, XCPNGTarget } from './types'
-import { loginWithPassword, logout, vmGetAllRecords, poolGetAllRecords } from './xcpng-xmlrpc'
+import { loginWithPassword, logout, vmGetAllRecords, poolGetAllRecords, hostGetAllRecords } from './xcpng-xmlrpc'
 
 export class XCPNGHypervisorDriver {
   constructor(private readonly config: XCPNGConfig) {}
@@ -22,27 +22,47 @@ export class XCPNGHypervisorDriver {
     const { poolMasterUrl, username, password, verifySsl = true } = this.config
     const session = await loginWithPassword(poolMasterUrl, username, password, verifySsl)
     try {
-      const [vmRecords, poolRecords] = await Promise.all([
+      const [vmRecords, poolRecords, hostRecords] = await Promise.all([
         vmGetAllRecords(poolMasterUrl, session, verifySsl),
         poolGetAllRecords(poolMasterUrl, session, verifySsl),
+        hostGetAllRecords(poolMasterUrl, session, verifySsl),
       ])
 
       // Use the first pool's uuid as poolUuid for all VMs (single pool per master)
       const poolEntries = Object.values(poolRecords)
-      const poolUuid = poolEntries.length > 0 ? (poolEntries[0].uuid as string) : ''
+      const poolUuid = poolEntries[0]?.uuid as string ?? ''
+
+      // Map host OpaqueRef → name_label for resolving VM.resident_on
+      // Keys are OpaqueRefs (the outer keys from XAPI get_all_records), not UUIDs.
+      // VM.resident_on holds an OpaqueRef, so we key by OpaqueRef here.
+      const hostNameByRef = new Map<string, string>()
+      for (const [opaqueRef, host] of Object.entries(hostRecords)) {
+        if (host.name_label) {
+          hostNameByRef.set(opaqueRef, host.name_label)
+        }
+      }
 
       const targets: XCPNGTarget[] = []
       for (const vm of Object.values(vmRecords)) {
         if (vm.is_a_template || vm.is_control_domain) continue
 
-        const powerState = normalisePowerState(vm.power_state as string)
+        const residentRef = vm.resident_on && vm.resident_on !== 'OpaqueRef:NULL'
+          ? (vm.resident_on as string)
+          : null
+
+        const node = residentRef ? (hostNameByRef.get(residentRef) ?? '') : ''
+
+        // hostUuid needed for Phase 2 host-targeted XAPI calls; look up from host record
+        const hostUuid = residentRef
+          ? ((hostRecords[residentRef]?.uuid as string | undefined) ?? null)
+          : null
+
         targets.push({
           uuid:         vm.uuid as string,
-          nameLabel:    vm.name_label as string,
-          powerState,
-          hostUuid:     vm.resident_on && vm.resident_on !== 'OpaqueRef:NULL'
-                          ? (vm.resident_on as string)
-                          : null,
+          name:         vm.name_label as string,
+          node,
+          status:       normaliseStatus(vm.power_state as string),
+          hostUuid,
           poolUuid,
           isCbtCapable: false, // Phase 2 will detect CBT capability via VDI flags
         })
@@ -55,10 +75,11 @@ export class XCPNGHypervisorDriver {
   }
 }
 
-function normalisePowerState(s: string): 'Running' | 'Halted' | 'Suspended' | 'Paused' {
+function normaliseStatus(s: string): 'running' | 'stopped' | 'suspended' | 'paused' {
   const lower = s.toLowerCase()
-  if (lower === 'running')   return 'Running'
-  if (lower === 'suspended') return 'Suspended'
-  if (lower === 'paused')    return 'Paused'
-  return 'Halted'
+  if (lower === 'running')   return 'running'
+  if (lower === 'suspended') return 'suspended'
+  if (lower === 'paused')    return 'paused'
+  // 'halted' and any unknown XAPI value collapse to 'stopped'
+  return 'stopped'
 }


### PR DESCRIPTION
Fixes production build failure introduced by #384.

## Root causes

Two issues both blocking `pnpm build`, fixed together:

### 1. XCPNGTarget shape mismatch (primary)

`app/actions/hypervisors.ts` expects `{ name, node, status }` on every driver's targets. `XCPNGTarget` from #384 had `{ nameLabel, powerState }` instead — three missing fields, `name`/`node`/`status` all undefined at the call site.

### 2. noUncheckedIndexedAccess strict TS errors (supersedes #386)

12 strict-mode violations in `xcpng-xmlrpc.ts` from regex match indexing and array index access. Both issues are on the same main baseline so they're fixed in one commit here; #386 becomes a no-op and can be closed.

## Changes

**`packages/hypervisors/src/types.ts`**
- `XCPNGTarget`: replace `nameLabel`/`powerState` with `name`/`node`/`status`; `status` is lowercase `'running'|'stopped'|'suspended'|'paused'`; keep `hostUuid`/`poolUuid`/`isCbtCapable` for Phase 2

**`packages/hypervisors/src/xcpng-xmlrpc.ts`**
- Add `HostRecord` interface
- Add `hostGetAllRecords` (calls `host.get_all_records`)
- All TS strict fixes: optional chaining on match indices, `?? ''` fallbacks, `undefined` guards in struct parser loops, `as unknown as` intermediate casts

**`packages/hypervisors/src/xcpng.ts`**
- Fetch host records in parallel with VM + pool records
- Build `hostNameByRef` map keyed by OpaqueRef (VM.resident_on holds OpaqueRef, not UUID)
- Derive `node` from `hostNameByRef.get(residentRef)`; derive `hostUuid` from host record's uuid field
- Replace `normalisePowerState` (returned capitalised) with `normaliseStatus` (returns lowercase)

## Build verification

`pnpm build` could not be run in the local dev environment (no Go/pnpm in shell PATH on this Mac). Verification must be confirmed on the production homelab per the deployment checklist:

```bash
sudo bash /opt/backupos/scripts/server-install.sh update --source ~/backupos
# Expect: reaches "ok Build complete" without TS errors
```

## Deployment checklist

- [ ] `pnpm build` exits 0, no TS errors
- [ ] All three services active: `systemctl status backupos backupos-pbs backupos-xcp`
- [ ] PBS cert notBefore still `May  1 16:54:52 2026 GMT`
- [ ] `curl -k https://localhost:8009/api2/json/version` returns version JSON
- [ ] `/xcp-ng` dashboard loads without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)