### PR TITLE
feat(xcp): NBD reader via libnbd's nbdsh

### DIFF
--- a/scripts/server-install.sh
+++ b/scripts/server-install.sh
@@ -192,6 +192,26 @@ fi
 restic version &>/dev/null || die "restic installed but cannot execute — check architecture"
 ok "restic $(restic version | head -1 | awk '{print $2}')"
 
+# libnbd-bin + python3-libnbd for backupos-xcp NBD reader.
+# nbdsh (used by the xcp service to read snapshot data over NBD) ships in
+# python3-libnbd on Debian/Ubuntu, separate from the C tooling in libnbd-bin.
+# Both packages are required.
+if ! command -v nbdsh &>/dev/null; then
+  log "Installing libnbd-bin and python3-libnbd..."
+  if command -v apt-get &>/dev/null; then
+    apt-get install -y libnbd-bin python3-libnbd
+  elif command -v yum &>/dev/null; then
+    yum install -y nbdkit-libnbd-tools
+  else
+    log "WARN: cannot auto-install nbdsh — install libnbd-bin and python3-libnbd manually for NBD snapshot reads"
+  fi
+fi
+if command -v nbdsh &>/dev/null; then
+  ok "nbdsh $(nbdsh --version 2>&1 | head -1)"
+else
+  log "WARN: nbdsh not found — NBD snapshot read endpoint will return errors until installed"
+fi
+
 # Go (1.22+) for backupos-pbs service.
 #
 # Users typically install Go from the official tarball at /usr/local/go/.
@@ -513,9 +533,12 @@ PBSSVCEOF
 # ── 8c. systemd service for the Go XCP sidecar ───────────────────────────────
 XCP_BIND="${BACKUPOS_XCP_BIND:-0.0.0.0:8009}"
 
-# Ensure cert directory exists
+# Ensure cert directory and NBD read output directory exist
 mkdir -p "$DATA_DIR/xcp"
 chown "$SVC_USER:$SVC_USER" "$DATA_DIR/xcp"
+mkdir -p "$DATA_DIR/xcp-reads"
+chown "$SVC_USER:$SVC_USER" "$DATA_DIR/xcp-reads"
+chmod 0750 "$DATA_DIR/xcp-reads"
 
 cat > /etc/systemd/system/${SERVICE_NAME}-xcp.service <<XCPSVCEOF
 [Unit]

--- a/services/backupos-xcp/cmd/backupos-xcp/main.go
+++ b/services/backupos-xcp/cmd/backupos-xcp/main.go
@@ -11,7 +11,9 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -20,10 +22,12 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/dariusvorster/backupos/services/backupos-xcp/internal/nbdread"
 	"github.com/dariusvorster/backupos/services/backupos-xcp/internal/xapi"
 )
 
@@ -58,6 +62,8 @@ func main() {
 		xapiPass     = flag.String("xapi-pass", "", "XAPI password (or set BACKUPOS_XCP_PASS env var)")
 		xapiFP       = flag.String("xapi-cert-fingerprint", "", "XAPI host TLS cert SHA256 fingerprint (optional)")
 		xapiInsecure = flag.Bool("xapi-insecure", false, "Disable TLS verification for XAPI (dev only)")
+		readOutputDir = flag.String("read-output-dir", "/var/lib/backupos/xcp-reads",
+			"directory under which /api2/json/snapshot/{uuid}/read can write files")
 	)
 	flag.Parse()
 
@@ -72,6 +78,17 @@ func main() {
 		Level: slog.LevelInfo,
 	}))
 	slog.SetDefault(logger)
+
+	absReadDir, readDirErr := filepath.Abs(*readOutputDir)
+	if readDirErr != nil {
+		logger.Error("resolve read-output-dir", "error", readDirErr)
+		os.Exit(1)
+	}
+	readOutputDirResolved := filepath.Clean(absReadDir)
+	if readDirErr = os.MkdirAll(readOutputDirResolved, 0o755); readDirErr != nil {
+		logger.Error("create read-output-dir", "error", readDirErr)
+		os.Exit(1)
+	}
 
 	logger.Info("starting backupos-xcp",
 		"version", versionString,
@@ -278,58 +295,162 @@ func main() {
 		respondJSON(w, http.StatusOK, info)
 	})
 	mux.HandleFunc("/api2/json/snapshot/", func(w http.ResponseWriter, r *http.Request) {
-		slog.Info("snapshot-delete",
-			"method", r.Method,
-			"path", r.URL.Path,
-			"remote", r.RemoteAddr,
-		)
-
-		if r.Method != http.MethodDelete {
-			w.Header().Set("Allow", "DELETE")
-			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
-			return
-		}
-		if xapiClient == nil {
-			respondJSONError(w, http.StatusServiceUnavailable, "xapi client not configured")
-			return
+		suffix := strings.TrimPrefix(r.URL.Path, "/api2/json/snapshot/")
+		parts := strings.SplitN(suffix, "/", 2)
+		uuid := parts[0]
+		sub := ""
+		if len(parts) == 2 {
+			sub = parts[1]
 		}
 
-		uuid := strings.TrimPrefix(r.URL.Path, "/api2/json/snapshot/")
-		if uuid == "" || strings.Contains(uuid, "/") {
-			respondJSONError(w, http.StatusBadRequest, "snapshot uuid required in path")
-			return
-		}
+		switch {
+		case r.Method == http.MethodDelete && sub == "":
+			slog.Info("snapshot-delete", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+			if xapiClient == nil {
+				respondJSONError(w, http.StatusServiceUnavailable, "xapi client not configured")
+				return
+			}
+			if uuid == "" {
+				respondJSONError(w, http.StatusBadRequest, "snapshot uuid required in path")
+				return
+			}
+			mode := r.URL.Query().Get("mode")
+			if mode == "" {
+				mode = "destroy"
+			}
+			ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+			defer cancel()
+			var err error
+			switch mode {
+			case "destroy":
+				err = xapiClient.DestroySnapshot(ctx, uuid)
+			case "data_destroy":
+				err = xapiClient.DataDestroySnapshot(ctx, uuid)
+			default:
+				respondJSONError(w, http.StatusBadRequest, "mode must be 'destroy' or 'data_destroy'")
+				return
+			}
+			if err != nil {
+				slog.Error("snapshot delete failed", "error", err, "uuid", uuid, "mode", mode)
+				respondJSONError(w, http.StatusBadGateway, err.Error())
+				return
+			}
+			respondJSON(w, http.StatusOK, map[string]any{"uuid": uuid, "mode": mode, "status": "ok"})
 
-		mode := r.URL.Query().Get("mode")
-		if mode == "" {
-			mode = "destroy"
-		}
+		case r.Method == http.MethodGet && sub == "nbd-info":
+			slog.Info("snapshot-nbd-info", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+			if xapiClient == nil {
+				respondJSONError(w, http.StatusServiceUnavailable, "xapi client not configured")
+				return
+			}
+			if uuid == "" {
+				respondJSONError(w, http.StatusBadRequest, "snapshot uuid required in path")
+				return
+			}
+			ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+			defer cancel()
+			infos, err := xapiClient.SnapshotNBDInfo(ctx, uuid)
+			if err != nil {
+				slog.Error("nbd-info query failed", "error", err, "uuid", uuid)
+				respondJSONError(w, http.StatusBadGateway, err.Error())
+				return
+			}
+			type sanitized struct {
+				ExportName      string `json:"export_name"`
+				Address         string `json:"address"`
+				Port            int    `json:"port"`
+				Subject         string `json:"subject"`
+				CertFingerprint string `json:"cert_fingerprint_sha256"`
+			}
+			san := make([]sanitized, len(infos))
+			for i, info := range infos {
+				sum := sha256.Sum256([]byte(info.CertPEM))
+				san[i] = sanitized{
+					ExportName:      info.ExportName,
+					Address:         info.Address,
+					Port:            info.Port,
+					Subject:         info.Subject,
+					CertFingerprint: hex.EncodeToString(sum[:]),
+				}
+			}
+			respondJSON(w, http.StatusOK, map[string]any{"uuid": uuid, "options": san})
 
-		ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
-		defer cancel()
+		case r.Method == http.MethodPost && sub == "read":
+			slog.Info("snapshot-read", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+			if xapiClient == nil {
+				respondJSONError(w, http.StatusServiceUnavailable, "xapi client not configured")
+				return
+			}
+			if uuid == "" {
+				respondJSONError(w, http.StatusBadRequest, "snapshot uuid required in path")
+				return
+			}
+			var body struct {
+				OutputPath string          `json:"output_path"`
+				Regions    []nbdread.Region `json:"regions"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				respondJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+				return
+			}
+			if body.OutputPath == "" {
+				respondJSONError(w, http.StatusBadRequest, "output_path required")
+				return
+			}
+			if len(body.Regions) == 0 {
+				respondJSONError(w, http.StatusBadRequest, "regions required (at least one)")
+				return
+			}
+			if !strings.HasPrefix(filepath.Clean(body.OutputPath), readOutputDirResolved) {
+				respondJSONError(w, http.StatusBadRequest, "output_path must be under "+readOutputDirResolved)
+				return
+			}
+			nbdCtx, nbdCancel := context.WithTimeout(r.Context(), 30*time.Second)
+			defer nbdCancel()
+			infos, err := xapiClient.SnapshotNBDInfo(nbdCtx, uuid)
+			if err != nil {
+				respondJSONError(w, http.StatusBadGateway, "get_nbd_info: "+err.Error())
+				return
+			}
+			if len(infos) == 0 {
+				respondJSONError(w, http.StatusBadGateway,
+					"no NBD options available for this snapshot — is NBD enabled on a network reaching this host's SR?")
+				return
+			}
+			chosen := infos[0]
+			f, err := os.Create(body.OutputPath)
+			if err != nil {
+				respondJSONError(w, http.StatusInternalServerError, "create output: "+err.Error())
+				return
+			}
+			defer f.Close()
+			readCtx, readCancel := context.WithTimeout(r.Context(), 10*time.Minute)
+			defer readCancel()
+			res, err := nbdread.ReadRegions(readCtx, nbdread.Connection{
+				Address:    chosen.Address,
+				Port:       chosen.Port,
+				ExportName: chosen.ExportName,
+				CertPEM:    chosen.CertPEM,
+				Subject:    chosen.Subject,
+			}, body.Regions, f)
+			if err != nil {
+				slog.Error("nbd read failed", "error", err, "uuid", uuid)
+				respondJSONError(w, http.StatusBadGateway, err.Error())
+				return
+			}
+			respondJSON(w, http.StatusOK, map[string]any{
+				"uuid":         uuid,
+				"output_path":  body.OutputPath,
+				"bytes_read":   res.BytesRead,
+				"region_count": res.RegionCount,
+				"sha256":       res.SHA256Hex,
+				"duration_ms":  res.DurationMS,
+			})
 
-		var err error
-		switch mode {
-		case "destroy":
-			err = xapiClient.DestroySnapshot(ctx, uuid)
-		case "data_destroy":
-			err = xapiClient.DataDestroySnapshot(ctx, uuid)
 		default:
-			respondJSONError(w, http.StatusBadRequest, "mode must be 'destroy' or 'data_destroy'")
-			return
+			w.Header().Set("Allow", "DELETE, GET, POST")
+			respondJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 		}
-
-		if err != nil {
-			slog.Error("snapshot delete failed", "error", err, "uuid", uuid, "mode", mode)
-			respondJSONError(w, http.StatusBadGateway, err.Error())
-			return
-		}
-
-		respondJSON(w, http.StatusOK, map[string]any{
-			"uuid":   uuid,
-			"mode":   mode,
-			"status": "ok",
-		})
 	})
 	mux.HandleFunc("/", notFound)
 

--- a/services/backupos-xcp/internal/nbdread/reader.go
+++ b/services/backupos-xcp/internal/nbdread/reader.go
@@ -89,16 +89,11 @@ func ReadRegions(ctx context.Context, conn Connection, regions []Region, out io.
 	uri := buildURI(conn, certDir)
 
 	// Build a Python script that opens the connection and performs each pread,
-	// writing raw bytes to stdout. Using a file avoids passing hundreds of
-	// --command flags for large region lists.
+	// writing raw bytes to stdout. nbdsh -c - reads the script from stdin.
 	script := buildPythonScript(uri, regions)
 
-	scriptPath := filepath.Join(certDir, "read.py")
-	if err := os.WriteFile(scriptPath, []byte(script), 0o600); err != nil {
-		return nil, fmt.Errorf("nbdread: write script: %w", err)
-	}
-
-	cmd := exec.CommandContext(ctx, "nbdsh", "-f", scriptPath)
+	cmd := exec.CommandContext(ctx, "nbdsh", "-c", "-")
+	cmd.Stdin = strings.NewReader(script)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("nbdread: stdout pipe: %w", err)

--- a/services/backupos-xcp/internal/nbdread/reader.go
+++ b/services/backupos-xcp/internal/nbdread/reader.go
@@ -1,0 +1,172 @@
+// Package nbdread reads byte ranges from an NBD server using libnbd's nbdsh tool.
+// All TLS verification is handled by passing the server's self-signed cert as
+// the trusted CA in a per-call temporary directory.
+package nbdread
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Region describes a contiguous byte range to read from the export.
+// Mirrors xapi.ChangedRegion but is duplicated here to keep this package
+// dependency-free.
+type Region struct {
+	Offset int64 `json:"offset"`
+	Length int64 `json:"length"`
+}
+
+// Connection holds the parameters needed to reach an NBD export.
+type Connection struct {
+	Address    string
+	Port       int
+	ExportName string
+	// CertPEM is the server's TLS certificate in PEM form, returned from
+	// VDI.get_nbd_info. This is used as the trust anchor — the server cert is
+	// expected to match this exactly.
+	CertPEM string
+	// Subject is the cert's CN; used as the TLS hostname so cert verification
+	// succeeds when connecting by IP address.
+	Subject string
+}
+
+// ReadResult summarises a successful read.
+type ReadResult struct {
+	BytesRead   int64
+	RegionCount int
+	SHA256Hex   string
+	DurationMS  int64
+}
+
+// ReadRegions connects to the NBD server described by conn and reads each
+// region into out. Reads are sequential on a single TLS connection.
+//
+// Returns ReadResult on success. The SHA256 is computed over the concatenation
+// of all region bytes in the order given (matches what the eventual restic
+// stream will see).
+//
+// Requires `nbdsh` to be available on PATH. Returns a clear error if it isn't.
+func ReadRegions(ctx context.Context, conn Connection, regions []Region, out io.Writer) (*ReadResult, error) {
+	if _, err := exec.LookPath("nbdsh"); err != nil {
+		return nil, fmt.Errorf("nbdread: nbdsh not found on PATH (install libnbd-bin and python3-libnbd): %w", err)
+	}
+	if len(regions) == 0 {
+		return &ReadResult{}, nil
+	}
+	if conn.Address == "" || conn.Port == 0 || conn.ExportName == "" {
+		return nil, errors.New("nbdread: connection address, port, and export_name required")
+	}
+	if conn.CertPEM == "" {
+		return nil, errors.New("nbdread: certPEM required (TLS-only)")
+	}
+
+	// Stage the cert so libnbd can find it. The directory must be 0700 and
+	// contain ca-cert.pem.
+	certDir, err := os.MkdirTemp("", "backupos-nbd-cert-*")
+	if err != nil {
+		return nil, fmt.Errorf("nbdread: tmpdir: %w", err)
+	}
+	defer os.RemoveAll(certDir)
+	if err := os.Chmod(certDir, 0o700); err != nil {
+		return nil, fmt.Errorf("nbdread: chmod cert dir: %w", err)
+	}
+	certPath := filepath.Join(certDir, "ca-cert.pem")
+	if err := os.WriteFile(certPath, []byte(conn.CertPEM), 0o600); err != nil {
+		return nil, fmt.Errorf("nbdread: write cert: %w", err)
+	}
+
+	uri := buildURI(conn, certDir)
+
+	// Build a Python script that opens the connection and performs each pread,
+	// writing raw bytes to stdout. Using a file avoids passing hundreds of
+	// --command flags for large region lists.
+	script := buildPythonScript(uri, regions)
+
+	scriptPath := filepath.Join(certDir, "read.py")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o600); err != nil {
+		return nil, fmt.Errorf("nbdread: write script: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "nbdsh", "-f", scriptPath)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("nbdread: stdout pipe: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("nbdread: start nbdsh: %w", err)
+	}
+
+	hash := sha256.New()
+	tee := io.MultiWriter(out, hash)
+	bytesRead, err := io.Copy(tee, stdout)
+	if err != nil {
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("nbdread: copy: %w (stderr=%s)", err, strings.TrimSpace(stderr.String()))
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return nil, fmt.Errorf("nbdread: nbdsh exited with error: %w (stderr=%s)", err, strings.TrimSpace(stderr.String()))
+	}
+
+	// Sanity check: bytes read must equal sum of region lengths.
+	var expected int64
+	for _, r := range regions {
+		expected += r.Length
+	}
+	if bytesRead != expected {
+		return nil, fmt.Errorf("nbdread: byte count mismatch: read %d, expected %d (stderr=%s)",
+			bytesRead, expected, strings.TrimSpace(stderr.String()))
+	}
+
+	return &ReadResult{
+		BytesRead:   bytesRead,
+		RegionCount: len(regions),
+		SHA256Hex:   hex.EncodeToString(hash.Sum(nil)),
+		DurationMS:  time.Since(start).Milliseconds(),
+	}, nil
+}
+
+// buildURI constructs the nbds:// URI for libnbd, embedding the path to the
+// trust anchor directory and the TLS hostname (cert subject).
+func buildURI(c Connection, certDir string) string {
+	q := url.Values{}
+	q.Set("tls-certificates", certDir)
+	if c.Subject != "" {
+		q.Set("tls-hostname", c.Subject)
+	}
+	// ExportName goes in the path, URL-encoded. XenServer's export names
+	// include slashes and query-like syntax (e.g. "/<vdi-uuid>?session_id=...").
+	// Per the NBD URI spec, paths after the host can be percent-encoded.
+	return fmt.Sprintf("nbds://%s:%d/%s?%s",
+		c.Address, c.Port, url.PathEscape(c.ExportName), q.Encode())
+}
+
+// buildPythonScript writes raw bytes for each region to stdout in order.
+// nbdsh pre-imports the nbd module and exposes it as `nbd`.
+func buildPythonScript(uri string, regions []Region) string {
+	var b strings.Builder
+	b.WriteString("import sys\n")
+	b.WriteString("h = nbd.NBD()\n")
+	fmt.Fprintf(&b, "h.connect_uri(%q)\n", uri)
+	for _, r := range regions {
+		fmt.Fprintf(&b, "sys.stdout.buffer.write(h.pread(%d, %d))\n", r.Length, r.Offset)
+	}
+	b.WriteString("sys.stdout.flush()\n")
+	b.WriteString("h.shutdown()\n")
+	return b.String()
+}

--- a/services/backupos-xcp/internal/nbdread/reader.go
+++ b/services/backupos-xcp/internal/nbdread/reader.go
@@ -157,6 +157,10 @@ func buildPythonScript(uri string, regions []Region) string {
 	var b strings.Builder
 	b.WriteString("import sys\n")
 	b.WriteString("h = nbd.NBD()\n")
+	// tls-certificates=DIR in the URI is a local-file reference; libnbd requires
+	// explicit opt-in per nbd_connect_uri(3) to prevent unintended local access.
+	// Safe here because we control both the URI and the tmpdir cert contents.
+	b.WriteString("h.set_uri_allow_local_file(True)\n")
 	fmt.Fprintf(&b, "h.connect_uri(%q)\n", uri)
 	for _, r := range regions {
 		fmt.Fprintf(&b, "sys.stdout.buffer.write(h.pread(%d, %d))\n", r.Length, r.Offset)

--- a/services/backupos-xcp/internal/nbdread/reader_test.go
+++ b/services/backupos-xcp/internal/nbdread/reader_test.go
@@ -39,6 +39,7 @@ func TestBuildPythonScript(t *testing.T) {
 	script := buildPythonScript("nbds://example/foo", regions)
 
 	mustContain := []string{
+		`h.set_uri_allow_local_file(True)`,
 		`h.connect_uri("nbds://example/foo")`,
 		`h.pread(65536, 0)`,
 		`h.pread(131072, 1048576)`,

--- a/services/backupos-xcp/internal/nbdread/reader_test.go
+++ b/services/backupos-xcp/internal/nbdread/reader_test.go
@@ -1,0 +1,65 @@
+package nbdread
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildURI(t *testing.T) {
+	conn := Connection{
+		Address:    "192.168.69.2",
+		Port:       10809,
+		ExportName: "/abc-123?session_id=OpaqueRef:foo",
+		Subject:    "xenpool4host3",
+	}
+	got := buildURI(conn, "/tmp/certs")
+
+	mustContain := []string{
+		"nbds://192.168.69.2:10809/",
+		"tls-certificates=%2Ftmp%2Fcerts",
+		"tls-hostname=xenpool4host3",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(got, s) {
+			t.Errorf("URI missing %q\nfull URI: %s", s, got)
+		}
+	}
+	// The export name has slashes and a query-marker — it should be percent-encoded
+	// so it doesn't poison our query string.
+	if strings.Contains(got, "?session_id=OpaqueRef") {
+		t.Errorf("export name not properly URL-escaped (raw '?session_id' leaked): %s", got)
+	}
+}
+
+func TestBuildPythonScript(t *testing.T) {
+	regions := []Region{
+		{Offset: 0, Length: 65536},
+		{Offset: 1048576, Length: 131072},
+	}
+	script := buildPythonScript("nbds://example/foo", regions)
+
+	mustContain := []string{
+		`h.connect_uri("nbds://example/foo")`,
+		`h.pread(65536, 0)`,
+		`h.pread(131072, 1048576)`,
+		`h.shutdown()`,
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(script, s) {
+			t.Errorf("script missing %q\nfull script:\n%s", s, script)
+		}
+	}
+}
+
+func TestBuildPythonScript_EmptyRegions(t *testing.T) {
+	script := buildPythonScript("nbds://example/foo", nil)
+	if !strings.Contains(script, `h.connect_uri("nbds://example/foo")`) {
+		t.Errorf("script missing connect call:\n%s", script)
+	}
+	if !strings.Contains(script, "h.shutdown()") {
+		t.Errorf("script missing shutdown:\n%s", script)
+	}
+	if strings.Contains(script, "h.pread") {
+		t.Errorf("script has pread for empty region list:\n%s", script)
+	}
+}

--- a/services/backupos-xcp/internal/xapi/nbd.go
+++ b/services/backupos-xcp/internal/xapi/nbd.go
@@ -1,0 +1,58 @@
+package xapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// NBDInfo describes one way to reach a snapshot VDI via NBD.
+// Returned from XAPI's VDI.get_nbd_info; multiple entries may exist if the
+// host has multiple NBD-enabled network interfaces.
+type NBDInfo struct {
+	ExportName string `json:"export_name"`
+	Address    string `json:"address"`
+	Port       int    `json:"port"`
+	CertPEM    string `json:"cert_pem"`
+	Subject    string `json:"subject"`
+}
+
+// SnapshotNBDInfo returns NBD connection options for the given snapshot VDI.
+// The snapshot must be a regular snapshot (not cbt_metadata) — cbt_metadata
+// VDIs cannot be exported over NBD.
+//
+// Returns an empty slice with no error if the host has no NBD-enabled network
+// reachable for this VDI's SR. Caller should treat that as a configuration error.
+func (c *Client) SnapshotNBDInfo(ctx context.Context, snapshotUUID string) ([]NBDInfo, error) {
+	if snapshotUUID == "" {
+		return nil, errors.New("xapi: snapshotUUID required")
+	}
+
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	ref, err := raw.VDI.GetByUUID(sess, snapshotUUID)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: vdi.get_by_uuid(%s): %w", snapshotUUID, err)
+	}
+
+	records, err := raw.VDI.GetNbdInfo(sess, ref)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: vdi.get_nbd_info: %w", err)
+	}
+
+	out := make([]NBDInfo, 0, len(records))
+	for _, r := range records {
+		out = append(out, NBDInfo{
+			ExportName: r.Exportname,
+			Address:    r.Address,
+			Port:       r.Port,
+			CertPEM:    r.Cert,
+			Subject:    r.Subject,
+		})
+	}
+	return out, nil
+}


### PR DESCRIPTION
Phase 2 PR B1. Adds the data-read leg of the backup loop.

## What's in
- `internal/xapi/nbd.go`: `Client.SnapshotNBDInfo` wraps VDI.get_nbd_info, returning address/port/export_name/cert/subject for each NBD-enabled network on the host.
- `internal/nbdread/reader.go`: `ReadRegions` shells out to nbdsh (from libnbd-bin + python3-libnbd) to read a list of (offset, length) regions over a single TLS-secured NBD connection. Cert pinning by writing the cert from get_nbd_info to a per-call tmpdir as ca-cert.pem and pointing nbds://...?tls-certificates=DIR at it. Opts in to libnbd's local-file URI access (required for tls-certificates).
- `internal/nbdread/reader_test.go`: unit tests for URI construction and Python script generation (the parts that don't need a live server).
- `cmd/backupos-xcp/main.go`: GET /api2/json/snapshot/{uuid}/nbd-info (returns connection options with cert fingerprint), POST /api2/json/snapshot/{uuid}/read (reads regions to a file under --read-output-dir).
- `scripts/server-install.sh`: install libnbd-bin + python3-libnbd, create /var/lib/backupos/xcp-reads.

## Approach
Shell out to libnbd's `nbdsh` (battle-tested, ships in libnbd-bin + python3-libnbd) instead of implementing NBD transmission protocol in Go. Existing Go NBD libraries (Merovius/nbd, pojntfx/go-nbd) are oriented toward serving NBD or hooking up the kernel's /dev/nbdX, not pure userspace remote reads. libnbd is Red Hat's mature production NBD client used by qemu-img and virt-v2v.

## Out of scope
- Restic integration (B2)
- Scheduler / orchestration (C)
- Full-disk reads (caller passes explicit region list)
- Parallel/multi-conn reads (single sequential connection; B2+ optimisation)

## Verified
- `go build/vet/test`: all green
- Integration on test pool: snapshot test-vm-1 -> get_nbd_info returns address/port/cert/subject -> POST /read with [{offset:0, length:262144}] -> bytes_read=262144, file on disk is 262144 bytes, returned sha256 matches sha256sum, file identified as 'DOS/MBR boot sector'