### PR TITLE
fix(ci): build before typecheck so workspace deps resolve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Typecheck
-        run: pnpm -r typecheck
-
       - name: Build
         run: pnpm -r build
+
+      - name: Typecheck
+        run: pnpm -r typecheck
 
   go-services:
     name: Go services build + vet


### PR DESCRIPTION
Fixes the failure on the first real CI run (#389's own checks). Workspace package dists must exist before typecheck can resolve cross-package imports.

Verified locally with dist/ directories cleaned first to mirror CI.