### PR TITLE
fix(xcp): keep XAPI session open during NBD stream + DELETE creds from body

### DIFF
--- a/packages/agent/src/handlers/xcpngBackup.ts
+++ b/packages/agent/src/handlers/xcpngBackup.ts
@@ -24,7 +24,8 @@ async function xcpRequest(opts: {
 }): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     const url = new URL(opts.xcpBase + opts.path)
-    const poolHeaders: Record<string, string> = opts.method !== 'POST' ? {
+    // GET: pool creds in headers. POST/DELETE: pool creds in body.
+    const poolHeaders: Record<string, string> = opts.method === 'GET' ? {
       'X-XAPI-Pool-Master-URL':         opts.pool.masterUrl,
       'X-XAPI-Username':                opts.pool.username,
       'X-XAPI-Password':                opts.pool.password,
@@ -171,6 +172,12 @@ export async function runXcpngBackup(
         const destResp = await xcpRequest({
           method: 'DELETE', path: `/api2/json/snapshot/${snap.uuid}?mode=destroy`,
           xcpBase, bearerToken: xcp.bearerToken, pool,
+          body: {
+            pool_master_url:         pool.masterUrl,
+            username:                pool.username,
+            password:                pool.password,
+            cert_fingerprint_sha256: pool.certFingerprintSha256,
+          },
         }).catch((e: unknown) => ({ status: 0, body: String(e) }))
         if (destResp.status !== 200) {
           log(`WARN: snapshot destroy failed (${destResp.status}): ${destResp.body}`)

--- a/services/backupos-xcp/cmd/backupos-xcp/main.go
+++ b/services/backupos-xcp/cmd/backupos-xcp/main.go
@@ -246,7 +246,20 @@ func main() {
 				respondJSONError(w, http.StatusBadRequest, "mode must be 'destroy' or 'data_destroy'")
 				return
 			}
-			creds := extractGetCreds(r)
+			var delBody struct {
+				PoolMasterURL         string `json:"pool_master_url"`
+				Username              string `json:"username"`
+				Password              string `json:"password"`
+				CertFingerprintSHA256 string `json:"cert_fingerprint_sha256"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&delBody); err != nil {
+				respondJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+				return
+			}
+			creds := xapi.PerRequestCredentials{
+				PoolMasterURL: delBody.PoolMasterURL, Username: delBody.Username,
+				Password: delBody.Password, CertFingerprintSHA256: delBody.CertFingerprintSHA256,
+			}
 			ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 			defer cancel()
 			if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
@@ -334,44 +347,45 @@ func main() {
 				PoolMasterURL: body.PoolMasterURL, Username: body.Username,
 				Password: body.Password, CertFingerprintSHA256: body.CertFingerprintSHA256,
 			}
-			nbdCtx, nbdCancel := context.WithTimeout(r.Context(), 30*time.Second)
-			defer nbdCancel()
-			var chosen xapi.NBDInfo
-			if err := xapi.WithSession(nbdCtx, creds, func(c *xapi.Client) error {
-				infos, err := c.SnapshotNBDInfo(nbdCtx, uuid)
+			// Session must span SnapshotNBDInfo + ReadRegions — the export_name encodes
+			// this session's session_id, which XCP-ng validates on every NBD block read.
+			sessionCtx, sessionCancel := context.WithTimeout(r.Context(), 10*time.Minute+30*time.Second)
+			defer sessionCancel()
+			var readRes nbdread.ReadResult
+			if err := xapi.WithSession(sessionCtx, creds, func(c *xapi.Client) error {
+				infos, err := c.SnapshotNBDInfo(sessionCtx, uuid)
 				if err != nil {
 					return err
 				}
 				if len(infos) == 0 {
 					return errors.New("no NBD options available for this snapshot — is NBD enabled on a network reaching this host's SR?")
 				}
-				chosen = infos[0]
+				chosen := infos[0]
+				f, ferr := os.Create(body.OutputPath)
+				if ferr != nil {
+					return fmt.Errorf("create output: %w", ferr)
+				}
+				defer f.Close()
+				readCtx, readCancel := context.WithTimeout(r.Context(), 10*time.Minute)
+				defer readCancel()
+				res, rerr := nbdread.ReadRegions(readCtx, nbdread.Connection{
+					Address: chosen.Address, Port: chosen.Port,
+					ExportName: chosen.ExportName, CertPEM: chosen.CertPEM, Subject: chosen.Subject,
+				}, body.Regions, f)
+				if rerr != nil {
+					slog.Error("nbd read failed", "error", rerr, "uuid", uuid)
+					return rerr
+				}
+				readRes = res
 				return nil
 			}); err != nil {
-				respondJSONError(w, http.StatusBadGateway, "get_nbd_info: "+err.Error())
-				return
-			}
-			f, err := os.Create(body.OutputPath)
-			if err != nil {
-				respondJSONError(w, http.StatusInternalServerError, "create output: "+err.Error())
-				return
-			}
-			defer f.Close()
-			readCtx, readCancel := context.WithTimeout(r.Context(), 10*time.Minute)
-			defer readCancel()
-			res, err := nbdread.ReadRegions(readCtx, nbdread.Connection{
-				Address: chosen.Address, Port: chosen.Port,
-				ExportName: chosen.ExportName, CertPEM: chosen.CertPEM, Subject: chosen.Subject,
-			}, body.Regions, f)
-			if err != nil {
-				slog.Error("nbd read failed", "error", err, "uuid", uuid)
 				respondJSONError(w, http.StatusBadGateway, err.Error())
 				return
 			}
 			respondJSON(w, http.StatusOK, map[string]any{
 				"uuid": uuid, "output_path": body.OutputPath,
-				"bytes_read": res.BytesRead, "region_count": res.RegionCount,
-				"sha256": res.SHA256Hex, "duration_ms": res.DurationMS,
+				"bytes_read": readRes.BytesRead, "region_count": readRes.RegionCount,
+				"sha256": readRes.SHA256Hex, "duration_ms": readRes.DurationMS,
 			})
 
 		case r.Method == http.MethodGet && sub == "stream":
@@ -381,45 +395,47 @@ func main() {
 				return
 			}
 			creds := extractGetCreds(r)
-			nbdCtx, nbdCancel := context.WithTimeout(r.Context(), 30*time.Second)
-			defer nbdCancel()
-			var chosen xapi.NBDInfo
-			if err := xapi.WithSession(nbdCtx, creds, func(c *xapi.Client) error {
-				infos, err := c.SnapshotNBDInfo(nbdCtx, uuid)
+			// Session must stay open for the full NBD stream duration — the export_name
+			// encodes this session's session_id, which XCP-ng validates on every block read.
+			streamCtx, streamCancel := context.WithTimeout(r.Context(), 4*time.Hour)
+			defer streamCancel()
+			var headersSent bool
+			if err := xapi.WithSession(streamCtx, creds, func(c *xapi.Client) error {
+				infos, err := c.SnapshotNBDInfo(streamCtx, uuid)
 				if err != nil {
-					return err
+					return fmt.Errorf("get_nbd_info: %w", err)
 				}
 				if len(infos) == 0 {
 					return errors.New("no NBD options for this snapshot — is NBD enabled on a network reaching this host's SR?")
 				}
-				chosen = infos[0]
+				chosen := infos[0]
+				w.Header().Set("Content-Type", "application/octet-stream")
+				w.Header().Set("X-BackupOS-Snapshot-UUID", uuid)
+				w.Header().Set("X-BackupOS-NBD-Address", fmt.Sprintf("%s:%d", chosen.Address, chosen.Port))
+				w.Header().Set("X-BackupOS-NBD-Export-Name", chosen.ExportName)
+				w.Header().Set("Cache-Control", "no-store")
+				w.WriteHeader(http.StatusOK)
+				headersSent = true
+				res, streamErr := nbdread.StreamFullExport(streamCtx, nbdread.Connection{
+					Address: chosen.Address, Port: chosen.Port,
+					ExportName: chosen.ExportName, CertPEM: chosen.CertPEM, Subject: chosen.Subject,
+				}, w)
+				if streamErr != nil {
+					var bytesWritten int64
+					if res != nil {
+						bytesWritten = res.BytesWritten
+					}
+					slog.Error("nbd stream failed", "error", streamErr, "uuid", uuid, "bytes_so_far", bytesWritten)
+					return streamErr
+				}
+				slog.Info("nbd stream complete", "uuid", uuid,
+					"bytes_written", res.BytesWritten, "duration_ms", res.DurationMS)
 				return nil
 			}); err != nil {
-				respondJSONError(w, http.StatusBadGateway, "get_nbd_info: "+err.Error())
-				return
-			}
-			w.Header().Set("Content-Type", "application/octet-stream")
-			w.Header().Set("X-BackupOS-Snapshot-UUID", uuid)
-			w.Header().Set("X-BackupOS-NBD-Address", fmt.Sprintf("%s:%d", chosen.Address, chosen.Port))
-			w.Header().Set("X-BackupOS-NBD-Export-Name", chosen.ExportName)
-			w.Header().Set("Cache-Control", "no-store")
-			w.WriteHeader(http.StatusOK)
-			streamCtx, streamCancel := context.WithTimeout(r.Context(), 4*time.Hour)
-			defer streamCancel()
-			res, err := nbdread.StreamFullExport(streamCtx, nbdread.Connection{
-				Address: chosen.Address, Port: chosen.Port,
-				ExportName: chosen.ExportName, CertPEM: chosen.CertPEM, Subject: chosen.Subject,
-			}, w)
-			if err != nil {
-				var bytesWritten int64
-				if res != nil {
-					bytesWritten = res.BytesWritten
+				if !headersSent {
+					respondJSONError(w, http.StatusBadGateway, err.Error())
 				}
-				slog.Error("nbd stream failed", "error", err, "uuid", uuid, "bytes_so_far", bytesWritten)
-				return
 			}
-			slog.Info("nbd stream complete", "uuid", uuid,
-				"bytes_written", res.BytesWritten, "duration_ms", res.DurationMS)
 
 		default:
 			w.Header().Set("Allow", "DELETE, GET, POST")

--- a/services/backupos-xcp/cmd/backupos-xcp/main.go
+++ b/services/backupos-xcp/cmd/backupos-xcp/main.go
@@ -351,7 +351,7 @@ func main() {
 			// this session's session_id, which XCP-ng validates on every NBD block read.
 			sessionCtx, sessionCancel := context.WithTimeout(r.Context(), 10*time.Minute+30*time.Second)
 			defer sessionCancel()
-			var readRes nbdread.ReadResult
+			var readRes *nbdread.ReadResult
 			if err := xapi.WithSession(sessionCtx, creds, func(c *xapi.Client) error {
 				infos, err := c.SnapshotNBDInfo(sessionCtx, uuid)
 				if err != nil {


### PR DESCRIPTION
## Summary

- **Root cause of 0-byte streams**: `WithSession` was closing the XAPI session after `SnapshotNBDInfo` returned, but the `export_name` it returns encodes that session's `session_id`. XCP-ng validates the session_id on every NBD block read — when the session was already closed, the NBD server immediately disconnected ("server disconnected unexpectedly", 0 bytes received).
- **Fix (stream)**: `SnapshotNBDInfo` and `StreamFullExport` now run inside a single `WithSession` block with a 4-hour timeout. The XAPI session stays open for the entire NBD connection lifetime.
- **Fix (read)**: Same change — `SnapshotNBDInfo` and `ReadRegions` share one session (10m 30s timeout).
- **Fix (DELETE)**: Server-side DELETE handler now reads pool creds from JSON body instead of `X-XAPI-*` headers, consistent with POST. Agent updated: pool creds are now in the body for DELETE (headers only sent for GET).

## Test plan

- [ ] `curl -X GET https://backupos:8009/api2/json/snapshot/<uuid>/stream` — verify non-zero bytes
- [ ] Trigger an xcpng_vm backup job end-to-end — verify agent logs show snapshot → stream bytes → restic snapshot → destroy OK
- [ ] Verify snapshot destroy no longer returns "pool URL, username, and password required"

🤖 Generated with [Claude Code](https://claude.com/claude-code)