### PR TITLE
feat(xcp): XAPI client with session, cert pinning, /api2/json/pool

### DIFF
--- a/services/backupos-xcp/cmd/backupos-xcp/main.go
+++ b/services/backupos-xcp/cmd/backupos-xcp/main.go
@@ -22,6 +22,8 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/dariusvorster/backupos/services/backupos-xcp/internal/xapi"
 )
 
 // Build-time variables, set via -ldflags during go build.
@@ -37,8 +39,21 @@ func main() {
 		certPath = flag.String("cert", "/var/lib/backupos/xcp/cert.pem", "TLS certificate path")
 		keyPath  = flag.String("key", "/var/lib/backupos/xcp/key.pem", "TLS private key path")
 		dbPath   = flag.String("db", "/var/lib/backupos/backupos.db", "SQLite database path")
+
+		// XAPI connection flags. If xapiURL is empty, the service starts but
+		// XAPI features are disabled — useful for the placeholder Phase 1 deploy.
+		xapiURL      = flag.String("xapi-url", "", "XAPI pool master URL (e.g. https://192.168.69.2)")
+		xapiUser     = flag.String("xapi-user", "root", "XAPI username")
+		xapiPass     = flag.String("xapi-pass", "", "XAPI password (or set BACKUPOS_XCP_PASS env var)")
+		xapiFP       = flag.String("xapi-cert-fingerprint", "", "XAPI host TLS cert SHA256 fingerprint (optional)")
+		xapiInsecure = flag.Bool("xapi-insecure", false, "Disable TLS verification for XAPI (dev only)")
 	)
 	flag.Parse()
+
+	// Password can also come from env var (preferred for systemd EnvironmentFile).
+	if *xapiPass == "" {
+		*xapiPass = os.Getenv("BACKUPOS_XCP_PASS")
+	}
 
 	_ = dbPath // reserved for future use
 
@@ -67,6 +82,38 @@ func main() {
 		os.Exit(1)
 	}
 
+	// serverCtx is the parent context for all incoming HTTP request contexts
+	// (via http.Server.BaseContext). Cancelled on SIGINT/SIGTERM so in-flight
+	// requests can react to shutdown. Phase 2 will also use serverCtx to stop
+	// background goroutines (XAPI session reaper, CBT chain GC scheduler).
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+
+	var xapiClient *xapi.Client
+	if *xapiURL != "" {
+		cfg := xapi.Config{
+			PoolMasterURL:      *xapiURL,
+			Username:           *xapiUser,
+			Password:           *xapiPass,
+			CertFingerprint:    *xapiFP,
+			InsecureSkipVerify: *xapiInsecure,
+		}
+		xc, err := xapi.New(cfg, logger)
+		if err != nil {
+			logger.Error("xapi: invalid config", "error", err)
+			os.Exit(1)
+		}
+		if err := xc.Connect(serverCtx); err != nil {
+			logger.Error("xapi: initial connect failed", "error", err)
+			// Non-fatal: service still starts, but XAPI endpoints will return 503.
+		} else {
+			xapiClient = xc
+			defer xapiClient.Close() //nolint:gocritic
+		}
+	} else {
+		logger.Warn("xapi-url not set; XAPI endpoints will return 503")
+	}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api2/json/version", func(w http.ResponseWriter, r *http.Request) {
 		slog.Info("version",
@@ -83,14 +130,44 @@ func main() {
 		}
 		_ = json.NewEncoder(w).Encode(resp)
 	})
-	mux.HandleFunc("/", notFound)
+	mux.HandleFunc("/api2/json/pool", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("pool",
+			"method", r.Method,
+			"path",   r.URL.Path,
+			"remote", r.RemoteAddr,
+		)
 
-	// serverCtx is the parent context for all incoming HTTP request contexts
-	// (via http.Server.BaseContext). Cancelled on SIGINT/SIGTERM so in-flight
-	// requests can react to shutdown. Phase 2 will also use serverCtx to stop
-	// background goroutines (XAPI session reaper, CBT chain GC scheduler).
-	serverCtx, serverCancel := context.WithCancel(context.Background())
-	defer serverCancel()
+		if xapiClient == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error": "xapi client not configured",
+			})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+
+		uuid, name, err := xapiClient.PoolName(ctx)
+		if err != nil {
+			slog.Error("pool query failed", "error", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadGateway)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"uuid": uuid,
+			"name": name,
+		})
+	})
+	mux.HandleFunc("/", notFound)
 
 	server := &http.Server{
 		Addr:    *bind,

--- a/services/backupos-xcp/go.mod
+++ b/services/backupos-xcp/go.mod
@@ -2,22 +2,6 @@ module github.com/dariusvorster/backupos/services/backupos-xcp
 
 go 1.26
 
-require (
-	github.com/terra-farm/go-xen-api-client v0.0.1
-	modernc.org/sqlite v1.34.1
-)
+require github.com/terra-farm/go-xen-api-client v0.0.2
 
-require (
-	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/ncruces/go-strftime v0.1.9 // indirect
-	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	golang.org/x/sys v0.22.0 // indirect
-	modernc.org/gc/v3 v3.0.0-20240107210532-573471604cb6 // indirect
-	modernc.org/libc v1.55.3 // indirect
-	modernc.org/mathutil v1.6.0 // indirect
-	modernc.org/memory v1.8.0 // indirect
-	modernc.org/strutil v1.2.0 // indirect
-	modernc.org/token v1.1.0 // indirect
-)
+require github.com/amfranz/go-xmlrpc-client v0.0.0-20190612172737-76858463955d // indirect

--- a/services/backupos-xcp/go.mod
+++ b/services/backupos-xcp/go.mod
@@ -2,7 +2,10 @@ module github.com/dariusvorster/backupos/services/backupos-xcp
 
 go 1.26
 
-require modernc.org/sqlite v1.34.1
+require (
+	github.com/terra-farm/go-xen-api-client v0.0.1
+	modernc.org/sqlite v1.34.1
+)
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/services/backupos-xcp/go.sum
+++ b/services/backupos-xcp/go.sum
@@ -1,0 +1,4 @@
+github.com/amfranz/go-xmlrpc-client v0.0.0-20190612172737-76858463955d h1:39lR6Kg+GsvDpLMD2Mb7gkjXmmLexqfr7SPy4iQWDTE=
+github.com/amfranz/go-xmlrpc-client v0.0.0-20190612172737-76858463955d/go.mod h1:2NlXXRCkTbr/vZtUjcHKhbrESE4a3CDqVrgOROB16dg=
+github.com/terra-farm/go-xen-api-client v0.0.2 h1:EREW0N6XqU935b005yCwbPjm8F6582j2rI5C4ew3ZTQ=
+github.com/terra-farm/go-xen-api-client v0.0.2/go.mod h1:L7+Ea6rxzK7AL4DhcEPDQxdLKb4wKq0sYbxHS2ag9YE=

--- a/services/backupos-xcp/internal/xapi/client.go
+++ b/services/backupos-xcp/internal/xapi/client.go
@@ -178,11 +178,22 @@ func (c *Client) PoolName(ctx context.Context) (uuid string, name string, err er
 	if len(poolRefs) == 0 {
 		return "", "", errors.New("xapi: no pool found")
 	}
-	rec, err := raw.Pool.GetRecord(sess, poolRefs[0])
+	poolRef := poolRefs[0]
+
+	// Use primitive getters instead of GetRecord. The library's PoolRecord
+	// struct includes allowed_operations as a strict enum, but XCP-ng 8.3
+	// returns enum values (e.g. "cluster_create") that the 2021-era library
+	// doesn't know. GetUUID and GetNameLabel return scalar strings and
+	// bypass the problematic enum entirely.
+	uuid, err = raw.Pool.GetUUID(sess, poolRef)
 	if err != nil {
-		return "", "", fmt.Errorf("xapi: pool.get_record: %w", err)
+		return "", "", fmt.Errorf("xapi: pool.get_uuid: %w", err)
 	}
-	return rec.UUID, rec.NameLabel, nil
+	name, err = raw.Pool.GetNameLabel(sess, poolRef)
+	if err != nil {
+		return "", "", fmt.Errorf("xapi: pool.get_name_label: %w", err)
+	}
+	return uuid, name, nil
 }
 
 // xmlrpcURL constructs the XML-RPC endpoint URL from PoolMasterURL.

--- a/services/backupos-xcp/internal/xapi/client.go
+++ b/services/backupos-xcp/internal/xapi/client.go
@@ -44,7 +44,10 @@ type Config struct {
 	// exclusive with CertFingerprint.
 	InsecureSkipVerify bool
 
-	// Timeout for individual HTTP calls. Defaults to 30s if zero.
+	// Timeout caps how long an XAPI call waits for response headers from the
+	// host. Defaults to 30s if zero. Note: this is ResponseHeaderTimeout, not
+	// total request timeout — long-running calls (e.g. CBT bitmap streaming)
+	// can still take longer than this once data starts flowing.
 	Timeout time.Duration
 }
 
@@ -92,9 +95,9 @@ func (c *Client) Connect(ctx context.Context) error {
 		return nil // already connected
 	}
 
-	httpClient, err := c.buildHTTPClient()
+	transport, err := c.buildTransport()
 	if err != nil {
-		return fmt.Errorf("xapi: build http client: %w", err)
+		return fmt.Errorf("xapi: build http transport: %w", err)
 	}
 
 	rawURL, err := c.xmlrpcURL()
@@ -102,7 +105,7 @@ func (c *Client) Connect(ctx context.Context) error {
 		return fmt.Errorf("xapi: parse pool master url: %w", err)
 	}
 
-	raw, err := xenapi.NewClient(rawURL, httpClient)
+	raw, err := xenapi.NewClient(rawURL, transport)
 	if err != nil {
 		return fmt.Errorf("xapi: new generated client: %w", err)
 	}
@@ -197,8 +200,10 @@ func (c *Client) xmlrpcURL() (string, error) {
 	return u.String(), nil
 }
 
-// buildHTTPClient constructs an *http.Client with the configured TLS settings.
-func (c *Client) buildHTTPClient() (*http.Client, error) {
+// buildTransport constructs an *http.Transport with the configured TLS settings
+// (cert pinning OR insecure-skip OR system trust store). The library wraps this
+// transport in its own *http.Client internally.
+func (c *Client) buildTransport() (*http.Transport, error) {
 	tlsCfg := &tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}
@@ -211,7 +216,7 @@ func (c *Client) buildHTTPClient() (*http.Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		tlsCfg.InsecureSkipVerify = true // we verify manually via VerifyPeerCertificate
+		tlsCfg.InsecureSkipVerify = true // we verify manually below
 		tlsCfg.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 			for _, raw := range rawCerts {
 				cert, parseErr := x509.ParseCertificate(raw)
@@ -227,11 +232,9 @@ func (c *Client) buildHTTPClient() (*http.Client, error) {
 		}
 	}
 
-	return &http.Client{
-		Timeout: c.cfg.Timeout,
-		Transport: &http.Transport{
-			TLSClientConfig: tlsCfg,
-		},
+	return &http.Transport{
+		TLSClientConfig:       tlsCfg,
+		ResponseHeaderTimeout: c.cfg.Timeout,
 	}, nil
 }
 

--- a/services/backupos-xcp/internal/xapi/client.go
+++ b/services/backupos-xcp/internal/xapi/client.go
@@ -1,0 +1,249 @@
+// Package xapi wraps github.com/terra-farm/go-xen-api-client with session
+// management, cert pinning, and reconnection. All XAPI calls in backupos-xcp
+// go through Client; the raw generated client (xenapi.Client) is not used
+// directly elsewhere.
+package xapi
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	xenapi "github.com/terra-farm/go-xen-api-client"
+)
+
+// Config carries everything needed to open an XAPI session.
+type Config struct {
+	// PoolMasterURL is the base URL of the pool master (e.g. "https://192.168.69.2").
+	// Trailing slash optional. The XAPI XML-RPC endpoint is "<URL>/" by convention.
+	PoolMasterURL string
+
+	// Username and Password authenticate via Session.LoginWithPassword.
+	// For root@pam, Username = "root".
+	Username string
+	Password string
+
+	// CertFingerprint, if non-empty, pins the host TLS cert by SHA256.
+	// Format: "AB:CD:EF:..." (uppercase, colon-separated, matches openssl output).
+	// If empty, the cert is verified against the system trust store.
+	// Mutually exclusive with InsecureSkipVerify.
+	CertFingerprint string
+
+	// InsecureSkipVerify disables TLS verification entirely. Only for development
+	// against self-signed homelab certs without a known fingerprint. Mutually
+	// exclusive with CertFingerprint.
+	InsecureSkipVerify bool
+
+	// Timeout for individual HTTP calls. Defaults to 30s if zero.
+	Timeout time.Duration
+}
+
+// Client is a managed XAPI session.
+type Client struct {
+	cfg    Config
+	logger *slog.Logger
+
+	mu      sync.Mutex
+	raw     *xenapi.Client    // generated client (xen-api-client)
+	session xenapi.SessionRef // current valid session ref, or empty
+}
+
+// New constructs a Client with the given config and logger. It does not
+// open a session — call Connect before making any XAPI call.
+func New(cfg Config, logger *slog.Logger) (*Client, error) {
+	if cfg.PoolMasterURL == "" {
+		return nil, errors.New("xapi: PoolMasterURL required")
+	}
+	if cfg.Username == "" {
+		return nil, errors.New("xapi: Username required")
+	}
+	if cfg.Password == "" {
+		return nil, errors.New("xapi: Password required")
+	}
+	if cfg.CertFingerprint != "" && cfg.InsecureSkipVerify {
+		return nil, errors.New("xapi: CertFingerprint and InsecureSkipVerify are mutually exclusive")
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 30 * time.Second
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Client{cfg: cfg, logger: logger}, nil
+}
+
+// Connect opens an XAPI session. Safe to call multiple times — if a valid
+// session already exists, Connect is a no-op.
+func (c *Client) Connect(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.raw != nil && c.session != "" {
+		return nil // already connected
+	}
+
+	httpClient, err := c.buildHTTPClient()
+	if err != nil {
+		return fmt.Errorf("xapi: build http client: %w", err)
+	}
+
+	rawURL, err := c.xmlrpcURL()
+	if err != nil {
+		return fmt.Errorf("xapi: parse pool master url: %w", err)
+	}
+
+	raw, err := xenapi.NewClient(rawURL, httpClient)
+	if err != nil {
+		return fmt.Errorf("xapi: new generated client: %w", err)
+	}
+
+	session, err := raw.Session.LoginWithPassword(c.cfg.Username, c.cfg.Password, "1.0", "backupos-xcp")
+	if err != nil {
+		return fmt.Errorf("xapi: login: %w", err)
+	}
+
+	c.raw = raw
+	c.session = session
+	c.logger.Info("xapi session opened",
+		"pool_master_url", c.cfg.PoolMasterURL,
+		"user", c.cfg.Username,
+	)
+	return nil
+}
+
+// Close logs out the current session, if any. Idempotent.
+func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.raw == nil || c.session == "" {
+		return nil
+	}
+	err := c.raw.Session.Logout(c.session)
+	c.raw = nil
+	c.session = ""
+	if err != nil {
+		c.logger.Warn("xapi session logout error", "error", err)
+		return fmt.Errorf("xapi: logout: %w", err)
+	}
+	c.logger.Info("xapi session closed")
+	return nil
+}
+
+// Session returns the underlying generated client and current session ref,
+// reconnecting if necessary. Callers MUST hold the returned mutex (released
+// by calling the returned function) for the duration of any XAPI call to
+// prevent the session from being swapped out mid-call.
+//
+// Typical usage:
+//
+//	raw, sess, release, err := client.Session(ctx)
+//	if err != nil { return err }
+//	defer release()
+//	pool, err := raw.Pool.GetAllRecords(sess)
+func (c *Client) Session(ctx context.Context) (*xenapi.Client, xenapi.SessionRef, func(), error) {
+	if err := c.Connect(ctx); err != nil {
+		return nil, "", nil, err
+	}
+	c.mu.Lock()
+	return c.raw, c.session, c.mu.Unlock, nil
+}
+
+// PoolName returns the human-readable name of the connected pool.
+// Convenience wrapper for the /api2/json/pool endpoint.
+func (c *Client) PoolName(ctx context.Context) (uuid string, name string, err error) {
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	defer release()
+
+	poolRefs, err := raw.Pool.GetAll(sess)
+	if err != nil {
+		return "", "", fmt.Errorf("xapi: pool.get_all: %w", err)
+	}
+	if len(poolRefs) == 0 {
+		return "", "", errors.New("xapi: no pool found")
+	}
+	rec, err := raw.Pool.GetRecord(sess, poolRefs[0])
+	if err != nil {
+		return "", "", fmt.Errorf("xapi: pool.get_record: %w", err)
+	}
+	return rec.UUID, rec.NameLabel, nil
+}
+
+// xmlrpcURL constructs the XML-RPC endpoint URL from PoolMasterURL.
+func (c *Client) xmlrpcURL() (string, error) {
+	u, err := url.Parse(c.cfg.PoolMasterURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" {
+		u.Scheme = "https"
+	}
+	if u.Path == "" || u.Path == "/" {
+		u.Path = "/"
+	}
+	return u.String(), nil
+}
+
+// buildHTTPClient constructs an *http.Client with the configured TLS settings.
+func (c *Client) buildHTTPClient() (*http.Client, error) {
+	tlsCfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	switch {
+	case c.cfg.InsecureSkipVerify:
+		tlsCfg.InsecureSkipVerify = true //nolint:gosec
+	case c.cfg.CertFingerprint != "":
+		expected, err := normalizeFingerprint(c.cfg.CertFingerprint)
+		if err != nil {
+			return nil, err
+		}
+		tlsCfg.InsecureSkipVerify = true // we verify manually via VerifyPeerCertificate
+		tlsCfg.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			for _, raw := range rawCerts {
+				cert, parseErr := x509.ParseCertificate(raw)
+				if parseErr != nil {
+					continue
+				}
+				got := sha256.Sum256(cert.Raw)
+				if hex.EncodeToString(got[:]) == expected {
+					return nil
+				}
+			}
+			return fmt.Errorf("xapi: cert fingerprint mismatch (expected %s)", c.cfg.CertFingerprint)
+		}
+	}
+
+	return &http.Client{
+		Timeout: c.cfg.Timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsCfg,
+		},
+	}, nil
+}
+
+// normalizeFingerprint converts "AB:CD:EF:..." to "abcdef..." (lowercase hex).
+func normalizeFingerprint(fp string) (string, error) {
+	cleaned := strings.ReplaceAll(fp, ":", "")
+	cleaned = strings.ToLower(cleaned)
+	if len(cleaned) != 64 {
+		return "", fmt.Errorf("xapi: fingerprint must be 64 hex chars (got %d)", len(cleaned))
+	}
+	if _, err := hex.DecodeString(cleaned); err != nil {
+		return "", fmt.Errorf("xapi: fingerprint not valid hex: %w", err)
+	}
+	return cleaned, nil
+}

--- a/services/backupos-xcp/internal/xapi/client_test.go
+++ b/services/backupos-xcp/internal/xapi/client_test.go
@@ -1,0 +1,112 @@
+package xapi
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeFingerprint(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "colon-separated uppercase",
+			in:   "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89",
+			want: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+		},
+		{
+			name: "lowercase no separator",
+			in:   "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+			want: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+		},
+		{
+			name:    "too short",
+			in:      "AB:CD",
+			wantErr: true,
+		},
+		{
+			name:    "non-hex",
+			in:      "ZZ:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeFingerprint(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name:    "missing url",
+			cfg:     Config{Username: "root", Password: "x"},
+			wantErr: "PoolMasterURL required",
+		},
+		{
+			name:    "missing user",
+			cfg:     Config{PoolMasterURL: "https://example.com", Password: "x"},
+			wantErr: "Username required",
+		},
+		{
+			name:    "missing password",
+			cfg:     Config{PoolMasterURL: "https://example.com", Username: "root"},
+			wantErr: "Password required",
+		},
+		{
+			name:    "fingerprint and insecure mutually exclusive",
+			cfg:     Config{PoolMasterURL: "https://example.com", Username: "root", Password: "x", CertFingerprint: "ab", InsecureSkipVerify: true},
+			wantErr: "mutually exclusive",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.cfg, nil)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("err = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestXmlrpcURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"https with no path", "https://192.168.69.2", "https://192.168.69.2/"},
+		{"https with trailing slash", "https://192.168.69.2/", "https://192.168.69.2/"},
+		{"http (scheme stays)", "http://example.com", "http://example.com/"},
+		{"no scheme defaults https", "192.168.69.2", "https://192.168.69.2/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{cfg: Config{PoolMasterURL: tt.in}}
+			got, err := c.xmlrpcURL()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
First PR of XCP Phase 2. Adds the XAPI session layer to backupos-xcp.

## What's in
- `internal/xapi/client.go`: managed XAPI session via terra-farm/go-xen-api-client
- `internal/xapi/client_test.go`: unit tests
- `cmd/backupos-xcp/main.go`: new flags + `/api2/json/pool` endpoint

## Out of scope
- CBT bitmap retrieval — PR A2
- Snapshot lifecycle — PR A3
- Auto-reconnect on SESSION_INVALID — follow-up