### PR TITLE
fix(xcp): use serverCtx as http.Server BaseContext

### DIFF
--- a/services/backupos-xcp/cmd/backupos-xcp/main.go
+++ b/services/backupos-xcp/cmd/backupos-xcp/main.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"flag"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -84,15 +85,19 @@ func main() {
 	})
 	mux.HandleFunc("/", notFound)
 
-	// serverCtx is cancelled on SIGINT/SIGTERM. Phase 2 will use it to stop
+	// serverCtx is the parent context for all incoming HTTP request contexts
+	// (via http.Server.BaseContext). Cancelled on SIGINT/SIGTERM so in-flight
+	// requests can react to shutdown. Phase 2 will also use serverCtx to stop
 	// background goroutines (XAPI session reaper, CBT chain GC scheduler).
-	// For now there are no background goroutines, so the cancel is a no-op.
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	defer serverCancel()
 
 	server := &http.Server{
 		Addr:    *bind,
 		Handler: mux,
+		BaseContext: func(_ net.Listener) context.Context {
+			return serverCtx
+		},
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			MinVersion:   tls.VersionTLS12,


### PR DESCRIPTION
Fixes production deploy failure introduced by #385's Go 1.26 bump combined with removal of the \`_ = serverCtx\` placeholder. Go enforces \"declared and not used\"; \`serverCtx\` was bound but never referenced.

## Fix

Pass \`serverCtx\` as \`http.Server.BaseContext\` so cancelling \`serverCtx\` (in the SIGTERM handler) propagates cancellation to all in-flight request contexts during graceful shutdown. Add \`"net"\` import. Update the comment block to describe the actual behaviour.

## Changes

- `services/backupos-xcp/cmd/backupos-xcp/main.go` only — one file, three edits

## Deployment checklist

- [ ] \`go build ./...\` exits 0 on the production server after deploy
- [ ] \`systemctl is-active backupos backupos-pbs backupos-xcp\` — all three active
- [ ] \`curl -k https://localhost:8009/api2/json/version\` returns version JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)