### PR TITLE
feat(xcp): snapshot lifecycle (create, destroy, data_destroy)

### DIFF
--- a/services/backupos-xcp/cmd/backupos-xcp/main.go
+++ b/services/backupos-xcp/cmd/backupos-xcp/main.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -32,6 +33,16 @@ var (
 	releaseString = "1"
 	repoIDString  = "backupos-xcp"
 )
+
+func respondJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func respondJSONError(w http.ResponseWriter, status int, msg string) {
+	respondJSON(w, status, map[string]string{"error": msg})
+}
 
 func main() {
 	var (
@@ -222,6 +233,102 @@ func main() {
 			"region_count": len(regions),
 			"total_bytes":  totalBytes,
 			"regions":      regions,
+		})
+	})
+	mux.HandleFunc("/api2/json/snapshot", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("snapshot",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"remote", r.RemoteAddr,
+		)
+
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", "POST")
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		if xapiClient == nil {
+			respondJSONError(w, http.StatusServiceUnavailable, "xapi client not configured")
+			return
+		}
+
+		var body struct {
+			SourceUUID string `json:"source_uuid"`
+			NameLabel  string `json:"name_label"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			respondJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+			return
+		}
+		if body.SourceUUID == "" {
+			respondJSONError(w, http.StatusBadRequest, "source_uuid required")
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+		defer cancel()
+
+		info, err := xapiClient.Snapshot(ctx, body.SourceUUID, body.NameLabel)
+		if err != nil {
+			slog.Error("snapshot failed", "error", err, "source_uuid", body.SourceUUID)
+			respondJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+
+		respondJSON(w, http.StatusOK, info)
+	})
+	mux.HandleFunc("/api2/json/snapshot/", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("snapshot-delete",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"remote", r.RemoteAddr,
+		)
+
+		if r.Method != http.MethodDelete {
+			w.Header().Set("Allow", "DELETE")
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		if xapiClient == nil {
+			respondJSONError(w, http.StatusServiceUnavailable, "xapi client not configured")
+			return
+		}
+
+		uuid := strings.TrimPrefix(r.URL.Path, "/api2/json/snapshot/")
+		if uuid == "" || strings.Contains(uuid, "/") {
+			respondJSONError(w, http.StatusBadRequest, "snapshot uuid required in path")
+			return
+		}
+
+		mode := r.URL.Query().Get("mode")
+		if mode == "" {
+			mode = "destroy"
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+		defer cancel()
+
+		var err error
+		switch mode {
+		case "destroy":
+			err = xapiClient.DestroySnapshot(ctx, uuid)
+		case "data_destroy":
+			err = xapiClient.DataDestroySnapshot(ctx, uuid)
+		default:
+			respondJSONError(w, http.StatusBadRequest, "mode must be 'destroy' or 'data_destroy'")
+			return
+		}
+
+		if err != nil {
+			slog.Error("snapshot delete failed", "error", err, "uuid", uuid, "mode", mode)
+			respondJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+
+		respondJSON(w, http.StatusOK, map[string]any{
+			"uuid":   uuid,
+			"mode":   mode,
+			"status": "ok",
 		})
 	})
 	mux.HandleFunc("/", notFound)

--- a/services/backupos-xcp/internal/xapi/snapshot.go
+++ b/services/backupos-xcp/internal/xapi/snapshot.go
@@ -1,0 +1,168 @@
+package xapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	xenapi "github.com/terra-farm/go-xen-api-client"
+)
+
+// SnapshotInfo is the result of taking a snapshot.
+type SnapshotInfo struct {
+	UUID       string `json:"uuid"`
+	NameLabel  string `json:"name_label"`
+	CbtEnabled bool   `json:"cbt_enabled"`
+	SourceUUID string `json:"source_uuid"`
+}
+
+// Snapshot creates a read-only snapshot of the given VDI and sets a
+// recognisable name label. The snapshot inherits CBT state from its source —
+// if the source has CBT enabled, the snapshot does too.
+//
+// nameLabel is what appears in the XenCenter / xe vdi-list UI. Passing an
+// empty string falls back to the XAPI default (typically "<source_label>
+// (<timestamp>)").
+//
+// Returns SnapshotInfo with the new snapshot's UUID, label, and inherited CBT
+// state. Caller is responsible for eventually destroying or data_destroying.
+func (c *Client) Snapshot(ctx context.Context, sourceVDIUUID, nameLabel string) (*SnapshotInfo, error) {
+	if sourceVDIUUID == "" {
+		return nil, errors.New("xapi: sourceVDIUUID required")
+	}
+
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	sourceRef, err := raw.VDI.GetByUUID(sess, sourceVDIUUID)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: vdi.get_by_uuid(%s): %w", sourceVDIUUID, err)
+	}
+
+	// Empty driver_params is the common case. Specific SR backends accept
+	// hints here (e.g. "compress=true" for compressed snapshots), but those
+	// are SR-specific and we don't surface them at this layer.
+	snapRef, err := raw.VDI.Snapshot(sess, sourceRef, map[string]string{})
+	if err != nil {
+		return nil, fmt.Errorf("xapi: vdi.snapshot: %w", err)
+	}
+
+	// Best-effort label set. If it fails, the snapshot is still valid;
+	// we signal the failure by returning an empty label so the caller knows.
+	if nameLabel != "" {
+		if labelErr := raw.VDI.SetNameLabel(sess, snapRef, nameLabel); labelErr != nil {
+			nameLabel = ""
+		}
+	}
+
+	snapUUID, err := raw.VDI.GetUUID(sess, snapRef)
+	if err != nil {
+		// Snapshot was created but we can't read its UUID. Try to clean up,
+		// best-effort. If destroy fails the snapshot is orphaned in the pool.
+		_ = raw.VDI.Destroy(sess, snapRef)
+		return nil, fmt.Errorf("xapi: vdi.get_uuid(snapshot): %w", err)
+	}
+
+	cbtEnabled, err := raw.VDI.GetCbtEnabled(sess, snapRef)
+	if err != nil {
+		cbtEnabled = false
+	}
+
+	return &SnapshotInfo{
+		UUID:       snapUUID,
+		NameLabel:  nameLabel,
+		CbtEnabled: cbtEnabled,
+		SourceUUID: sourceVDIUUID,
+	}, nil
+}
+
+// DestroySnapshot fully removes the snapshot VDI (both data and metadata).
+//
+// Idempotent: if the snapshot is already gone (HANDLE_INVALID), returns nil.
+func (c *Client) DestroySnapshot(ctx context.Context, snapshotUUID string) error {
+	if snapshotUUID == "" {
+		return errors.New("xapi: snapshotUUID required")
+	}
+
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	ref, err := raw.VDI.GetByUUID(sess, snapshotUUID)
+	if err != nil {
+		if isHandleInvalid(err) {
+			return nil
+		}
+		return fmt.Errorf("xapi: vdi.get_by_uuid(%s): %w", snapshotUUID, err)
+	}
+
+	if err := raw.VDI.Destroy(sess, ref); err != nil {
+		if isHandleInvalid(err) {
+			return nil
+		}
+		return fmt.Errorf("xapi: vdi.destroy(%s): %w", snapshotUUID, err)
+	}
+	return nil
+}
+
+// DataDestroySnapshot deletes the snapshot's data while preserving its CBT
+// metadata. After this call, the snapshot's VDI type changes to cbt_metadata
+// and it can no longer be read for data, but it can still serve as the
+// reference point for a future ChangedRegions comparison.
+//
+// Idempotent: calling on an already-cbt_metadata VDI is a no-op (XAPI
+// guarantees this).
+func (c *Client) DataDestroySnapshot(ctx context.Context, snapshotUUID string) error {
+	if snapshotUUID == "" {
+		return errors.New("xapi: snapshotUUID required")
+	}
+
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	ref, err := raw.VDI.GetByUUID(sess, snapshotUUID)
+	if err != nil {
+		if isHandleInvalid(err) {
+			return nil
+		}
+		return fmt.Errorf("xapi: vdi.get_by_uuid(%s): %w", snapshotUUID, err)
+	}
+
+	if err := raw.VDI.DataDestroy(sess, ref); err != nil {
+		if isHandleInvalid(err) {
+			return nil
+		}
+		return fmt.Errorf("xapi: vdi.data_destroy(%s): %w", snapshotUUID, err)
+	}
+	return nil
+}
+
+// isHandleInvalid checks whether an XAPI error means the VDI is already gone.
+// XAPI returns errors as strings like:
+//
+//	"API Error: HANDLE_INVALID VDI OpaqueRef:..."
+//
+// We match on the HANDLE_INVALID token to avoid coupling to the exact format.
+func isHandleInvalid(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "HANDLE_INVALID")
+}
+
+// Compile-time assertion that VDIRef remains a string-alias.
+// Mirrors the assertion in cbt.go.
+var _ = func() any {
+	var ref xenapi.VDIRef
+	_ = string(ref)
+	return nil
+}()

--- a/services/backupos-xcp/internal/xapi/snapshot.go
+++ b/services/backupos-xcp/internal/xapi/snapshot.go
@@ -82,7 +82,7 @@ func (c *Client) Snapshot(ctx context.Context, sourceVDIUUID, nameLabel string) 
 
 // DestroySnapshot fully removes the snapshot VDI (both data and metadata).
 //
-// Idempotent: if the snapshot is already gone (HANDLE_INVALID), returns nil.
+// Idempotent: if the snapshot is already gone (HANDLE_INVALID or UUID_INVALID), returns nil.
 func (c *Client) DestroySnapshot(ctx context.Context, snapshotUUID string) error {
 	if snapshotUUID == "" {
 		return errors.New("xapi: snapshotUUID required")
@@ -96,14 +96,14 @@ func (c *Client) DestroySnapshot(ctx context.Context, snapshotUUID string) error
 
 	ref, err := raw.VDI.GetByUUID(sess, snapshotUUID)
 	if err != nil {
-		if isHandleInvalid(err) {
+		if isAlreadyGone(err) {
 			return nil
 		}
 		return fmt.Errorf("xapi: vdi.get_by_uuid(%s): %w", snapshotUUID, err)
 	}
 
 	if err := raw.VDI.Destroy(sess, ref); err != nil {
-		if isHandleInvalid(err) {
+		if isAlreadyGone(err) {
 			return nil
 		}
 		return fmt.Errorf("xapi: vdi.destroy(%s): %w", snapshotUUID, err)
@@ -131,14 +131,14 @@ func (c *Client) DataDestroySnapshot(ctx context.Context, snapshotUUID string) e
 
 	ref, err := raw.VDI.GetByUUID(sess, snapshotUUID)
 	if err != nil {
-		if isHandleInvalid(err) {
+		if isAlreadyGone(err) {
 			return nil
 		}
 		return fmt.Errorf("xapi: vdi.get_by_uuid(%s): %w", snapshotUUID, err)
 	}
 
 	if err := raw.VDI.DataDestroy(sess, ref); err != nil {
-		if isHandleInvalid(err) {
+		if isAlreadyGone(err) {
 			return nil
 		}
 		return fmt.Errorf("xapi: vdi.data_destroy(%s): %w", snapshotUUID, err)
@@ -146,17 +146,15 @@ func (c *Client) DataDestroySnapshot(ctx context.Context, snapshotUUID string) e
 	return nil
 }
 
-// isHandleInvalid checks whether an XAPI error means the VDI is already gone.
-// XAPI returns errors as strings like:
-//
-//	"API Error: HANDLE_INVALID VDI OpaqueRef:..."
-//
-// We match on the HANDLE_INVALID token to avoid coupling to the exact format.
-func isHandleInvalid(err error) bool {
+// isAlreadyGone checks whether an XAPI error means the VDI no longer exists.
+// XAPI uses HANDLE_INVALID for opaque refs that have been freed, and UUID_INVALID
+// when get_by_uuid is called with a UUID that no longer resolves.
+func isAlreadyGone(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "HANDLE_INVALID")
+	msg := err.Error()
+	return strings.Contains(msg, "HANDLE_INVALID") || strings.Contains(msg, "UUID_INVALID")
 }
 
 // Compile-time assertion that VDIRef remains a string-alias.

--- a/services/backupos-xcp/internal/xapi/snapshot_test.go
+++ b/services/backupos-xcp/internal/xapi/snapshot_test.go
@@ -1,0 +1,30 @@
+package xapi
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsHandleInvalid(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"plain error", errors.New("connection refused"), false},
+		{"HANDLE_INVALID full XAPI message", errors.New("API Error: HANDLE_INVALID VDI OpaqueRef:abc-123"), true},
+		{"HANDLE_INVALID anywhere in string", errors.New("xapi: vdi.destroy: HANDLE_INVALID"), true},
+		{"case sensitive — does NOT match lowercase", errors.New("handle_invalid"), false},
+		{"different error code", errors.New("VDI_IN_USE"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isHandleInvalid(tt.err)
+			if got != tt.want {
+				t.Fatalf("isHandleInvalid(%v): got %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/services/backupos-xcp/internal/xapi/snapshot_test.go
+++ b/services/backupos-xcp/internal/xapi/snapshot_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestIsHandleInvalid(t *testing.T) {
+func TestIsAlreadyGone(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
@@ -15,15 +15,17 @@ func TestIsHandleInvalid(t *testing.T) {
 		{"plain error", errors.New("connection refused"), false},
 		{"HANDLE_INVALID full XAPI message", errors.New("API Error: HANDLE_INVALID VDI OpaqueRef:abc-123"), true},
 		{"HANDLE_INVALID anywhere in string", errors.New("xapi: vdi.destroy: HANDLE_INVALID"), true},
+		{"UUID_INVALID full XAPI message", errors.New("API Error: UUID_INVALID VDI 723a75d5-..."), true},
+		{"UUID_INVALID anywhere in string", errors.New("xapi: vdi.get_by_uuid: UUID_INVALID"), true},
 		{"case sensitive — does NOT match lowercase", errors.New("handle_invalid"), false},
 		{"different error code", errors.New("VDI_IN_USE"), false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isHandleInvalid(tt.err)
+			got := isAlreadyGone(tt.err)
 			if got != tt.want {
-				t.Fatalf("isHandleInvalid(%v): got %v, want %v", tt.err, got, tt.want)
+				t.Fatalf("isAlreadyGone(%v): got %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Phase 2 PR A3. Adds VDI snapshot lifecycle to backupos-xcp.

## What's in
- `internal/xapi/snapshot.go`: `Client.Snapshot`, `Client.DestroySnapshot`, `Client.DataDestroySnapshot` with idempotent destroy paths
- `internal/xapi/snapshot_test.go`: unit tests for already-gone matcher (HANDLE_INVALID + UUID_INVALID)
- `cmd/backupos-xcp/main.go`: POST `/api2/json/snapshot`, DELETE `/api2/json/snapshot/{uuid}?mode=destroy|data_destroy`

## Out of scope
- NBD copy / restic integration (PR B)
- Scheduler that orchestrates the full backup loop (PR C)
- DB persistence of snapshot history (PR C)

## Verified

Local Go: build/vet/test all green.

Integration against test pool:
- Snapshot creates with `cbt_enabled: true`
- `data_destroy` transitions VDI to `type=cbt_metadata` with `cbt-enabled=true`
- `destroy` after `data_destroy` succeeds (cbt_metadata VDIs are still destroyable)
- Re-destroy and re-data_destroy on already-gone UUIDs both return `{"status":"ok"}` (UUID_INVALID treated as success)