### PR TITLE
feat(xcp,web): hypervisor integration + target discovery for XCP-ng

### DIFF
--- a/apps/web/app/(dashboard)/hypervisors/new/page.tsx
+++ b/apps/web/app/(dashboard)/hypervisors/new/page.tsx
@@ -10,6 +10,7 @@ async function createHypervisor(formData: FormData) {
   const username = (formData.get('username') as string).trim()
   const password = (formData.get('password') as string).trim()
   const port = formData.get('port') ? Number(formData.get('port')) : undefined
+  const certFingerprint = (formData.get('cert_fingerprint_sha256') as string | null)?.trim() ?? ''
 
   if (!name || !type || !host) return
 
@@ -18,7 +19,7 @@ async function createHypervisor(formData: FormData) {
     id:        crypto.randomUUID(),
     name,
     type:      type as 'proxmox' | 'xcpng' | 'vmware',
-    config:    JSON.stringify({ host, username, password, port }),
+    config:    JSON.stringify({ host, username, password, port, cert_fingerprint_sha256: certFingerprint }),
     status:    'unknown',
     createdAt: new Date(),
   })
@@ -98,6 +99,11 @@ export default function NewHypervisorPage() {
           <div>
             <label style={labelStyle}>Password / API token</label>
             <input name="password" type="password" placeholder="••••••••" style={inputStyle} />
+          </div>
+
+          <div>
+            <label style={labelStyle}>TLS cert fingerprint (SHA-256, XCP-ng only)</label>
+            <input name="cert_fingerprint_sha256" placeholder="AB:CD:EF:..." style={inputStyle} />
           </div>
 
           <div style={{ display: 'flex', gap: 10, paddingTop: 4 }}>

--- a/apps/web/app/actions/hypervisors.ts
+++ b/apps/web/app/actions/hypervisors.ts
@@ -2,8 +2,8 @@
 
 import { revalidatePath } from 'next/cache'
 import { getDb, hypervisorIntegrations, hypervisorTargets, eq } from '@backupos/db'
-import { ProxmoxHypervisorDriver, XCPNGHypervisorDriver, VMwareHypervisorDriver } from '@backupos/hypervisors'
-import type { ProxmoxConfig, XCPNGConfig, VMwareConfig } from '@backupos/hypervisors'
+import { ProxmoxHypervisorDriver, VMwareHypervisorDriver } from '@backupos/hypervisors'
+import type { ProxmoxConfig, VMwareConfig } from '@backupos/hypervisors'
 import { requireAdmin } from '@/lib/user'
 
 type DiscoverResult = { ok: boolean; count?: number; error?: string }
@@ -57,18 +57,44 @@ export async function discoverHypervisorTargets(integrationId: string): Promise<
         lastSeenAt:   now,
       }))
     } else if (integration.type === 'xcpng') {
-      const driver  = new XCPNGHypervisorDriver(config as XCPNGConfig)
-      const targets = await driver.listTargets()
-      rows = targets.map(x => ({
-        id:           crypto.randomUUID(),
-        integrationId,
-        externalId:   x.uuid,
-        name:         x.name,
-        type:         'xcpng_vm',
-        node:         x.node,
-        status:       x.status,
-        lastSeenAt:   now,
-      }))
+      const cfg = config as { host: string; username: string; password: string; cert_fingerprint_sha256?: string }
+      const xcpURL = process.env.BACKUPOS_XCP_URL
+      if (!xcpURL) throw new Error('BACKUPOS_XCP_URL not configured')
+      const secret = process.env.BACKUPOS_INTERNAL_SECRET
+      if (!secret) throw new Error('BACKUPOS_INTERNAL_SECRET not configured')
+      const res = await fetch(`${xcpURL}/internal/inventory`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${secret}`,
+        },
+        body: JSON.stringify({
+          pool_master_url:          cfg.host,
+          username:                 cfg.username,
+          password:                 cfg.password,
+          cert_fingerprint_sha256:  cfg.cert_fingerprint_sha256 ?? '',
+        }),
+      })
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => ({ error: 'unknown error' })) as { error?: string }
+        throw new Error(errBody.error ?? `XCP inventory HTTP ${res.status}`)
+      }
+      type XCPDisk = { uuid: string; name_label: string; virtual_size: number; type: string; cbt_enabled: boolean; user_device: string; bootable: boolean }
+      type XCPVM  = { uuid: string; name_label: string; power_state: string; is_template: boolean; is_control_domain: boolean; disks: XCPDisk[] }
+      const inv = await res.json() as { pool_uuid: string; pool_name: string; host_count: number; vms: XCPVM[] }
+      rows = inv.vms
+        .filter(vm => !vm.is_template && !vm.is_control_domain)
+        .map(vm => ({
+          id:           crypto.randomUUID(),
+          integrationId,
+          externalId:   vm.uuid,
+          name:         vm.name_label,
+          type:         'xcpng_vm',
+          node:         inv.pool_name,
+          status:       vm.power_state.toLowerCase(),
+          tags:         JSON.stringify({ disks: vm.disks }),
+          lastSeenAt:   now,
+        }))
     } else if (integration.type === 'vmware') {
       const driver  = new VMwareHypervisorDriver(config as VMwareConfig)
       const targets = await driver.listTargets()

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -36,9 +36,10 @@ const NAV: NavGroup[] = [
   {
     label: 'Infrastructure',
     items: [
-      { href: '/agents',       label: 'Agents',       icon: <Server size={15} /> },
+      { href: '/agents',       label: 'Agents',       icon: <Server   size={15} /> },
       { href: '/repositories', label: 'Repositories', icon: <Database size={15} /> },
-      { href: '/monitors',     label: 'Monitors',     icon: <Radar size={15} /> },
+      { href: '/monitors',     label: 'Monitors',     icon: <Radar    size={15} /> },
+      { href: '/hypervisors',  label: 'Hypervisors',  icon: <HardDrive size={15} /> },
     ],
   },
   {
@@ -47,14 +48,6 @@ const NAV: NavGroup[] = [
       { href: '/pbs/connect', label: 'Connect',    icon: <PlugZap   size={15} /> },
       { href: '/pbs',         label: 'Datastores', icon: <HardDrive size={15} /> },
       { href: '/pbs/tokens',  label: 'Tokens',     icon: <KeyRound  size={15} /> },
-    ],
-  },
-  {
-    label: 'XCP-NG',
-    items: [
-      { href: '/xcp-ng/connect', label: 'Connect', icon: <PlugZap   size={15} /> },
-      { href: '/xcp-ng/pools',   label: 'Pools',   icon: <Server    size={15} /> },
-      { href: '/xcp-ng/vms',     label: 'VMs',     icon: <HardDrive size={15} /> },
     ],
   },
   {

--- a/scripts/server-install.sh
+++ b/scripts/server-install.sh
@@ -429,6 +429,14 @@ if ! grep -q '^BACKUPOS_INTERNAL_URL=' "$ENV_FILE" 2>/dev/null; then
   echo "BACKUPOS_INTERNAL_URL=http://127.0.0.1:3093" >> "$ENV_FILE"
   echo "[backupos] Set BACKUPOS_INTERNAL_URL"
 fi
+if ! grep -q '^BACKUPOS_XCP_URL=' "$ENV_FILE" 2>/dev/null; then
+  echo "BACKUPOS_XCP_URL=https://127.0.0.1:8009" >> "$ENV_FILE"
+  echo "[backupos] Set BACKUPOS_XCP_URL"
+fi
+if ! grep -q '^NODE_EXTRA_CA_CERTS=' "$ENV_FILE" 2>/dev/null; then
+  echo "NODE_EXTRA_CA_CERTS=/var/lib/backupos/xcp/cert.pem" >> "$ENV_FILE"
+  echo "[backupos] Set NODE_EXTRA_CA_CERTS"
+fi
 
 # Heal env-file ownership for upgrades from older installs that left the
 # file as root:root. The service runs as $SVC_USER and needs write access

--- a/services/backupos-xcp/cmd/backupos-xcp/main.go
+++ b/services/backupos-xcp/cmd/backupos-xcp/main.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dariusvorster/backupos/services/backupos-xcp/internal/internalauth"
 	"github.com/dariusvorster/backupos/services/backupos-xcp/internal/nbdread"
 	"github.com/dariusvorster/backupos/services/backupos-xcp/internal/xapi"
 )
@@ -502,6 +503,7 @@ func main() {
 			respondJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 		}
 	})
+	mux.Handle("/internal/inventory", internalauth.Middleware(internalSecret, http.HandlerFunc(handleInventory)))
 	mux.HandleFunc("/", notFound)
 
 	server := &http.Server{
@@ -538,6 +540,42 @@ func main() {
 		os.Exit(1)
 	}
 	logger.Info("backupos-xcp stopped")
+}
+
+func handleInventory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		respondJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var body struct {
+		PoolMasterURL         string `json:"pool_master_url"`
+		Username              string `json:"username"`
+		Password              string `json:"password"`
+		CertFingerprintSHA256 string `json:"cert_fingerprint_sha256"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		respondJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if body.PoolMasterURL == "" || body.Username == "" || body.Password == "" {
+		respondJSONError(w, http.StatusBadRequest, "pool_master_url, username, and password required")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+	result, err := xapi.InventoryPool(ctx, xapi.PoolCredentials{
+		PoolMasterURL:         body.PoolMasterURL,
+		Username:              body.Username,
+		Password:              body.Password,
+		CertFingerprintSHA256: body.CertFingerprintSHA256,
+	})
+	if err != nil {
+		slog.Error("inventory failed", "error", err, "url", body.PoolMasterURL)
+		respondJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	respondJSON(w, http.StatusOK, result)
 }
 
 func notFound(w http.ResponseWriter, r *http.Request) {

--- a/services/backupos-xcp/internal/internalauth/internalauth.go
+++ b/services/backupos-xcp/internal/internalauth/internalauth.go
@@ -1,0 +1,35 @@
+// Package internalauth gates internal-only HTTP routes by validating an
+// Authorization: Bearer <BACKUPOS_INTERNAL_SECRET> header.
+//
+// Mirrors services/backupos-pbs/internal/internalauth — same pattern,
+// without the PBS-specific auth.Identity injection.
+package internalauth
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+)
+
+// Middleware wraps next, rejecting requests without a valid bearer token.
+// If secret is empty, every request is rejected — fail-closed.
+func Middleware(secret string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if secret == "" {
+			http.Error(w, "internal auth not configured", http.StatusServiceUnavailable)
+			return
+		}
+		gotAuth := r.Header.Get("Authorization")
+		const prefix = "Bearer "
+		if !strings.HasPrefix(gotAuth, prefix) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		got := gotAuth[len(prefix):]
+		if subtle.ConstantTimeCompare([]byte(got), []byte(secret)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/services/backupos-xcp/internal/xapi/inventory.go
+++ b/services/backupos-xcp/internal/xapi/inventory.go
@@ -1,0 +1,270 @@
+package xapi
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	xenapi "github.com/terra-farm/go-xen-api-client"
+)
+
+// PoolCredentials describes how to reach an XCP-ng pool for one inventory call.
+type PoolCredentials struct {
+	PoolMasterURL         string
+	Username              string
+	Password              string
+	CertFingerprintSHA256 string
+}
+
+// InventoryDisk is one VDI attached to a VM.
+type InventoryDisk struct {
+	UUID        string `json:"uuid"`
+	NameLabel   string `json:"name_label"`
+	VirtualSize int64  `json:"virtual_size"`
+	Type        string `json:"type"`
+	CBTEnabled  bool   `json:"cbt_enabled"`
+	UserDevice  string `json:"user_device"`
+	Bootable    bool   `json:"bootable"`
+}
+
+// InventoryVM is one VM with its disks.
+type InventoryVM struct {
+	UUID            string          `json:"uuid"`
+	NameLabel       string          `json:"name_label"`
+	PowerState      string          `json:"power_state"`
+	IsTemplate      bool            `json:"is_template"`
+	IsControlDomain bool            `json:"is_control_domain"`
+	Disks           []InventoryDisk `json:"disks"`
+}
+
+// InventoryResult is the full inventory of one pool.
+type InventoryResult struct {
+	PoolUUID  string        `json:"pool_uuid"`
+	PoolName  string        `json:"pool_name"`
+	HostCount int           `json:"host_count"`
+	VMs       []InventoryVM `json:"vms"`
+}
+
+// InventoryPool opens a short-lived XAPI session against the given pool and
+// returns its VMs with their attached VDIs. Closes the session on return.
+//
+// Uses scalar getters throughout to avoid the stale-enum issue with GetRecord
+// (XCP-ng 8.3 returns allowed_operations values unknown to the 2021-era library).
+func InventoryPool(ctx context.Context, creds PoolCredentials) (*InventoryResult, error) {
+	if creds.PoolMasterURL == "" || creds.Username == "" || creds.Password == "" {
+		return nil, errors.New("xapi: pool URL, username, and password required")
+	}
+
+	transport, err := buildInventoryTransport(creds.CertFingerprintSHA256)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: build transport: %w", err)
+	}
+
+	rawURL, err := normalizeXMLRPCURL(creds.PoolMasterURL)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: parse pool master url: %w", err)
+	}
+
+	raw, err := xenapi.NewClient(rawURL, transport)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: NewClient: %w", err)
+	}
+
+	sess, err := raw.Session.LoginWithPassword(creds.Username, creds.Password, "1.0", "backupos-xcp/inventory")
+	if err != nil {
+		return nil, fmt.Errorf("xapi: login: %w", err)
+	}
+	defer raw.Session.Logout(sess) //nolint:errcheck
+
+	// Pool info — use scalar getters, not GetRecord (stale-enum risk).
+	poolRefs, err := raw.Pool.GetAll(sess)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: pool.get_all: %w", err)
+	}
+	if len(poolRefs) == 0 {
+		return nil, errors.New("xapi: no pools found at this URL")
+	}
+	poolUUID, err := raw.Pool.GetUUID(sess, poolRefs[0])
+	if err != nil {
+		return nil, fmt.Errorf("xapi: pool.get_uuid: %w", err)
+	}
+	poolName, err := raw.Pool.GetNameLabel(sess, poolRefs[0])
+	if err != nil {
+		return nil, fmt.Errorf("xapi: pool.get_name_label: %w", err)
+	}
+
+	hostRefs, err := raw.Host.GetAll(sess)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: host.get_all: %w", err)
+	}
+
+	vmRefs, err := raw.VM.GetAll(sess)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: vm.get_all: %w", err)
+	}
+
+	out := &InventoryResult{
+		PoolUUID:  poolUUID,
+		PoolName:  poolName,
+		HostCount: len(hostRefs),
+		VMs:       make([]InventoryVM, 0, len(vmRefs)),
+	}
+
+	for _, vmRef := range vmRefs {
+		vmUUID, err := raw.VM.GetUUID(sess, vmRef)
+		if err != nil {
+			continue
+		}
+		vmName, err := raw.VM.GetNameLabel(sess, vmRef)
+		if err != nil {
+			continue
+		}
+		powerState, err := raw.VM.GetPowerState(sess, vmRef)
+		if err != nil {
+			continue
+		}
+		isTemplate, err := raw.VM.GetIsATemplate(sess, vmRef)
+		if err != nil {
+			continue
+		}
+		isControlDomain, err := raw.VM.GetIsControlDomain(sess, vmRef)
+		if err != nil {
+			continue
+		}
+		vbdRefs, err := raw.VM.GetVBDs(sess, vmRef)
+		if err != nil {
+			continue
+		}
+
+		disks := make([]InventoryDisk, 0)
+		for _, vbdRef := range vbdRefs {
+			vbdType, err := raw.VBD.GetType(sess, vbdRef)
+			if err != nil {
+				continue
+			}
+			if vbdType != xenapi.VbdTypeDisk {
+				continue
+			}
+			vdiRef, err := raw.VBD.GetVDI(sess, vbdRef)
+			if err != nil {
+				continue
+			}
+			if string(vdiRef) == "OpaqueRef:NULL" || string(vdiRef) == "" {
+				continue
+			}
+			userDevice, err := raw.VBD.GetUserDevice(sess, vbdRef)
+			if err != nil {
+				continue
+			}
+			bootable, err := raw.VBD.GetBootable(sess, vbdRef)
+			if err != nil {
+				continue
+			}
+
+			vdiUUID, err := raw.VDI.GetUUID(sess, vdiRef)
+			if err != nil {
+				continue
+			}
+			vdiName, err := raw.VDI.GetNameLabel(sess, vdiRef)
+			if err != nil {
+				continue
+			}
+			vdiVirtualSize, err := raw.VDI.GetVirtualSize(sess, vdiRef)
+			if err != nil {
+				continue
+			}
+			vdiType, err := raw.VDI.GetType(sess, vdiRef)
+			if err != nil {
+				continue
+			}
+			cbtEnabled, err := raw.VDI.GetCbtEnabled(sess, vdiRef)
+			if err != nil {
+				cbtEnabled = false
+			}
+
+			disks = append(disks, InventoryDisk{
+				UUID:        vdiUUID,
+				NameLabel:   vdiName,
+				VirtualSize: int64(vdiVirtualSize),
+				Type:        string(vdiType),
+				CBTEnabled:  cbtEnabled,
+				UserDevice:  userDevice,
+				Bootable:    bootable,
+			})
+		}
+
+		out.VMs = append(out.VMs, InventoryVM{
+			UUID:            vmUUID,
+			NameLabel:       vmName,
+			PowerState:      string(powerState),
+			IsTemplate:      isTemplate,
+			IsControlDomain: isControlDomain,
+			Disks:           disks,
+		})
+	}
+
+	return out, nil
+}
+
+// buildInventoryTransport builds an *http.Transport for a short-lived
+// inventory session. Mirrors Client.buildTransport using the shared
+// normalizeFingerprint helper from client.go.
+func buildInventoryTransport(fingerprintHex string) (*http.Transport, error) {
+	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	switch {
+	case fingerprintHex == "":
+		tlsCfg.InsecureSkipVerify = true //nolint:gosec
+	default:
+		expected, err := normalizeFingerprint(fingerprintHex)
+		if err != nil {
+			return nil, err
+		}
+		tlsCfg.InsecureSkipVerify = true // manual check below
+		tlsCfg.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			for _, raw := range rawCerts {
+				cert, parseErr := x509.ParseCertificate(raw)
+				if parseErr != nil {
+					continue
+				}
+				got := sha256.Sum256(cert.Raw)
+				if hex.EncodeToString(got[:]) == expected {
+					return nil
+				}
+			}
+			return fmt.Errorf("xapi: cert fingerprint mismatch (expected %s)", fingerprintHex)
+		}
+	}
+
+	return &http.Transport{
+		TLSClientConfig:       tlsCfg,
+		ResponseHeaderTimeout: 30 * time.Second,
+	}, nil
+}
+
+// normalizeXMLRPCURL ensures the URL has an https:// scheme and "/" path.
+// Mirrors the logic in Client.xmlrpcURL.
+func normalizeXMLRPCURL(raw string) (string, error) {
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" {
+		u.Scheme = "https"
+	}
+	if u.Path == "" || u.Path == "/" {
+		u.Path = "/"
+	}
+	return u.String(), nil
+}

--- a/services/backupos-xcp/internal/xapi/inventory.go
+++ b/services/backupos-xcp/internal/xapi/inventory.go
@@ -160,7 +160,7 @@ func InventoryPool(ctx context.Context, creds PoolCredentials) (*InventoryResult
 			if string(vdiRef) == "OpaqueRef:NULL" || string(vdiRef) == "" {
 				continue
 			}
-			userDevice, err := raw.VBD.GetUserDevice(sess, vbdRef)
+			userDevice, err := raw.VBD.GetUserdevice(sess, vbdRef)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
Phase 2 PR C1. Wires the existing hypervisor UI to actually work for XCP-ng pools.

## What's in
- `internal/xapi/inventory.go`: `InventoryPool` opens short-lived XAPI session, lists VMs+disks
- `internal/internalauth`: bearer-token middleware (mirrors backupos-pbs internalauth)
- `cmd/backupos-xcp/main.go`: POST /internal/inventory, gated by internalauth
- `app/actions/hypervisors.ts`: `discoverHypervisorTargets` implements xcpng — calls backupos-xcp via BACKUPOS_XCP_URL, populates hypervisor_targets
- `app/(dashboard)/hypervisors/new/page.tsx`: optional cert fingerprint field
- `components/sidebar.tsx`: Hypervisors entry under Infrastructure; dead /xcp-ng/* group removed
- `scripts/server-install.sh`: BACKUPOS_INTERNAL_SECRET shared with backupos-xcp; BACKUPOS_XCP_URL set on web

## Architecture
For C1 only the inventory endpoint accepts per-request pool credentials. Existing snapshot/stream/etc. routes still use startup-flag-configured pool. C2 will generalize per-request pool creds for true multi-pool support.

## Out of scope (follow-up issues)
- Hypervisor edit/delete buttons (#TBD)
- Dead /xcp-ng/* page files cleanup (#TBD)
- C2: backup execution path
- C3: job creation UI

## Verified
- All Go and TS builds/tests green
- Auth: 401 on no/wrong token, 400 on missing body, 200 on success
- Live inventory call returns pool UUID, host count, VMs including test-vm-1 with CBT-enabled disk
- End-to-end via deployed install: form submit → DB insert → Sync → backupos-xcp call → XAPI → DB insert → page renders test-vm-1 row with status running