### PR TITLE
feat(xcp): CBT bitmap retrieval and parsing

### DIFF
--- a/services/backupos-xcp/cmd/backupos-xcp/main.go
+++ b/services/backupos-xcp/cmd/backupos-xcp/main.go
@@ -167,6 +167,63 @@ func main() {
 			"name": name,
 		})
 	})
+	mux.HandleFunc("/api2/json/changed-blocks", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("changed-blocks",
+			"method", r.Method,
+			"path",   r.URL.Path,
+			"remote", r.RemoteAddr,
+		)
+
+		if xapiClient == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error": "xapi client not configured",
+			})
+			return
+		}
+
+		fromUUID := r.URL.Query().Get("from")
+		toUUID := r.URL.Query().Get("to")
+		if fromUUID == "" || toUUID == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error": "from and to query parameters required",
+			})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+		defer cancel()
+
+		regions, err := xapiClient.ChangedRegions(ctx, fromUUID, toUUID)
+		if err != nil {
+			slog.Error("changed-blocks query failed", "error", err, "from", fromUUID, "to", toUUID)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadGateway)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		var totalBytes int64
+		for _, rg := range regions {
+			totalBytes += rg.Length
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"from":         fromUUID,
+			"to":           toUUID,
+			"block_size":   xapi.BlockSize,
+			"region_count": len(regions),
+			"total_bytes":  totalBytes,
+			"regions":      regions,
+		})
+	})
 	mux.HandleFunc("/", notFound)
 
 	server := &http.Server{

--- a/services/backupos-xcp/internal/xapi/cbt.go
+++ b/services/backupos-xcp/internal/xapi/cbt.go
@@ -1,0 +1,110 @@
+package xapi
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	xenapi "github.com/terra-farm/go-xen-api-client"
+)
+
+// BlockSize is the CBT block size in bytes. Per XenServer, CBT tracks
+// changes at 64 KiB granularity.
+const BlockSize int64 = 64 * 1024
+
+// ChangedRegion describes a contiguous run of changed blocks in a VDI,
+// expressed as a byte offset and byte length. Offset is always a multiple
+// of BlockSize. Length is always a multiple of BlockSize.
+type ChangedRegion struct {
+	Offset int64 `json:"offset"`
+	Length int64 `json:"length"`
+}
+
+// ChangedRegions retrieves the CBT bitmap between two snapshot VDIs and
+// returns the changed regions as (offset, length) tuples.
+func (c *Client) ChangedRegions(ctx context.Context, vdiFromUUID, vdiToUUID string) ([]ChangedRegion, error) {
+	if vdiFromUUID == "" || vdiToUUID == "" {
+		return nil, errors.New("xapi: vdiFromUUID and vdiToUUID required")
+	}
+
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	fromRef, err := raw.VDI.GetByUUID(sess, vdiFromUUID)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: vdi.get_by_uuid(from=%s): %w", vdiFromUUID, err)
+	}
+	toRef, err := raw.VDI.GetByUUID(sess, vdiToUUID)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: vdi.get_by_uuid(to=%s): %w", vdiToUUID, err)
+	}
+
+	bitmapB64, err := raw.VDI.ListChangedBlocks(sess, fromRef, toRef)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: vdi.list_changed_blocks: %w", err)
+	}
+
+	return ParseBitmap(bitmapB64)
+}
+
+// ParseBitmap decodes a base64-encoded CBT bitmap and returns the changed
+// regions as (offset, length) tuples in bytes. Each set bit represents one
+// 64 KiB block. Adjacent set bits are coalesced into single regions.
+//
+// Bit ordering within each byte: most-significant bit first. Bit N (where
+// N is the global block index) lives in byte N/8 at bit position 7-(N%8).
+//
+// An empty input returns nil (no error).
+func ParseBitmap(b64 string) ([]ChangedRegion, error) {
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: parse bitmap: base64 decode: %w", err)
+	}
+
+	var regions []ChangedRegion
+	var (
+		runStart int64 = -1
+		blockIdx int64
+	)
+
+	for byteIdx, b := range raw {
+		for bitInByte := 7; bitInByte >= 0; bitInByte-- {
+			blockIdx = int64(byteIdx)*8 + int64(7-bitInByte)
+			isSet := (b>>uint(bitInByte))&1 == 1
+			if isSet {
+				if runStart == -1 {
+					runStart = blockIdx
+				}
+			} else {
+				if runStart != -1 {
+					regions = append(regions, ChangedRegion{
+						Offset: runStart * BlockSize,
+						Length: (blockIdx - runStart) * BlockSize,
+					})
+					runStart = -1
+				}
+			}
+		}
+	}
+
+	if runStart != -1 {
+		endBlock := int64(len(raw)) * 8
+		regions = append(regions, ChangedRegion{
+			Offset: runStart * BlockSize,
+			Length: (endBlock - runStart) * BlockSize,
+		})
+	}
+
+	return regions, nil
+}
+
+// Compile-time assertion that VDIRef is a string alias.
+var _ = func() any {
+	var ref xenapi.VDIRef
+	_ = string(ref)
+	return nil
+}()

--- a/services/backupos-xcp/internal/xapi/cbt_test.go
+++ b/services/backupos-xcp/internal/xapi/cbt_test.go
@@ -1,0 +1,101 @@
+package xapi
+
+import (
+	"encoding/base64"
+	"reflect"
+	"testing"
+)
+
+func TestParseBitmap(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+		want []ChangedRegion
+	}{
+		{
+			name: "empty",
+			raw:  []byte{},
+			want: nil,
+		},
+		{
+			name: "all zeros, no changes",
+			raw:  []byte{0x00, 0x00, 0x00},
+			want: nil,
+		},
+		{
+			name: "single bit set, first block",
+			raw:  []byte{0x80}, // 1000 0000 — block 0
+			want: []ChangedRegion{{Offset: 0, Length: BlockSize}},
+		},
+		{
+			name: "single bit set, last block of first byte",
+			raw:  []byte{0x01}, // 0000 0001 — block 7
+			want: []ChangedRegion{{Offset: 7 * BlockSize, Length: BlockSize}},
+		},
+		{
+			name: "all 8 bits set, single byte",
+			raw:  []byte{0xFF}, // blocks 0..7, coalesced
+			want: []ChangedRegion{{Offset: 0, Length: 8 * BlockSize}},
+		},
+		{
+			name: "two non-adjacent regions",
+			raw:  []byte{0xC0, 0x03}, // 1100 0000  0000 0011
+			// blocks 0,1 and blocks 14,15
+			want: []ChangedRegion{
+				{Offset: 0, Length: 2 * BlockSize},
+				{Offset: 14 * BlockSize, Length: 2 * BlockSize},
+			},
+		},
+		{
+			name: "region spans byte boundary",
+			raw:  []byte{0x03, 0xC0}, // 0000 0011  1100 0000
+			// blocks 6,7,8,9 — coalesced
+			want: []ChangedRegion{{Offset: 6 * BlockSize, Length: 4 * BlockSize}},
+		},
+		{
+			name: "alternating bits",
+			raw:  []byte{0xAA}, // 1010 1010 = blocks 0, 2, 4, 6
+			want: []ChangedRegion{
+				{Offset: 0, Length: BlockSize},
+				{Offset: 2 * BlockSize, Length: BlockSize},
+				{Offset: 4 * BlockSize, Length: BlockSize},
+				{Offset: 6 * BlockSize, Length: BlockSize},
+			},
+		},
+		{
+			name: "run extends to end of bitmap",
+			raw:  []byte{0x0F}, // 0000 1111 = blocks 4,5,6,7
+			want: []ChangedRegion{{Offset: 4 * BlockSize, Length: 4 * BlockSize}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b64 := base64.StdEncoding.EncodeToString(tt.raw)
+			got, err := ParseBitmap(b64)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("regions mismatch:\n got: %+v\nwant: %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseBitmap_InvalidBase64(t *testing.T) {
+	_, err := ParseBitmap("not!valid!base64!!!")
+	if err == nil {
+		t.Fatal("expected error on invalid base64, got nil")
+	}
+}
+
+func TestParseBitmap_Empty(t *testing.T) {
+	got, err := ParseBitmap("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil regions, got %+v", got)
+	}
+}

--- a/services/backupos-xcp/internal/xapi/client.go
+++ b/services/backupos-xcp/internal/xapi/client.go
@@ -198,7 +198,13 @@ func (c *Client) PoolName(ctx context.Context) (uuid string, name string, err er
 
 // xmlrpcURL constructs the XML-RPC endpoint URL from PoolMasterURL.
 func (c *Client) xmlrpcURL() (string, error) {
-	u, err := url.Parse(c.cfg.PoolMasterURL)
+	raw := c.cfg.PoolMasterURL
+	// url.Parse treats a bare host (no scheme) as a path, leaving Host empty.
+	// Prepend the scheme so the host is parsed correctly before we normalise.
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	u, err := url.Parse(raw)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Phase 2 PR A2. Adds CBT bitmap support to backupos-xcp.

## What's in
- `internal/xapi/cbt.go`: `ParseBitmap` decoder + `Client.ChangedRegions` high-level method
- `internal/xapi/cbt_test.go`: 9 unit tests for the bitmap parser
- `cmd/backupos-xcp/main.go`: `/api2/json/changed-blocks?from=&to=` endpoint
- (fixup) `internal/xapi/client.go`: normalise xmlrpcURL for bare-host inputs

## Verified
- All Go tests pass locally (parser tests + pre-existing config/cert tests)
- Integration against test pool: SNAP1->SNAP2 returns 320 KB delta (idle Debian), SNAP2->SNAP3 returns 8.4 MB delta (real disk activity; the 50 MB urandom write was to tmpfs and correctly invisible to CBT)

## Out of scope
- Snapshot lifecycle (PR A3)
- NBD client / actual data copy (PR B)
- DB persistence of regions