### PR TITLE
feat(xcp): Phase 2 C2 — XCP-ng backup execution path

### DIFF
--- a/apps/web/app/(dashboard)/jobs/new/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/new/page.tsx
@@ -17,6 +17,7 @@ export default async function NewJobPage({
   const composeError        = params.composeError
 
   const db      = getDb()
+  const builtInPrefix = '00000000-0000-0000-0000-'
   const [repos, agentList, services, xcpngTargets] = await Promise.all([
     db.select().from(repositories).all(),
     db.select().from(agents).all(),
@@ -24,6 +25,9 @@ export default async function NewJobPage({
     db.select({ id: hypervisorTargets.id, name: hypervisorTargets.name, externalId: hypervisorTargets.externalId })
       .from(hypervisorTargets).where(eq(hypervisorTargets.type, 'xcpng_vm')).all(),
   ])
+
+  const builtInAgent   = agentList.find(a => a.id.startsWith(builtInPrefix))
+  const defaultAgentId = prefillSourceType === 'xcpng_vm' && builtInAgent ? builtInAgent.id : ''
 
   return (
     <div style={{ maxWidth: 640 }}>
@@ -76,14 +80,16 @@ export default async function NewJobPage({
             <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6, fontWeight: 500 }}>
               Agent
             </label>
-            <select name="agentId" style={{
+            <select name="agentId" defaultValue={defaultAgentId} style={{
               width: '100%', padding: '8px 12px',
               backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
               borderRadius: 'var(--radius-sm)', color: 'var(--fg)', fontSize: 14, outline: 'none',
             }}>
               <option value="">— Select agent —</option>
               {agentList.map(a => (
-                <option key={a.id} value={a.id}>{a.name} ({a.platform ?? 'unknown'})</option>
+                <option key={a.id} value={a.id}>
+                  {a.name} ({a.platform ?? 'unknown'}){a.id.startsWith(builtInPrefix) ? ' — recommended for VM backups' : ''}
+                </option>
               ))}
             </select>
           </div>

--- a/apps/web/app/(dashboard)/jobs/new/page.tsx
+++ b/apps/web/app/(dashboard)/jobs/new/page.tsx
@@ -1,4 +1,4 @@
-import { getDb, repositories, agents, infraOsServices } from '@backupos/db'
+import { getDb, repositories, agents, infraOsServices, hypervisorTargets, eq } from '@backupos/db'
 import { Button } from '@/components/ui/button'
 import { createJob } from '@/app/actions/jobs'
 import { SourceConfigSection } from '@/components/source-config-section'
@@ -17,10 +17,12 @@ export default async function NewJobPage({
   const composeError        = params.composeError
 
   const db      = getDb()
-  const [repos, agentList, services] = await Promise.all([
+  const [repos, agentList, services, xcpngTargets] = await Promise.all([
     db.select().from(repositories).all(),
     db.select().from(agents).all(),
     db.select().from(infraOsServices).all(),
+    db.select({ id: hypervisorTargets.id, name: hypervisorTargets.name, externalId: hypervisorTargets.externalId })
+      .from(hypervisorTargets).where(eq(hypervisorTargets.type, 'xcpng_vm')).all(),
   ])
 
   return (
@@ -67,6 +69,7 @@ export default async function NewJobPage({
           <SourceConfigSection
             defaultSourceType={prefillSourceType || 'filesystem'}
             composeError={composeError}
+            xcpngTargets={xcpngTargets}
           />
 
           <div style={{ marginBottom: 20 }}>

--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -52,6 +52,9 @@ function parseSourceConfig(sourceType: string, fd: FormData): string {
   } else if (sourceType === 'compose_project') {
     const raw = str('composeConfig')
     cfg = raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
+  } else if (sourceType === 'xcpng_vm') {
+    const targetId = (fd.get('xcpng_target_id') as string | null)?.trim() ?? ''
+    if (targetId) cfg = { targetId }
   }
 
   return JSON.stringify(cfg)

--- a/apps/web/components/source-config-section.tsx
+++ b/apps/web/components/source-config-section.tsx
@@ -9,6 +9,7 @@ const SOURCE_TYPES = [
   { value: 'database',       label: 'Database',        desc: 'PostgreSQL, MySQL, SQLite, Redis' },
   { value: 'proxmox_vm',     label: 'Proxmox VM',      desc: 'Virtual machine via Proxmox API' },
   { value: 'proxmox_lxc',    label: 'Proxmox LXC',     desc: 'Container via Proxmox API' },
+  { value: 'xcpng_vm',       label: 'XCP-ng VM',       desc: 'Virtual machine via XCP-ng / XAPI (CBT streaming)' },
   { value: 'windows_system', label: 'Windows system',  desc: 'Full system backup via VSS' },
   { value: 'nas_share',      label: 'NAS share',       desc: 'SMB or NFS share' },
 ]
@@ -312,6 +313,27 @@ function NasShareFields({ cfg }: { cfg: Cfg }) {
   )
 }
 
+function XcpngVmFields({ cfg, targets }: { cfg: Cfg; targets: Array<{ id: string; name: string; externalId: string }> }) {
+  return (
+    <div style={{ marginTop: 16 }}>
+      <label style={labelStyle}>XCP-ng VM</label>
+      {targets.length === 0 ? (
+        <div style={{ fontSize: 12, color: 'var(--fg-mute)', marginTop: 4 }}>
+          No XCP-ng VMs found.{' '}
+          <a href="/hypervisors" style={{ color: 'var(--accent)' }}>Add a hypervisor and sync.</a>
+        </div>
+      ) : (
+        <select name="xcpng_target_id" required style={inputStyle} defaultValue={(cfg.targetId as string | undefined) ?? ''}>
+          <option value="">— Select a VM —</option>
+          {targets.map(t => (
+            <option key={t.id} value={t.id}>{t.name} ({t.externalId.slice(0, 8)})</option>
+          ))}
+        </select>
+      )}
+    </div>
+  )
+}
+
 function WindowsFields({ cfg }: { cfg: Cfg }) {
   return (
     <div style={{ marginTop: 16 }}>
@@ -334,10 +356,12 @@ export function SourceConfigSection({
   defaultSourceType,
   initialConfig,
   composeError,
+  xcpngTargets = [],
 }: {
   defaultSourceType?: string
   initialConfig?: string
   composeError?: string
+  xcpngTargets?: Array<{ id: string; name: string; externalId: string }>
 }) {
   const cfg: Cfg = (() => {
     try { return JSON.parse(initialConfig ?? '{}') as Cfg } catch { return {} }
@@ -437,6 +461,7 @@ export function SourceConfigSection({
         {selected === 'database'       && <DatabaseFields cfg={cfg} detected={detected} />}
         {selected === 'proxmox_vm'     && <ProxmoxFields label="VM" cfg={cfg} />}
         {selected === 'proxmox_lxc'    && <ProxmoxFields label="LXC" cfg={cfg} />}
+        {selected === 'xcpng_vm'       && <XcpngVmFields cfg={cfg} targets={xcpngTargets} />}
         {selected === 'windows_system' && <WindowsFields cfg={cfg} />}
         {selected === 'nas_share'      && <NasShareFields cfg={cfg} />}
       </div>

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -1,6 +1,6 @@
 import * as cron from 'node-cron'
 import { parseExpression } from 'cron-parser'
-import { getDb, backupJobs, backupRuns, repositories, agents, backupMonitors, verificationTests, backupDefaults, bandwidthProfiles, bandwidthRules, eq, and, or, lt, lte, gte, isNotNull, isNull } from '@backupos/db'
+import { getDb, backupJobs, backupRuns, repositories, agents, backupMonitors, verificationTests, backupDefaults, bandwidthProfiles, bandwidthRules, hypervisorTargets, hypervisorIntegrations, eq, and, or, lt, lte, gte, isNotNull, isNull } from '@backupos/db'
 import { decryptField } from './repo-crypto'
 import { sendAlert } from './alerts'
 import { dispatch, connectedAgentIds } from './ws-state'
@@ -151,6 +151,72 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
       jobId:              job.id,
       runId,
       config:             composeConfig,
+      repoId:             job.repositoryId ?? '',
+      repoUrl:            cfg['repositoryUrl'] ?? '',
+      repoPassword:       password,
+      envVars:            cfg,
+      bandwidthLimitKbps,
+    }
+  } else if (job.sourceType === 'xcpng_vm') {
+    const srcConfig = JSON.parse(job.sourceConfig) as { targetId?: string }
+    const [target] = await db.select().from(hypervisorTargets)
+      .where(eq(hypervisorTargets.id, srcConfig.targetId ?? '')).limit(1)
+    if (!target) {
+      await db.update(backupRuns).set({
+        status: 'failed', completedAt: now,
+        errorMessage: `hypervisor target ${srcConfig.targetId ?? '(unset)'} not found`,
+      }).where(eq(backupRuns.id, runId))
+      return false
+    }
+    const [integration] = await db.select().from(hypervisorIntegrations)
+      .where(eq(hypervisorIntegrations.id, target.integrationId ?? '')).limit(1)
+    if (!integration) {
+      await db.update(backupRuns).set({
+        status: 'failed', completedAt: now,
+        errorMessage: `hypervisor integration ${target.integrationId ?? '(unset)'} not found`,
+      }).where(eq(backupRuns.id, runId))
+      return false
+    }
+    const xcpServiceUrl    = process.env['BACKUPOS_XCP_URL']
+    const internalSecret   = process.env['BACKUPOS_INTERNAL_SECRET']
+    if (!xcpServiceUrl || !internalSecret) {
+      await db.update(backupRuns).set({
+        status: 'failed', completedAt: now,
+        errorMessage: 'BACKUPOS_XCP_URL or BACKUPOS_INTERNAL_SECRET not set on server',
+      }).where(eq(backupRuns.id, runId))
+      return false
+    }
+    const integrationConfig = JSON.parse(integration.config) as Record<string, string>
+    const tagsData = JSON.parse(target.tags ?? '{}') as {
+      disks?: Array<{ uuid: string; name_label: string; virtual_size: number; user_device: string; bootable: boolean }>
+    }
+    const poolMasterUrl = (integrationConfig['host'] ?? '').startsWith('http')
+      ? (integrationConfig['host'] ?? '')
+      : `https://${integrationConfig['host'] ?? ''}${integrationConfig['port'] ? `:${integrationConfig['port']}` : ''}`
+    msg = {
+      type:  'run_xcp_backup',
+      jobId: job.id,
+      runId,
+      pool: {
+        masterUrl:             poolMasterUrl,
+        username:              integrationConfig['username'] ?? '',
+        password:              integrationConfig['password'] ?? '',
+        certFingerprintSha256: integrationConfig['cert_fingerprint_sha256'] ?? '',
+      },
+      xcp: { serviceUrl: xcpServiceUrl, bearerToken: internalSecret },
+      target: {
+        vmUUID:   target.externalId,
+        vmName:   target.name,
+        poolUUID: '',
+        hostFqdn: (() => { try { return new URL(poolMasterUrl).hostname } catch { return poolMasterUrl } })(),
+        disks: (tagsData.disks ?? []).map(d => ({
+          vdiUUID:     d.uuid,
+          vdiName:     d.name_label,
+          virtualSize: d.virtual_size,
+          userDevice:  d.user_device,
+          bootable:    d.bootable,
+        })),
+      },
       repoId:             job.repositoryId ?? '',
       repoUrl:            cfg['repositoryUrl'] ?? '',
       repoPassword:       password,

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -188,6 +188,38 @@ export type ServerMessage =
   | { type: 'force_update' }
   | { type: 'list_compose_project'; requestId: string; projectName: string }
   | { type: 'run_compose_backup'; jobId: string; runId: string; config: ComposeProjectConfig; repoId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; bandwidthLimitKbps?: number | null }
+  | { type: 'run_xcp_backup'
+      jobId:   string
+      runId:   string
+      pool: {
+        masterUrl:             string
+        username:              string
+        password:              string
+        certFingerprintSha256: string
+      }
+      xcp: {
+        serviceUrl:  string
+        bearerToken: string
+      }
+      target: {
+        vmUUID:   string
+        vmName:   string
+        poolUUID: string
+        hostFqdn: string
+        disks: Array<{
+          vdiUUID:     string
+          vdiName:     string
+          virtualSize: number
+          userDevice:  string
+          bootable:    boolean
+        }>
+      }
+      repoId:               string
+      repoUrl:              string
+      repoPassword:         string
+      envVars?:             Record<string, string>
+      bandwidthLimitKbps?:  number | null
+    }
   | { type: 'run_compose_restore'; jobId: string; runId: string; repoId: string; config: ComposeRestoreConfig; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
   | { type: 'mount_repository'; requestId: string; repoId: string; nfsServer: string; nfsExport: string; nfsOptions: string }
   | { type: 'run_verification'; verificationRunId: string; repoId: string; snapshotId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; targetType: 'temp_directory' | 'docker_volume' | 'ssh_target' | 'proxmox_vm_clone' | 'xcpng_vm'; targetConfig?: SshVerificationTargetConfig; validationHook?: string | null }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -257,6 +257,12 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
       await runComposeBackup(msg, send, activeJobs, BINARY, ensureRepoInitialized)
     })()
 
+  } else if (msg.type === 'run_xcp_backup') {
+    void (async () => {
+      const { runXcpngBackup } = await import('./handlers/xcpngBackup')
+      await runXcpngBackup(msg, send, activeJobs, BINARY, ensureRepoInitialized)
+    })()
+
   } else if (msg.type === 'run_compose_restore') {
     void (async () => {
       const { runComposeRestore } = await import('./handlers/composeRestore')

--- a/packages/agent/src/handlers/xcpngBackup.ts
+++ b/packages/agent/src/handlers/xcpngBackup.ts
@@ -1,0 +1,211 @@
+import * as https from 'node:https'
+import { ResticEngine } from '@backupos/engine'
+import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
+
+type SendFn = (msg: AgentMessage) => void
+type RunMsg = Extract<ServerMessage, { type: 'run_xcp_backup' }>
+type EnsureRepoFn = (engine: ResticEngine, repoId: string) => Promise<void>
+
+interface ActiveJobRef {
+  ctrl: AbortController
+  runId: string
+  phase: string
+  lastResticEventAt: number
+  cancelled: boolean
+}
+
+async function xcpRequest(opts: {
+  method: 'GET' | 'POST' | 'DELETE'
+  path: string
+  xcpBase: string
+  bearerToken: string
+  pool: RunMsg['pool']
+  body?: object
+}): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(opts.xcpBase + opts.path)
+    const poolHeaders: Record<string, string> = opts.method !== 'POST' ? {
+      'X-XAPI-Pool-Master-URL':         opts.pool.masterUrl,
+      'X-XAPI-Username':                opts.pool.username,
+      'X-XAPI-Password':                opts.pool.password,
+      'X-XAPI-Cert-Fingerprint-SHA256': opts.pool.certFingerprintSha256,
+    } : {}
+    const req = https.request({
+      hostname:           url.hostname,
+      port:               url.port ? parseInt(url.port) : 443,
+      path:               url.pathname + url.search,
+      method:             opts.method,
+      rejectUnauthorized: false, // self-signed cert; bearer token provides auth. TODO: proper pinning
+      headers: {
+        'Content-Type':  'application/json',
+        'Authorization': `Bearer ${opts.bearerToken}`,
+        ...poolHeaders,
+      },
+    }, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', (c: Buffer) => chunks.push(c))
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') }))
+    })
+    req.on('error', reject)
+    if (opts.body) req.end(JSON.stringify(opts.body))
+    else req.end()
+  })
+}
+
+export async function runXcpngBackup(
+  msg: RunMsg,
+  send: SendFn,
+  activeJobs: Map<string, ActiveJobRef>,
+  binaryPath: string | undefined,
+  ensureRepo: EnsureRepoFn,
+): Promise<void> {
+  const { jobId, pool, xcp, target, repoId, repoUrl, repoPassword, envVars, bandwidthLimitKbps } = msg
+  const ctrl      = new AbortController()
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+
+  activeJobs.set(jobId, { ctrl, runId: msg.runId, phase: 'starting', lastResticEventAt: Date.now(), cancelled: false })
+
+  const setPhase = (phase: string) => {
+    const j = activeJobs.get(jobId)
+    if (j) { j.phase = phase; j.lastResticEventAt = Date.now() }
+  }
+
+  const engine = new ResticEngine({
+    repositoryUrl:      repoUrl,
+    password:           repoPassword,
+    envVars:            envVars ?? {},
+    binaryPath,
+    bandwidthLimitKbps: bandwidthLimitKbps ?? undefined,
+  })
+
+  const xcpBase = xcp.serviceUrl.replace(/\/$/, '')
+
+  const snapshotIds: string[] = []
+  const agg = { filesNew: 0, filesChanged: 0, filesUnmodified: 0, dataAdded: 0, totalSize: 0, durationMs: 0 }
+  const logLines: string[] = []
+  const log = (line: string) => logLines.push(`[${new Date().toISOString()}] ${line}`)
+
+  try {
+    await ensureRepo(engine, repoId)
+
+    for (const disk of target.disks) {
+      if (ctrl.signal.aborted) throw new Error('cancelled')
+      log(`disk ${disk.vdiName} (${disk.vdiUUID}, ${disk.virtualSize} bytes, position ${disk.userDevice})`)
+
+      // 1. Take snapshot
+      setPhase(`snapshot:${disk.userDevice}`)
+      const snapResp = await xcpRequest({
+        method: 'POST', path: '/api2/json/snapshot',
+        xcpBase, bearerToken: xcp.bearerToken, pool,
+        body: {
+          pool_master_url:         pool.masterUrl,
+          username:                pool.username,
+          password:                pool.password,
+          cert_fingerprint_sha256: pool.certFingerprintSha256,
+          source_uuid:             disk.vdiUUID,
+          name_label:              `backupos-${jobId.slice(0, 8)}-${disk.userDevice}-${timestamp}`,
+        },
+      })
+      if (snapResp.status !== 200) throw new Error(`snapshot failed (${snapResp.status}): ${snapResp.body}`)
+      const snap = JSON.parse(snapResp.body) as { uuid: string; name_label: string; cbt_enabled: boolean }
+      log(`snapshot taken: ${snap.uuid} (cbt_enabled=${snap.cbt_enabled})`)
+
+      try {
+        // 2. Open stream
+        setPhase(`stream:${disk.userDevice}`)
+        const streamUrl = new URL(`${xcpBase}/api2/json/snapshot/${snap.uuid}/stream`)
+        const streamRes = await new Promise<import('http').IncomingMessage>((resolve, reject) => {
+          const req = https.request({
+            hostname:           streamUrl.hostname,
+            port:               streamUrl.port ? parseInt(streamUrl.port) : 443,
+            path:               streamUrl.pathname,
+            method:             'GET',
+            rejectUnauthorized: false,
+            headers: {
+              'Authorization':                  `Bearer ${xcp.bearerToken}`,
+              'X-XAPI-Pool-Master-URL':         pool.masterUrl,
+              'X-XAPI-Username':                pool.username,
+              'X-XAPI-Password':                pool.password,
+              'X-XAPI-Cert-Fingerprint-SHA256': pool.certFingerprintSha256,
+            },
+          })
+          req.once('response', resolve)
+          req.once('error', reject)
+          req.end()
+        })
+        if (streamRes.statusCode !== 200) {
+          let errBody = ''
+          streamRes.setEncoding('utf8')
+          for await (const chunk of streamRes) errBody += chunk as string
+          throw new Error(`stream failed (${streamRes.statusCode}): ${errBody}`)
+        }
+
+        // 3. Pipe to restic
+        setPhase(`restic:${disk.userDevice}`)
+        const result = await engine.backupFromStream({
+          stream:        streamRes,
+          stdinFilename: `${target.vmName}-${disk.userDevice}.img`,
+          tags: [
+            `xcp:pool=${target.poolUUID}`,
+            `xcp:host=${target.hostFqdn}`,
+            `xcp:vm=${target.vmUUID}`,
+            `xcp:vdi=${disk.vdiUUID}`,
+            `xcp:snapshot=${snap.uuid}`,
+            `xcp:user_device=${disk.userDevice}`,
+            `xcp:job=${jobId}`,
+          ],
+          signal: ctrl.signal,
+        })
+        snapshotIds.push(result.snapshotId)
+        agg.filesNew        += result.filesNew
+        agg.filesChanged    += result.filesChanged
+        agg.filesUnmodified += result.filesUnmodified
+        agg.dataAdded       += result.dataAdded
+        agg.totalSize       += result.totalSize
+        agg.durationMs      += result.duration
+        log(`disk ${disk.userDevice} done: restic snapshot ${result.snapshotId}, +${result.dataAdded} bytes`)
+
+      } finally {
+        // 4. Always destroy snapshot — don't fail the run on destroy failure
+        setPhase(`destroy:${disk.userDevice}`)
+        const destResp = await xcpRequest({
+          method: 'DELETE', path: `/api2/json/snapshot/${snap.uuid}?mode=destroy`,
+          xcpBase, bearerToken: xcp.bearerToken, pool,
+        }).catch((e: unknown) => ({ status: 0, body: String(e) }))
+        if (destResp.status !== 200) {
+          log(`WARN: snapshot destroy failed (${destResp.status}): ${destResp.body}`)
+        }
+      }
+    }
+
+    send({
+      type:       'backup_complete',
+      jobId,
+      snapshotId: snapshotIds[0] ?? '',
+      snapshotIds,
+      stats: {
+        filesNew:            agg.filesNew,
+        filesChanged:        agg.filesChanged,
+        filesUnmodified:     agg.filesUnmodified,
+        dataAdded:           agg.dataAdded,
+        totalFilesProcessed: agg.filesNew + agg.filesChanged + agg.filesUnmodified,
+        totalBytesProcessed: agg.totalSize,
+        durationMs:          agg.durationMs,
+      },
+      log: logLines.join('\n').slice(0, 1_000_000) || undefined,
+    })
+
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err)
+    log(`FAIL: ${errMsg}`)
+    send({
+      type:   'backup_failed',
+      jobId,
+      error:  errMsg,
+      detail: err instanceof Error && err.stack ? err.stack : '',
+      log:    logLines.join('\n').slice(0, 1_000_000) || undefined,
+    })
+  } finally {
+    activeJobs.delete(jobId)
+  }
+}

--- a/scripts/server-install.sh
+++ b/scripts/server-install.sh
@@ -620,6 +620,95 @@ else
   log "Service $SERVICE_NAME-xcp may have failed. Check:  journalctl -u $SERVICE_NAME-xcp -n 50"
 fi
 
+# ── 9. Built-in BackupOS server agent ────────────────────────────────────────
+# A local agent instance running on this server.
+# Used as the recommended agent for xcpng_vm jobs — VM disk streams are piped
+# through the XCP service which runs here, so the agent must be co-located.
+
+AGENT_DIR=/opt/backupos-agent
+AGENT_SERVICE=backupos-agent
+AGENT_ENV_FILE="$AGENT_DIR/.env"
+NODE_BIN="$(command -v node)"
+DB_PATH="$DATA_DIR/backupos.db"
+
+# Ensure sqlite3 is available for the DB enrollment step
+if ! command -v sqlite3 &>/dev/null; then
+  if command -v apt-get &>/dev/null; then apt-get install -y sqlite3
+  elif command -v yum &>/dev/null; then yum install -y sqlite; fi
+fi
+
+mkdir -p "$AGENT_DIR"
+chown "$SVC_USER:$SVC_USER" "$AGENT_DIR"
+
+cp "$INSTALL_DIR/apps/web/public/agent/bundle.js" "$AGENT_DIR/agent.js"
+chown "$SVC_USER:$SVC_USER" "$AGENT_DIR/agent.js"
+
+# Stable ID: 00000000-0000-0000-0000-<first 12 hex chars of sha256(machine-id)>
+MACHINE_ID="$(cat /etc/machine-id 2>/dev/null || hostname)"
+AGENT_SUFFIX="$(printf '%s' "$MACHINE_ID" | sha256sum | cut -c1-12)"
+BUILTIN_AGENT_ID="00000000-0000-0000-0000-${AGENT_SUFFIX}"
+
+EXISTING="$(sqlite3 "$DB_PATH" "SELECT id FROM agents WHERE id='${BUILTIN_AGENT_ID}';" 2>/dev/null || true)"
+if [[ -z "$EXISTING" ]]; then
+  AGENT_TOKEN="$(openssl rand -hex 32)"
+  NOW_MS="$(date +%s)000"
+  sqlite3 "$DB_PATH" \
+    "INSERT INTO agents (id, name, status, platform, public_key, enrolled_at) \
+     VALUES ('${BUILTIN_AGENT_ID}', 'BackupOS Server (built-in)', 'disconnected', 'linux', '${AGENT_TOKEN}', ${NOW_MS});"
+  log "Enrolled built-in agent ${BUILTIN_AGENT_ID}"
+else
+  AGENT_TOKEN="$(sqlite3 "$DB_PATH" "SELECT public_key FROM agents WHERE id='${BUILTIN_AGENT_ID}';")"
+  log "Built-in agent already enrolled"
+fi
+
+cat > "$AGENT_ENV_FILE" <<AGENTENV
+BACKUPOS_URL=ws://127.0.0.1:${PORT}
+BACKUPOS_TOKEN=${AGENT_TOKEN}
+RESTIC_BINARY_PATH=${RESTIC_BIN}
+AGENTENV
+chmod 600 "$AGENT_ENV_FILE"
+chown "$SVC_USER:$SVC_USER" "$AGENT_ENV_FILE"
+
+cat > /etc/systemd/system/${AGENT_SERVICE}.service <<AGENTSVCEOF
+[Unit]
+Description=BackupOS Agent (built-in server agent)
+After=network-online.target ${SERVICE_NAME}.service
+Requires=${SERVICE_NAME}.service
+
+[Service]
+Type=simple
+User=$SVC_USER
+Group=$SVC_USER
+WorkingDirectory=$AGENT_DIR
+EnvironmentFile=$AGENT_ENV_FILE
+ExecStart=${NODE_BIN} ${AGENT_DIR}/agent.js
+Restart=on-failure
+RestartSec=10
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=full
+ReadWritePaths=$DATA_DIR
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=$AGENT_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+AGENTSVCEOF
+
+systemctl daemon-reload
+systemctl enable "$AGENT_SERVICE"
+systemctl restart "$AGENT_SERVICE"
+
+sleep 1
+if systemctl is-active --quiet "$AGENT_SERVICE"; then
+  ok "Service $AGENT_SERVICE started"
+else
+  log "Service $AGENT_SERVICE may have failed. Check:  journalctl -u $AGENT_SERVICE -n 50"
+fi
+
 # ── Done ──────────────────────────────────────────────────────────────────────
 PUBLIC_URL_ACTUAL="$(grep '^BETTER_AUTH_URL=' "$ENV_FILE" | cut -d= -f2-)"
 
@@ -633,7 +722,8 @@ echo "  XCP service:  https://<host>:8009/api2/json/version"
 echo "  Logs (web):   journalctl -u $SERVICE_NAME -f"
 echo "  Logs (pbs):   journalctl -u $SERVICE_NAME-pbs -f"
 echo "  Logs (xcp):   journalctl -u $SERVICE_NAME-xcp -f"
-echo "  Status:       systemctl status $SERVICE_NAME $SERVICE_NAME-pbs $SERVICE_NAME-xcp"
+echo "  Logs (agent): journalctl -u $AGENT_SERVICE -f"
+echo "  Status:       systemctl status $SERVICE_NAME $SERVICE_NAME-pbs $SERVICE_NAME-xcp $AGENT_SERVICE"
 echo "  Config:       $ENV_FILE"
 echo "  Data:         $DATA_DIR"
 echo ""

--- a/services/backupos-xcp/cmd/backupos-xcp/main.go
+++ b/services/backupos-xcp/cmd/backupos-xcp/main.go
@@ -159,7 +159,7 @@ func main() {
 		}
 		ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 		defer cancel()
-		var regions []xapi.Region
+		var regions []xapi.ChangedRegion
 		if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
 			var err error
 			regions, err = c.ChangedRegions(ctx, fromUUID, toUUID)

--- a/services/backupos-xcp/cmd/backupos-xcp/main.go
+++ b/services/backupos-xcp/cmd/backupos-xcp/main.go
@@ -7,6 +7,8 @@
 //
 // Endpoints:
 //   - GET /api2/json/version  unauthenticated, 200 JSON
+//   - All other /api2/json/* routes require Authorization: Bearer <BACKUPOS_INTERNAL_SECRET>
+//   - POST /internal/inventory requires the same bearer token
 package main
 
 import (
@@ -50,35 +52,47 @@ func respondJSONError(w http.ResponseWriter, status int, msg string) {
 	respondJSON(w, status, map[string]string{"error": msg})
 }
 
+// extractGetCreds reads per-request pool credentials from request headers.
+// Used by GET and DELETE handlers.
+func extractGetCreds(r *http.Request) xapi.PerRequestCredentials {
+	return xapi.PerRequestCredentials{
+		PoolMasterURL:         r.Header.Get("X-XAPI-Pool-Master-URL"),
+		Username:              r.Header.Get("X-XAPI-Username"),
+		Password:              r.Header.Get("X-XAPI-Password"),
+		CertFingerprintSHA256: r.Header.Get("X-XAPI-Cert-Fingerprint-SHA256"),
+	}
+}
+
 func main() {
 	var (
 		bind     = flag.String("bind", "0.0.0.0:8009", "address:port to listen on")
 		certPath = flag.String("cert", "/var/lib/backupos/xcp/cert.pem", "TLS certificate path")
 		keyPath  = flag.String("key", "/var/lib/backupos/xcp/key.pem", "TLS private key path")
-		dbPath   = flag.String("db", "/var/lib/backupos/backupos.db", "SQLite database path")
+		dbPath   = flag.String("db", "/var/lib/backupos/backupos.db", "SQLite database path (unused)")
 
-		// XAPI connection flags. If xapiURL is empty, the service starts but
-		// XAPI features are disabled — useful for the placeholder Phase 1 deploy.
-		xapiURL      = flag.String("xapi-url", "", "XAPI pool master URL (e.g. https://192.168.69.2)")
-		xapiUser     = flag.String("xapi-user", "root", "XAPI username")
-		xapiPass     = flag.String("xapi-pass", "", "XAPI password (or set BACKUPOS_XCP_PASS env var)")
-		xapiFP       = flag.String("xapi-cert-fingerprint", "", "XAPI host TLS cert SHA256 fingerprint (optional)")
-		xapiInsecure = flag.Bool("xapi-insecure", false, "Disable TLS verification for XAPI (dev only)")
+		// Deprecated startup XAPI flags — kept so existing install.sh ExecStart lines
+		// don't break. Pool credentials are now per-request on every handler.
+		xapiURL  = flag.String("xapi-url",              "", "deprecated: pool master URL (now per-request)")
+		xapiUser = flag.String("xapi-user",             "root", "deprecated: XAPI username (now per-request)")
+		xapiPass = flag.String("xapi-pass",             "", "deprecated: XAPI password (now per-request)")
+		xapiFP   = flag.String("xapi-cert-fingerprint", "", "deprecated: cert fingerprint (now per-request)")
+		_        = flag.Bool("xapi-insecure",            false, "deprecated")
+
 		readOutputDir = flag.String("read-output-dir", "/var/lib/backupos/xcp-reads",
 			"directory under which /api2/json/snapshot/{uuid}/read can write files")
 	)
 	flag.Parse()
 
-	// Password can also come from env var (preferred for systemd EnvironmentFile).
-	if *xapiPass == "" {
-		*xapiPass = os.Getenv("BACKUPOS_XCP_PASS")
+	_ = dbPath
+	_ = *xapiUser
+	_ = *xapiPass
+
+	if *xapiURL != "" || *xapiFP != "" {
+		slog.Warn("startup XAPI flags are deprecated and ignored; pool credentials are now per-request",
+			"deprecated_flags", []string{"--xapi-url", "--xapi-user", "--xapi-pass", "--xapi-cert-fingerprint"})
 	}
 
-	_ = dbPath // reserved for future use
-
-	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
 
 	absReadDir, readDirErr := filepath.Abs(*readOutputDir)
@@ -98,12 +112,9 @@ func main() {
 		"bind", *bind,
 	)
 
-	internalURL := os.Getenv("BACKUPOS_INTERNAL_URL")
 	internalSecret := os.Getenv("BACKUPOS_INTERNAL_SECRET")
-	if internalURL == "" || internalSecret == "" {
-		slog.Warn("BACKUPOS_INTERNAL_URL or BACKUPOS_INTERNAL_SECRET not set; XCP alerts will not fire")
-	} else {
-		slog.Info("internal webhook configured", "url", internalURL)
+	if internalSecret == "" {
+		slog.Warn("BACKUPOS_INTERNAL_SECRET not set; all authenticated routes will return 503")
 	}
 
 	cert, err := tls.LoadX509KeyPair(*certPath, *keyPath)
@@ -112,168 +123,77 @@ func main() {
 		os.Exit(1)
 	}
 
-	// serverCtx is the parent context for all incoming HTTP request contexts
-	// (via http.Server.BaseContext). Cancelled on SIGINT/SIGTERM so in-flight
-	// requests can react to shutdown. Phase 2 will also use serverCtx to stop
-	// background goroutines (XAPI session reaper, CBT chain GC scheduler).
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	defer serverCancel()
 
-	var xapiClient *xapi.Client
-	if *xapiURL != "" {
-		cfg := xapi.Config{
-			PoolMasterURL:      *xapiURL,
-			Username:           *xapiUser,
-			Password:           *xapiPass,
-			CertFingerprint:    *xapiFP,
-			InsecureSkipVerify: *xapiInsecure,
-		}
-		xc, err := xapi.New(cfg, logger)
-		if err != nil {
-			logger.Error("xapi: invalid config", "error", err)
-			os.Exit(1)
-		}
-		if err := xc.Connect(serverCtx); err != nil {
-			logger.Error("xapi: initial connect failed", "error", err)
-			// Non-fatal: service still starts, but XAPI endpoints will return 503.
-		} else {
-			xapiClient = xc
-			defer xapiClient.Close() //nolint:gocritic
-		}
-	} else {
-		logger.Warn("xapi-url not set; XAPI endpoints will return 503")
-	}
+	// apiMux handles all authenticated /api2/json/* routes.
+	// /api2/json/version is registered on the main mux without auth.
+	apiMux := http.NewServeMux()
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api2/json/version", func(w http.ResponseWriter, r *http.Request) {
-		slog.Info("version",
-			"method", r.Method,
-			"path",   r.URL.Path,
-			"remote", r.RemoteAddr,
-		)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		resp := map[string]string{
-			"version": versionString,
-			"release": releaseString,
-			"repoID":  repoIDString,
-		}
-		_ = json.NewEncoder(w).Encode(resp)
-	})
-	mux.HandleFunc("/api2/json/pool", func(w http.ResponseWriter, r *http.Request) {
-		slog.Info("pool",
-			"method", r.Method,
-			"path",   r.URL.Path,
-			"remote", r.RemoteAddr,
-		)
-
-		if xapiClient == nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusServiceUnavailable)
-			_ = json.NewEncoder(w).Encode(map[string]string{
-				"error": "xapi client not configured",
-			})
-			return
-		}
-
+	apiMux.HandleFunc("/api2/json/pool", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("pool", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+		creds := extractGetCreds(r)
 		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 		defer cancel()
-
-		uuid, name, err := xapiClient.PoolName(ctx)
-		if err != nil {
+		var poolUUID, poolName string
+		if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
+			var err error
+			poolUUID, poolName, err = c.PoolName(ctx)
+			return err
+		}); err != nil {
 			slog.Error("pool query failed", "error", err)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadGateway)
-			_ = json.NewEncoder(w).Encode(map[string]string{
-				"error": err.Error(),
-			})
+			respondJSONError(w, http.StatusBadGateway, err.Error())
 			return
 		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]string{
-			"uuid": uuid,
-			"name": name,
-		})
+		respondJSON(w, http.StatusOK, map[string]string{"uuid": poolUUID, "name": poolName})
 	})
-	mux.HandleFunc("/api2/json/changed-blocks", func(w http.ResponseWriter, r *http.Request) {
-		slog.Info("changed-blocks",
-			"method", r.Method,
-			"path",   r.URL.Path,
-			"remote", r.RemoteAddr,
-		)
 
-		if xapiClient == nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusServiceUnavailable)
-			_ = json.NewEncoder(w).Encode(map[string]string{
-				"error": "xapi client not configured",
-			})
-			return
-		}
-
+	apiMux.HandleFunc("/api2/json/changed-blocks", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("changed-blocks", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+		creds := extractGetCreds(r)
 		fromUUID := r.URL.Query().Get("from")
 		toUUID := r.URL.Query().Get("to")
 		if fromUUID == "" || toUUID == "" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			_ = json.NewEncoder(w).Encode(map[string]string{
-				"error": "from and to query parameters required",
-			})
+			respondJSONError(w, http.StatusBadRequest, "from and to query parameters required")
 			return
 		}
-
 		ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 		defer cancel()
-
-		regions, err := xapiClient.ChangedRegions(ctx, fromUUID, toUUID)
-		if err != nil {
+		var regions []xapi.Region
+		if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
+			var err error
+			regions, err = c.ChangedRegions(ctx, fromUUID, toUUID)
+			return err
+		}); err != nil {
 			slog.Error("changed-blocks query failed", "error", err, "from", fromUUID, "to", toUUID)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadGateway)
-			_ = json.NewEncoder(w).Encode(map[string]string{
-				"error": err.Error(),
-			})
+			respondJSONError(w, http.StatusBadGateway, err.Error())
 			return
 		}
-
 		var totalBytes int64
 		for _, rg := range regions {
 			totalBytes += rg.Length
 		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"from":         fromUUID,
-			"to":           toUUID,
-			"block_size":   xapi.BlockSize,
-			"region_count": len(regions),
-			"total_bytes":  totalBytes,
-			"regions":      regions,
+		respondJSON(w, http.StatusOK, map[string]any{
+			"from": fromUUID, "to": toUUID,
+			"block_size": xapi.BlockSize, "region_count": len(regions),
+			"total_bytes": totalBytes, "regions": regions,
 		})
 	})
-	mux.HandleFunc("/api2/json/snapshot", func(w http.ResponseWriter, r *http.Request) {
-		slog.Info("snapshot",
-			"method", r.Method,
-			"path", r.URL.Path,
-			"remote", r.RemoteAddr,
-		)
 
+	apiMux.HandleFunc("/api2/json/snapshot", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("snapshot", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
 		if r.Method != http.MethodPost {
 			w.Header().Set("Allow", "POST")
-			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			respondJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
-		if xapiClient == nil {
-			respondJSONError(w, http.StatusServiceUnavailable, "xapi client not configured")
-			return
-		}
-
 		var body struct {
-			SourceUUID string `json:"source_uuid"`
-			NameLabel  string `json:"name_label"`
+			PoolMasterURL         string `json:"pool_master_url"`
+			Username              string `json:"username"`
+			Password              string `json:"password"`
+			CertFingerprintSHA256 string `json:"cert_fingerprint_sha256"`
+			SourceUUID            string `json:"source_uuid"`
+			NameLabel             string `json:"name_label"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			respondJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
@@ -283,20 +203,26 @@ func main() {
 			respondJSONError(w, http.StatusBadRequest, "source_uuid required")
 			return
 		}
-
+		creds := xapi.PerRequestCredentials{
+			PoolMasterURL: body.PoolMasterURL, Username: body.Username,
+			Password: body.Password, CertFingerprintSHA256: body.CertFingerprintSHA256,
+		}
 		ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 		defer cancel()
-
-		info, err := xapiClient.Snapshot(ctx, body.SourceUUID, body.NameLabel)
-		if err != nil {
+		var snapInfo any
+		if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
+			si, err := c.Snapshot(ctx, body.SourceUUID, body.NameLabel)
+			snapInfo = si
+			return err
+		}); err != nil {
 			slog.Error("snapshot failed", "error", err, "source_uuid", body.SourceUUID)
 			respondJSONError(w, http.StatusBadGateway, err.Error())
 			return
 		}
-
-		respondJSON(w, http.StatusOK, info)
+		respondJSON(w, http.StatusOK, snapInfo)
 	})
-	mux.HandleFunc("/api2/json/snapshot/", func(w http.ResponseWriter, r *http.Request) {
+
+	apiMux.HandleFunc("/api2/json/snapshot/", func(w http.ResponseWriter, r *http.Request) {
 		suffix := strings.TrimPrefix(r.URL.Path, "/api2/json/snapshot/")
 		parts := strings.SplitN(suffix, "/", 2)
 		uuid := parts[0]
@@ -308,10 +234,6 @@ func main() {
 		switch {
 		case r.Method == http.MethodDelete && sub == "":
 			slog.Info("snapshot-delete", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
-			if xapiClient == nil {
-				respondJSONError(w, http.StatusServiceUnavailable, "xapi client not configured")
-				return
-			}
 			if uuid == "" {
 				respondJSONError(w, http.StatusBadRequest, "snapshot uuid required in path")
 				return
@@ -320,19 +242,19 @@ func main() {
 			if mode == "" {
 				mode = "destroy"
 			}
-			ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
-			defer cancel()
-			var err error
-			switch mode {
-			case "destroy":
-				err = xapiClient.DestroySnapshot(ctx, uuid)
-			case "data_destroy":
-				err = xapiClient.DataDestroySnapshot(ctx, uuid)
-			default:
+			if mode != "destroy" && mode != "data_destroy" {
 				respondJSONError(w, http.StatusBadRequest, "mode must be 'destroy' or 'data_destroy'")
 				return
 			}
-			if err != nil {
+			creds := extractGetCreds(r)
+			ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+			defer cancel()
+			if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
+				if mode == "destroy" {
+					return c.DestroySnapshot(ctx, uuid)
+				}
+				return c.DataDestroySnapshot(ctx, uuid)
+			}); err != nil {
 				slog.Error("snapshot delete failed", "error", err, "uuid", uuid, "mode", mode)
 				respondJSONError(w, http.StatusBadGateway, err.Error())
 				return
@@ -341,18 +263,19 @@ func main() {
 
 		case r.Method == http.MethodGet && sub == "nbd-info":
 			slog.Info("snapshot-nbd-info", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
-			if xapiClient == nil {
-				respondJSONError(w, http.StatusServiceUnavailable, "xapi client not configured")
-				return
-			}
 			if uuid == "" {
 				respondJSONError(w, http.StatusBadRequest, "snapshot uuid required in path")
 				return
 			}
+			creds := extractGetCreds(r)
 			ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 			defer cancel()
-			infos, err := xapiClient.SnapshotNBDInfo(ctx, uuid)
-			if err != nil {
+			var infos []xapi.NBDInfo
+			if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
+				var err error
+				infos, err = c.SnapshotNBDInfo(ctx, uuid)
+				return err
+			}); err != nil {
 				slog.Error("nbd-info query failed", "error", err, "uuid", uuid)
 				respondJSONError(w, http.StatusBadGateway, err.Error())
 				return
@@ -379,17 +302,17 @@ func main() {
 
 		case r.Method == http.MethodPost && sub == "read":
 			slog.Info("snapshot-read", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
-			if xapiClient == nil {
-				respondJSONError(w, http.StatusServiceUnavailable, "xapi client not configured")
-				return
-			}
 			if uuid == "" {
 				respondJSONError(w, http.StatusBadRequest, "snapshot uuid required in path")
 				return
 			}
 			var body struct {
-				OutputPath string          `json:"output_path"`
-				Regions    []nbdread.Region `json:"regions"`
+				PoolMasterURL         string           `json:"pool_master_url"`
+				Username              string           `json:"username"`
+				Password              string           `json:"password"`
+				CertFingerprintSHA256 string           `json:"cert_fingerprint_sha256"`
+				OutputPath            string           `json:"output_path"`
+				Regions               []nbdread.Region `json:"regions"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				respondJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -407,19 +330,27 @@ func main() {
 				respondJSONError(w, http.StatusBadRequest, "output_path must be under "+readOutputDirResolved)
 				return
 			}
+			creds := xapi.PerRequestCredentials{
+				PoolMasterURL: body.PoolMasterURL, Username: body.Username,
+				Password: body.Password, CertFingerprintSHA256: body.CertFingerprintSHA256,
+			}
 			nbdCtx, nbdCancel := context.WithTimeout(r.Context(), 30*time.Second)
 			defer nbdCancel()
-			infos, err := xapiClient.SnapshotNBDInfo(nbdCtx, uuid)
-			if err != nil {
+			var chosen xapi.NBDInfo
+			if err := xapi.WithSession(nbdCtx, creds, func(c *xapi.Client) error {
+				infos, err := c.SnapshotNBDInfo(nbdCtx, uuid)
+				if err != nil {
+					return err
+				}
+				if len(infos) == 0 {
+					return errors.New("no NBD options available for this snapshot — is NBD enabled on a network reaching this host's SR?")
+				}
+				chosen = infos[0]
+				return nil
+			}); err != nil {
 				respondJSONError(w, http.StatusBadGateway, "get_nbd_info: "+err.Error())
 				return
 			}
-			if len(infos) == 0 {
-				respondJSONError(w, http.StatusBadGateway,
-					"no NBD options available for this snapshot — is NBD enabled on a network reaching this host's SR?")
-				return
-			}
-			chosen := infos[0]
 			f, err := os.Create(body.OutputPath)
 			if err != nil {
 				respondJSONError(w, http.StatusInternalServerError, "create output: "+err.Error())
@@ -429,11 +360,8 @@ func main() {
 			readCtx, readCancel := context.WithTimeout(r.Context(), 10*time.Minute)
 			defer readCancel()
 			res, err := nbdread.ReadRegions(readCtx, nbdread.Connection{
-				Address:    chosen.Address,
-				Port:       chosen.Port,
-				ExportName: chosen.ExportName,
-				CertPEM:    chosen.CertPEM,
-				Subject:    chosen.Subject,
+				Address: chosen.Address, Port: chosen.Port,
+				ExportName: chosen.ExportName, CertPEM: chosen.CertPEM, Subject: chosen.Subject,
 			}, body.Regions, f)
 			if err != nil {
 				slog.Error("nbd read failed", "error", err, "uuid", uuid)
@@ -441,37 +369,35 @@ func main() {
 				return
 			}
 			respondJSON(w, http.StatusOK, map[string]any{
-				"uuid":         uuid,
-				"output_path":  body.OutputPath,
-				"bytes_read":   res.BytesRead,
-				"region_count": res.RegionCount,
-				"sha256":       res.SHA256Hex,
-				"duration_ms":  res.DurationMS,
+				"uuid": uuid, "output_path": body.OutputPath,
+				"bytes_read": res.BytesRead, "region_count": res.RegionCount,
+				"sha256": res.SHA256Hex, "duration_ms": res.DurationMS,
 			})
 
 		case r.Method == http.MethodGet && sub == "stream":
 			slog.Info("snapshot-stream", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
-			if xapiClient == nil {
-				respondJSONError(w, http.StatusServiceUnavailable, "xapi client not configured")
-				return
-			}
 			if uuid == "" {
 				respondJSONError(w, http.StatusBadRequest, "snapshot uuid required in path")
 				return
 			}
+			creds := extractGetCreds(r)
 			nbdCtx, nbdCancel := context.WithTimeout(r.Context(), 30*time.Second)
 			defer nbdCancel()
-			infos, err := xapiClient.SnapshotNBDInfo(nbdCtx, uuid)
-			if err != nil {
+			var chosen xapi.NBDInfo
+			if err := xapi.WithSession(nbdCtx, creds, func(c *xapi.Client) error {
+				infos, err := c.SnapshotNBDInfo(nbdCtx, uuid)
+				if err != nil {
+					return err
+				}
+				if len(infos) == 0 {
+					return errors.New("no NBD options for this snapshot — is NBD enabled on a network reaching this host's SR?")
+				}
+				chosen = infos[0]
+				return nil
+			}); err != nil {
 				respondJSONError(w, http.StatusBadGateway, "get_nbd_info: "+err.Error())
 				return
 			}
-			if len(infos) == 0 {
-				respondJSONError(w, http.StatusBadGateway,
-					"no NBD options for this snapshot — is NBD enabled on a network reaching this host's SR?")
-				return
-			}
-			chosen := infos[0]
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.Header().Set("X-BackupOS-Snapshot-UUID", uuid)
 			w.Header().Set("X-BackupOS-NBD-Address", fmt.Sprintf("%s:%d", chosen.Address, chosen.Port))
@@ -481,11 +407,8 @@ func main() {
 			streamCtx, streamCancel := context.WithTimeout(r.Context(), 4*time.Hour)
 			defer streamCancel()
 			res, err := nbdread.StreamFullExport(streamCtx, nbdread.Connection{
-				Address:    chosen.Address,
-				Port:       chosen.Port,
-				ExportName: chosen.ExportName,
-				CertPEM:    chosen.CertPEM,
-				Subject:    chosen.Subject,
+				Address: chosen.Address, Port: chosen.Port,
+				ExportName: chosen.ExportName, CertPEM: chosen.CertPEM, Subject: chosen.Subject,
 			}, w)
 			if err != nil {
 				var bytesWritten int64
@@ -503,6 +426,15 @@ func main() {
 			respondJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 		}
 	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api2/json/version", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("version", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+		respondJSON(w, http.StatusOK, map[string]string{
+			"version": versionString, "release": releaseString, "repoID": repoIDString,
+		})
+	})
+	mux.Handle("/api2/json/", internalauth.Middleware(internalSecret, apiMux))
 	mux.Handle("/internal/inventory", internalauth.Middleware(internalSecret, http.HandlerFunc(handleInventory)))
 	mux.HandleFunc("/", notFound)
 
@@ -587,6 +519,5 @@ func notFound(w http.ResponseWriter, r *http.Request) {
 	)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusNotFound)
-	resp := map[string]string{"error": "not found"}
-	_ = json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
 }

--- a/services/backupos-xcp/internal/xapi/session.go
+++ b/services/backupos-xcp/internal/xapi/session.go
@@ -1,0 +1,36 @@
+package xapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+)
+
+// PerRequestCredentials is an alias for PoolCredentials used by per-request
+// XAPI sessions. The alias makes per-request usage grep-able.
+type PerRequestCredentials = PoolCredentials
+
+// WithSession opens a short-lived XAPI session, runs fn with the Client, and
+// closes the session on return. Use for any handler that receives pool
+// credentials per request rather than at startup.
+func WithSession(ctx context.Context, creds PerRequestCredentials, fn func(*Client) error) error {
+	if creds.PoolMasterURL == "" || creds.Username == "" || creds.Password == "" {
+		return errors.New("xapi: pool URL, username, and password required")
+	}
+	c, err := New(Config{
+		PoolMasterURL:      creds.PoolMasterURL,
+		Username:           creds.Username,
+		Password:           creds.Password,
+		CertFingerprint:    creds.CertFingerprintSHA256,
+		InsecureSkipVerify: creds.CertFingerprintSHA256 == "",
+	}, slog.Default())
+	if err != nil {
+		return fmt.Errorf("xapi: create client: %w", err)
+	}
+	if err := c.Connect(ctx); err != nil {
+		return fmt.Errorf("xapi: connect: %w", err)
+	}
+	defer c.Close() //nolint:errcheck
+	return fn(c)
+}


### PR DESCRIPTION
## Summary

- Refactors `backupos-xcp` Go service from startup-time XAPI session to per-request sessions via `WithSession` helper, enabling multi-pool deployments
- Adds `run_xcp_backup` agent protocol message; implements `xcpngBackup.ts` handler that snapshots, streams via NBD, and cleans up per-disk
- Wires `xcpng_vm` source type end-to-end: scheduler dispatch, job creation UI, and agent handler
- Enrolls a built-in server agent on install (`backupos-agent.service`) and defaults the job form's agent picker to it for xcpng_vm jobs

## Test plan

- [ ] Install/update via `server-install.sh` — verify `backupos-agent.service` starts and agent appears in dashboard
- [ ] Re-run install — verify idempotent (agent not re-enrolled, token preserved)
- [ ] Create xcpng_vm job via UI — verify built-in agent is pre-selected and labelled
- [ ] Trigger xcpng_vm job — verify snapshot → NBD stream → restic backup → snapshot delete sequence in agent logs
- [ ] Verify `run_xcp_backup` message fields match protocol spec (pool creds, xcp coords, disk array)
- [ ] Verify old `--xapi-url/--xapi-user` flags log deprecation warning but don't break startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)