### PR TITLE
ci: add typecheck + build + Go vet on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+    branches:
+      - main
+
+# Cancel superseded runs on the same ref to avoid wasted Actions minutes
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typescript:
+    name: TypeScript build + typecheck
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '9.15.0'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm -r typecheck
+
+      - name: Build
+        run: pnpm -r build
+
+  go-services:
+    name: Go services build + vet
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - backupos-pbs
+          - backupos-xcp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Build
+        working-directory: services/${{ matrix.service }}
+        run: go build ./...
+
+      - name: Vet
+        working-directory: services/${{ matrix.service }}
+        run: go vet ./...

--- a/apps/agent-windows/src/ws.ts
+++ b/apps/agent-windows/src/ws.ts
@@ -39,8 +39,9 @@ export function startAgent(config: AgentConfig): void {
         hostname:     hostname(),
         ip,
         osInfo:       { os: 'windows', arch: process.arch, kernel: release() },
-        agentVersion: AGENT_VERSION,
-        platform:     'windows',
+        agentVersion:    AGENT_VERSION,
+        platform:        'windows',
+        protocolVersion: '1.0',
       })
       pingTimer = setInterval(() => send({ type: 'ping' }), 30_000)
     }
@@ -129,7 +130,7 @@ async function handleBackup(
         dataAdded:           (summary['data_added'] as number | undefined)            ?? 0,
         totalFilesProcessed: (summary['total_files_processed'] as number | undefined) ?? 0,
         totalBytesProcessed: (summary['total_bytes_processed'] as number | undefined) ?? 0,
-        durationSeconds:     (summary['total_duration'] as number | undefined)        ?? 0,
+        durationMs:          (summary['total_duration'] as number | undefined)        ?? 0,
       },
     })
   } catch (err) {

--- a/services/backupos-pbs/internal/fixedappend/fixedappend_test.go
+++ b/services/backupos-pbs/internal/fixedappend/fixedappend_test.go
@@ -103,7 +103,10 @@ func TestFixedAppend_MismatchedLists_Returns400(t *testing.T) {
 	}
 	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/fixed_index", bodyJSON(body))
 	req.Header.Set("Content-Type", "application/json")
-	resp, _ := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400 for mismatched lists, got %d", resp.StatusCode)
@@ -124,7 +127,10 @@ func TestFixedAppend_DigestNotInKnownChunks_Returns400(t *testing.T) {
 	}
 	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/fixed_index", bodyJSON(body))
 	req.Header.Set("Content-Type", "application/json")
-	resp, _ := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400 for unknown digest, got %d", resp.StatusCode)

--- a/services/backupos-pbs/internal/fixedchunk/fixedchunk_test.go
+++ b/services/backupos-pbs/internal/fixedchunk/fixedchunk_test.go
@@ -88,7 +88,10 @@ func TestFixedChunk_MissingStreamCtx_Returns500(t *testing.T) {
 	srv := httptest.NewServer(NewHandler())
 	defer srv.Close()
 
-	resp, _ := http.Post(srv.URL+"/fixed_chunk", "", nil)
+	resp, err := http.Post(srv.URL+"/fixed_chunk", "", nil)
+	if err != nil {
+		t.Fatalf("Post failed: %v", err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusInternalServerError {
 		t.Errorf("expected 500, got %d", resp.StatusCode)
@@ -101,7 +104,10 @@ func TestFixedChunk_MissingParams_Returns400(t *testing.T) {
 	defer srv.Close()
 
 	// No query params at all.
-	resp, _ := http.Post(srv.URL+"/fixed_chunk", "", nil)
+	resp, err := http.Post(srv.URL+"/fixed_chunk", "", nil)
+	if err != nil {
+		t.Fatalf("Post failed: %v", err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400 for missing params, got %d", resp.StatusCode)
@@ -114,7 +120,10 @@ func TestFixedChunk_BadDigestHex_Returns400(t *testing.T) {
 	defer srv.Close()
 
 	url := fmt.Sprintf("%s/fixed_chunk?wid=%d&digest=notvalidhex&size=4&encoded-size=16", srv.URL, wid)
-	resp, _ := http.Post(url, "application/octet-stream", bytes.NewReader(make([]byte, 16)))
+	resp, err := http.Post(url, "application/octet-stream", bytes.NewReader(make([]byte, 16)))
+	if err != nil {
+		t.Fatalf("Post failed: %v", err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400 for bad digest, got %d", resp.StatusCode)
@@ -139,7 +148,10 @@ func TestFixedChunk_DigestMismatch_Returns400(t *testing.T) {
 	wrongDigest[0] = 0xFF
 	url := fmt.Sprintf("%s/fixed_chunk?wid=%d&digest=%s&size=%d&encoded-size=%d",
 		srv.URL, wid, hex.EncodeToString(wrongDigest[:]), len(payload), len(blob))
-	resp, _ := http.Post(url, "application/octet-stream", bytes.NewReader(blob))
+	resp, err := http.Post(url, "application/octet-stream", bytes.NewReader(blob))
+	if err != nil {
+		t.Fatalf("Post failed: %v", err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400 for digest mismatch, got %d", resp.StatusCode)

--- a/services/backupos-pbs/internal/fixedclose/fixedclose_test.go
+++ b/services/backupos-pbs/internal/fixedclose/fixedclose_test.go
@@ -80,7 +80,10 @@ func TestFixedClose_MissingStreamCtx_Returns500(t *testing.T) {
 	defer srv.Close()
 
 	var csum [32]byte
-	resp, _ := http.Post(closeURL(srv.URL, 1, 0, 0, csum), "", nil)
+	resp, err := http.Post(closeURL(srv.URL, 1, 0, 0, csum), "", nil)
+	if err != nil {
+		t.Fatalf("Post failed: %v", err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusInternalServerError {
 		t.Errorf("expected 500, got %d", resp.StatusCode)
@@ -94,7 +97,10 @@ func TestFixedClose_WrongChunkCount_Returns400(t *testing.T) {
 	defer srv.Close()
 
 	// Server appended 1 chunk; client claims 2.
-	resp, _ := http.Post(closeURL(srv.URL, wid, 2, 4194304, serverCsum), "", nil)
+	resp, err := http.Post(closeURL(srv.URL, wid, 2, 4194304, serverCsum), "", nil)
+	if err != nil {
+		t.Fatalf("Post failed: %v", err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400 for chunk count mismatch, got %d", resp.StatusCode)
@@ -110,7 +116,10 @@ func TestFixedClose_CsumMismatch_Returns400(t *testing.T) {
 
 	var wrongCsum [32]byte
 	wrongCsum[0] = 0xBB
-	resp, _ := http.Post(closeURL(srv.URL, wid, 1, 4194304, wrongCsum), "", nil)
+	resp, err := http.Post(closeURL(srv.URL, wid, 1, 4194304, wrongCsum), "", nil)
+	if err != nil {
+		t.Fatalf("Post failed: %v", err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400 for csum mismatch, got %d", resp.StatusCode)
@@ -142,7 +151,10 @@ func TestFixedClose_MissingParams_Returns400(t *testing.T) {
 	srv := httptest.NewServer(injectCtx(sc, NewHandler()))
 	defer srv.Close()
 
-	resp, _ := http.Post(srv.URL+"/fixed_close", "", nil)
+	resp, err := http.Post(srv.URL+"/fixed_close", "", nil)
+	if err != nil {
+		t.Fatalf("Post failed: %v", err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400 for missing params, got %d", resp.StatusCode)

--- a/services/backupos-pbs/internal/fixedindex/fixedindex_test.go
+++ b/services/backupos-pbs/internal/fixedindex/fixedindex_test.go
@@ -150,7 +150,10 @@ func TestFixedIndex_SecondCall_ReturnsWid2(t *testing.T) {
 
 	for i := 1; i <= 2; i++ {
 		url := srv.URL + "/fixed_index?archive-name=drive-" + string(rune('0'+i-1)) + ".fidx&size=4194304"
-		resp, _ := http.Post(url, "", nil)
+		resp, err := http.Post(url, "", nil)
+		if err != nil {
+			t.Fatalf("Post failed: %v", err)
+		}
 		defer resp.Body.Close()
 		var body struct{ Data int `json:"data"` }
 		_ = json.NewDecoder(resp.Body).Decode(&body)


### PR DESCRIPTION
Adds a CI workflow that runs on every push to non-main branches and every pull request targeting main.

## What runs

**TypeScript job (parallel):**
- \`pnpm install --frozen-lockfile\`
- \`pnpm -r typecheck\`
- \`pnpm -r build\` (includes Next.js production build)

**Go services job (parallel, matrix over backupos-pbs and backupos-xcp):**
- \`go build ./...\`
- \`go vet ./...\`

## Also fixes: agent-windows TS errors (Option A)

Two pre-existing errors in \`apps/agent-windows/src/ws.ts\` that would have blocked the typecheck gate:
- \`hello\` message missing required \`protocolVersion\` field
- \`BackupStats.durationSeconds\` → \`durationMs\` (field was renamed in an earlier PR)

Both were one-liners; fixed inline per the spec's Option A guidance.

## Why this is a V1-blocker

The May 6 session had six PRs land for what should have been three pieces of work. Three of those PRs (#386, #387 fixup, #388) were hotfixes for build failures that this workflow would have caught in under 60 seconds.

## Post-merge configuration

Branch protection on \`main\` needs to be updated to require these CI checks before allowing merge (GitHub UI → Repo Settings → Branches → main → Require status checks):
- \`TypeScript build + typecheck\`
- \`Go services build + vet (backupos-pbs)\`
- \`Go services build + vet (backupos-xcp)\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)