### PR TITLE
feat(xcp): Phase 2 PR D — VM restore via VDI.Create + NBD-write

### DIFF
--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -2,9 +2,9 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, backupJobs, backupRuns, alertChannels, eq, desc, and } from '@backupos/db'
+import { getDb, restoreSpecs, restoreRuns, snapshots, repositories, backupJobs, backupRuns, alertChannels, hypervisorTargets, hypervisorIntegrations, eq, desc, and } from '@backupos/db'
 import type { ComposeProjectConfig } from '@backupos/agent-protocol'
-import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult, type NotifyDelivery, type DatabaseRestoreDelivery } from '@backupos/restore'
+import { parseRestoreSpec, executeRestoreSpec, type RestoreRunResult, type NotifyDelivery, type DatabaseRestoreDelivery, type XcpngVmRestoreDelivery } from '@backupos/restore'
 import { requireAdmin } from '@/lib/user'
 import { dispatchToChannel, fireRestoreSucceeded, fireRestoreFailed } from '@/lib/alerts'
 import type { AlertType, AlertPayload } from '@/lib/alerts'
@@ -90,6 +90,81 @@ const deliverDatabaseRestore: DatabaseRestoreDelivery = async (step, _snapshotId
   })
 }
 
+const xcpngVmRestoreDelivery: XcpngVmRestoreDelivery = async (step, _snapshotId) => {
+  const db = getDb()
+
+  const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, step.backupJobId)).limit(1)
+  if (!job) return { success: false, error: `Backup job ${step.backupJobId} not found` }
+
+  const srcConfig = JSON.parse(job.sourceConfig ?? '{}') as { targetId?: string }
+  const [target] = await db.select().from(hypervisorTargets)
+    .where(eq(hypervisorTargets.id, srcConfig.targetId ?? '')).limit(1)
+  if (!target) return { success: false, error: `Hypervisor target not found for job ${step.backupJobId}` }
+
+  const [integration] = await db.select().from(hypervisorIntegrations)
+    .where(eq(hypervisorIntegrations.id, target.integrationId ?? '')).limit(1)
+  if (!integration) return { success: false, error: `Hypervisor integration not found` }
+
+  const xcpServiceUrl  = process.env['BACKUPOS_XCP_URL']
+  const internalSecret = process.env['BACKUPOS_INTERNAL_SECRET']
+  if (!xcpServiceUrl || !internalSecret) {
+    return { success: false, error: 'BACKUPOS_XCP_URL or BACKUPOS_INTERNAL_SECRET not set on server' }
+  }
+
+  const [repo] = await db.select().from(repositories)
+    .where(eq(repositories.id, job.repositoryId ?? '')).limit(1)
+  if (!repo) return { success: false, error: 'Repository not found for job' }
+
+  let repoConfig: { repositoryUrl?: string; envVars?: Record<string, string> }
+  try { repoConfig = JSON.parse(decryptField(repo.config)) as typeof repoConfig } catch {
+    return { success: false, error: 'Failed to decrypt repository config' }
+  }
+  const repoPassword = decryptField(repo.resticPassword)
+
+  const integrationConfig = JSON.parse(integration.config) as Record<string, string>
+  const poolMasterUrl = (integrationConfig['host'] ?? '').startsWith('http')
+    ? (integrationConfig['host'] ?? '')
+    : `https://${integrationConfig['host'] ?? ''}${integrationConfig['port'] ? `:${integrationConfig['port']}` : ''}`
+
+  const tagsData = JSON.parse(target.tags ?? '{}') as {
+    disks?: Array<{ uuid: string; virtual_size: number; user_device: string; bootable: boolean }>
+  }
+
+  const builtInAgentId = connectedAgentIds().find(id => id.startsWith('00000000-0000-0000-0000-'))
+  if (!builtInAgentId) return { success: false, error: 'XCP-ng built-in agent is not connected' }
+
+  const sent = dispatch(builtInAgentId, {
+    type:         'run_xcpng_vm_restore',
+    jobId:        crypto.randomUUID(),
+    runId:        crypto.randomUUID(),
+    pool: {
+      masterUrl:             poolMasterUrl,
+      username:              integrationConfig['username'] ?? '',
+      password:              integrationConfig['password'] ?? '',
+      certFingerprintSha256: integrationConfig['cert_fingerprint_sha256'] ?? '',
+    },
+    xcp: { serviceUrl: xcpServiceUrl, bearerToken: internalSecret },
+    vmUUID:       step.vmUUID,
+    vmName:       step.vmName,
+    targetSrUUID: step.targetSrUUID,
+    repoId:       job.repositoryId ?? '',
+    repoUrl:      repoConfig.repositoryUrl ?? '',
+    repoPassword,
+    envVars:      repoConfig.envVars,
+    memoryBytes:  step.memoryBytes,
+    vcpus:        step.vcpus,
+    disks: (tagsData.disks ?? []).map(d => ({
+      originalVdiUUID: d.uuid,
+      virtualSize:     d.virtual_size,
+      userDevice:      d.user_device,
+      bootable:        d.bootable,
+    })),
+  })
+
+  if (!sent) return { success: false, error: 'Built-in agent disconnected before dispatch' }
+  return { success: true }
+}
+
 async function deliverRestoreNotification(channel: string, message: string): Promise<void> {
   const db       = getDb()
   const channels = await db.select().from(alertChannels).all()
@@ -128,7 +203,7 @@ export async function runSpec(specId: string, snapshotId = 'latest'): Promise<vo
     })
   } catch (err) { console.error('[logger]', err) }
 
-  executeRestoreSpec(parsed, snapshotId, 'local', deliverRestoreNotification, deliverDatabaseRestore).then(async (result: RestoreRunResult) => {
+  executeRestoreSpec(parsed, snapshotId, 'local', deliverRestoreNotification, deliverDatabaseRestore, xcpngVmRestoreDelivery).then(async (result: RestoreRunResult) => {
     await db
       .update(restoreRuns)
       .set({

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -167,6 +167,8 @@ export type AgentMessage =
   | { type: 'database_restore_started'; requestId: string; restoreId: string }
   | { type: 'database_restore_complete'; restoreId: string; success: boolean; output?: string; error?: string; durationSec?: number }
   | { type: 'list_snapshot_paths_result'; requestId: string; ok: boolean; paths?: string[]; error?: string }
+  | { type: 'xcpng_vm_restore_started'; jobId: string; runId: string; diskCount: number }
+  | { type: 'xcpng_vm_restore_complete'; jobId: string; runId: string; success: boolean; newVmUUID?: string; error?: string; log?: string }
 
 export interface DetectedResources {
   dockerVolumes?: string[]
@@ -219,6 +221,35 @@ export type ServerMessage =
       repoPassword:         string
       envVars?:             Record<string, string>
       bandwidthLimitKbps?:  number | null
+    }
+  | { type: 'run_xcpng_vm_restore'
+      jobId:        string
+      runId:        string
+      pool: {
+        masterUrl:             string
+        username:              string
+        password:              string
+        certFingerprintSha256: string
+      }
+      xcp: {
+        serviceUrl:  string
+        bearerToken: string
+      }
+      vmUUID:       string
+      vmName:       string
+      targetSrUUID: string
+      repoId:       string
+      repoUrl:      string
+      repoPassword: string
+      envVars?:     Record<string, string>
+      memoryBytes?: number
+      vcpus?:       number
+      disks?: Array<{
+        originalVdiUUID: string
+        virtualSize:     number
+        userDevice:      string
+        bootable:        boolean
+      }>
     }
   | { type: 'run_compose_restore'; jobId: string; runId: string; repoId: string; config: ComposeRestoreConfig; repoUrl: string; repoPassword: string; envVars?: Record<string, string> }
   | { type: 'mount_repository'; requestId: string; repoId: string; nfsServer: string; nfsExport: string; nfsOptions: string }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -263,6 +263,12 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
       await runXcpngBackup(msg, send, activeJobs, BINARY, ensureRepoInitialized)
     })()
 
+  } else if (msg.type === 'run_xcpng_vm_restore') {
+    void (async () => {
+      const { runXcpngVmRestore } = await import('./handlers/xcpngRestore')
+      await runXcpngVmRestore(msg, send, BINARY, ensureRepoInitialized)
+    })()
+
   } else if (msg.type === 'run_compose_restore') {
     void (async () => {
       const { runComposeRestore } = await import('./handlers/composeRestore')

--- a/packages/agent/src/handlers/xcpngBackup.ts
+++ b/packages/agent/src/handlers/xcpngBackup.ts
@@ -153,6 +153,7 @@ export async function runXcpngBackup(
             `xcp:vdi=${disk.vdiUUID}`,
             `xcp:snapshot=${snap.uuid}`,
             `xcp:user_device=${disk.userDevice}`,
+            `xcp:virtual_size=${disk.virtualSize}`,
             `xcp:job=${jobId}`,
           ],
           signal: ctrl.signal,

--- a/packages/agent/src/handlers/xcpngRestore.ts
+++ b/packages/agent/src/handlers/xcpngRestore.ts
@@ -23,13 +23,14 @@ function parseTagValue(tags: string[], prefix: string): string {
   return t ? t.slice(prefix.length) : ''
 }
 
-function groupByVdi(snapshots: Array<{ id: string; tags: string[]; time: string }>): DiskInfo[] {
+function groupByVdi(snapshots: Array<{ id: string; tags?: string[]; time: string }>): DiskInfo[] {
   const byVdi = new Map<string, DiskInfo>()
   for (const snap of snapshots) {
-    const vdiUUID   = parseTagValue(snap.tags, 'xcp:vdi=')
-    const userDevice = parseTagValue(snap.tags, 'xcp:user_device=')
+    const tags    = snap.tags ?? []
+    const vdiUUID   = parseTagValue(tags, 'xcp:vdi=')
+    const userDevice = parseTagValue(tags, 'xcp:user_device=')
     if (!vdiUUID || !userDevice) continue
-    const sizeStr   = parseTagValue(snap.tags, 'xcp:virtual_size=')
+    const sizeStr   = parseTagValue(tags, 'xcp:virtual_size=')
     const virtualSize = sizeStr ? parseInt(sizeStr, 10) : 0
     const existing  = byVdi.get(vdiUUID)
     if (!existing || snap.time > existing.time) {

--- a/packages/agent/src/handlers/xcpngRestore.ts
+++ b/packages/agent/src/handlers/xcpngRestore.ts
@@ -1,0 +1,300 @@
+import * as https from 'node:https'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { ResticEngine } from '@backupos/engine'
+import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
+
+type SendFn = (msg: AgentMessage) => void
+type RunMsg = Extract<ServerMessage, { type: 'run_xcpng_vm_restore' }>
+type EnsureRepoFn = (engine: ResticEngine, repoId: string) => Promise<void>
+
+interface DiskInfo {
+  snapshotId:  string
+  vdiUUID:     string
+  userDevice:  string
+  virtualSize: number
+  bootable:    boolean
+  time:        string
+}
+
+function parseTagValue(tags: string[], prefix: string): string {
+  const t = tags.find(t => t.startsWith(prefix))
+  return t ? t.slice(prefix.length) : ''
+}
+
+function groupByVdi(snapshots: Array<{ id: string; tags: string[]; time: string }>): DiskInfo[] {
+  const byVdi = new Map<string, DiskInfo>()
+  for (const snap of snapshots) {
+    const vdiUUID   = parseTagValue(snap.tags, 'xcp:vdi=')
+    const userDevice = parseTagValue(snap.tags, 'xcp:user_device=')
+    if (!vdiUUID || !userDevice) continue
+    const sizeStr   = parseTagValue(snap.tags, 'xcp:virtual_size=')
+    const virtualSize = sizeStr ? parseInt(sizeStr, 10) : 0
+    const existing  = byVdi.get(vdiUUID)
+    if (!existing || snap.time > existing.time) {
+      byVdi.set(vdiUUID, {
+        snapshotId: snap.id,
+        vdiUUID,
+        userDevice,
+        virtualSize,
+        bootable:    userDevice === '0' || userDevice === 'xvda',
+        time:        snap.time,
+      })
+    }
+  }
+  return Array.from(byVdi.values()).sort((a, b) => a.userDevice.localeCompare(b.userDevice))
+}
+
+function findImgFile(dir: string): string | null {
+  const search = (d: string): string | null => {
+    let entries: fs.Dirent[]
+    try { entries = fs.readdirSync(d, { withFileTypes: true }) } catch { return null }
+    for (const e of entries) {
+      const full = path.join(d, e.name)
+      if (e.isDirectory()) {
+        const found = search(full)
+        if (found) return found
+      } else if (e.name.endsWith('.img')) {
+        return full
+      }
+    }
+    return null
+  }
+  return search(dir)
+}
+
+async function xcpPost(opts: {
+  path:        string
+  xcpBase:     string
+  bearerToken: string
+  pool:        RunMsg['pool']
+  body:        object
+}): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(opts.xcpBase + opts.path)
+    const payload = JSON.stringify(opts.body)
+    const req = https.request({
+      hostname:           url.hostname,
+      port:               url.port ? parseInt(url.port) : 443,
+      path:               url.pathname + url.search,
+      method:             'POST',
+      rejectUnauthorized: false,
+      headers: {
+        'Content-Type':   'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        'Authorization':  `Bearer ${opts.bearerToken}`,
+        'X-XAPI-Pool-Master-URL':         opts.pool.masterUrl,
+        'X-XAPI-Username':                opts.pool.username,
+        'X-XAPI-Password':                opts.pool.password,
+        'X-XAPI-Cert-Fingerprint-SHA256': opts.pool.certFingerprintSha256,
+      },
+    }, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', (c: Buffer) => chunks.push(c))
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') }))
+    })
+    req.on('error', reject)
+    req.end(payload)
+  })
+}
+
+async function uploadVdi(opts: {
+  imgPath:     string
+  vdiUUID:     string
+  xcpBase:     string
+  bearerToken: string
+  pool:        RunMsg['pool']
+  signal:      AbortSignal
+}): Promise<void> {
+  const { size } = fs.statSync(opts.imgPath)
+  const url = new URL(`${opts.xcpBase}/api2/json/vdi/${opts.vdiUUID}/upload`)
+
+  return new Promise((resolve, reject) => {
+    const req = https.request({
+      hostname:           url.hostname,
+      port:               url.port ? parseInt(url.port) : 443,
+      path:               url.pathname,
+      method:             'POST',
+      rejectUnauthorized: false,
+      headers: {
+        'Content-Type':                   'application/octet-stream',
+        'Content-Length':                 size,
+        'Authorization':                  `Bearer ${opts.bearerToken}`,
+        'X-XAPI-Pool-Master-URL':         opts.pool.masterUrl,
+        'X-XAPI-Username':                opts.pool.username,
+        'X-XAPI-Password':                opts.pool.password,
+        'X-XAPI-Cert-Fingerprint-SHA256': opts.pool.certFingerprintSha256,
+      },
+    }, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', (c: Buffer) => chunks.push(c))
+      res.on('end', () => {
+        if (res.statusCode === 200) resolve()
+        else reject(new Error(`vdi upload returned ${res.statusCode}: ${Buffer.concat(chunks).toString('utf8')}`))
+      })
+    })
+    req.on('error', reject)
+    opts.signal.addEventListener('abort', () => req.destroy(new Error('cancelled')))
+    const stream = fs.createReadStream(opts.imgPath)
+    stream.on('error', reject)
+    stream.pipe(req)
+  })
+}
+
+export async function runXcpngVmRestore(
+  msg: RunMsg,
+  send: SendFn,
+  binaryPath: string | undefined,
+  ensureRepo: EnsureRepoFn,
+): Promise<void> {
+  const { jobId, pool, xcp, vmUUID, vmName, targetSrUUID, repoId, repoUrl, repoPassword, envVars } = msg
+  const ctrl    = new AbortController()
+  const xcpBase = xcp.serviceUrl.replace(/\/$/, '')
+  const logLines: string[] = []
+  const log = (line: string) => logLines.push(`[${new Date().toISOString()}] ${line}`)
+
+  try {
+    const engine = new ResticEngine({
+      repositoryUrl: repoUrl,
+      password:      repoPassword,
+      envVars:       envVars ?? {},
+      binaryPath,
+    })
+
+    await ensureRepo(engine, repoId)
+
+    const allSnaps = await engine.snapshots([`xcp:vm=${vmUUID}`])
+    const disks    = groupByVdi(allSnaps)
+
+    if (disks.length === 0) {
+      throw new Error(`no restic snapshots found for VM ${vmUUID} — has a successful backup run completed?`)
+    }
+
+    send({ type: 'xcpng_vm_restore_started', jobId, runId: msg.runId, diskCount: disks.length })
+    log(`found ${disks.length} disk snapshot(s) for VM ${vmUUID}`)
+
+    // Apply disk info from message if available (provides accurate virtual_size)
+    if (msg.disks && msg.disks.length > 0) {
+      for (const d of disks) {
+        const hint = msg.disks.find(x => x.originalVdiUUID === d.vdiUUID || x.userDevice === d.userDevice)
+        if (hint) {
+          d.virtualSize = hint.virtualSize
+          d.bootable    = hint.bootable
+        }
+      }
+    }
+
+    const newVdiMap = new Map<string, string>() // userDevice → new VDI UUID
+
+    for (const disk of disks) {
+      if (ctrl.signal.aborted) throw new Error('cancelled')
+
+      log(`restoring disk ${disk.userDevice} (original VDI ${disk.vdiUUID}, snapshot ${disk.snapshotId})`)
+
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'backupos-xcprestore-'))
+      try {
+        await engine.restore(disk.snapshotId, tempDir, undefined, ctrl.signal)
+
+        const imgPath = findImgFile(tempDir)
+        if (!imgPath) throw new Error(`no .img file found in restore dir for disk ${disk.userDevice}`)
+
+        const fileSize   = fs.statSync(imgPath).size
+        const virtualSize = disk.virtualSize > 0 ? disk.virtualSize : fileSize
+        log(`restored image: ${imgPath} (${fileSize} bytes, virtual size ${virtualSize} bytes)`)
+
+        // Create new VDI on target SR
+        const createResp = await xcpPost({
+          path:        '/api2/json/vdi/create',
+          xcpBase, bearerToken: xcp.bearerToken, pool,
+          body: {
+            pool_master_url:         pool.masterUrl,
+            username:                pool.username,
+            password:                pool.password,
+            cert_fingerprint_sha256: pool.certFingerprintSha256,
+            sr_uuid:      targetSrUUID,
+            name_label:   `backupos-restore-${vmName}-${disk.userDevice}`,
+            virtual_size: virtualSize,
+          },
+        })
+        if (createResp.status !== 200) {
+          throw new Error(`vdi.create failed (${createResp.status}): ${createResp.body}`)
+        }
+        const newVdiUUID = (JSON.parse(createResp.body) as { uuid: string }).uuid
+        log(`created VDI ${newVdiUUID} on SR ${targetSrUUID}`)
+
+        // Upload image data to new VDI
+        await uploadVdi({ imgPath, vdiUUID: newVdiUUID, xcpBase, bearerToken: xcp.bearerToken, pool, signal: ctrl.signal })
+        log(`uploaded ${fileSize} bytes to VDI ${newVdiUUID}`)
+
+        newVdiMap.set(disk.userDevice, newVdiUUID)
+      } finally {
+        try { fs.rmSync(tempDir, { recursive: true }) } catch { /* best-effort cleanup */ }
+      }
+    }
+
+    // Create VM shell
+    const vmResp = await xcpPost({
+      path:        '/api2/json/vm/create',
+      xcpBase, bearerToken: xcp.bearerToken, pool,
+      body: {
+        pool_master_url:         pool.masterUrl,
+        username:                pool.username,
+        password:                pool.password,
+        cert_fingerprint_sha256: pool.certFingerprintSha256,
+        name_label:   `${vmName} (restored)`,
+        memory_bytes: msg.memoryBytes ?? 0,
+        vcpus:        msg.vcpus ?? 0,
+      },
+    })
+    if (vmResp.status !== 200) throw new Error(`vm.create failed (${vmResp.status}): ${vmResp.body}`)
+    const newVmUUID = (JSON.parse(vmResp.body) as { uuid: string }).uuid
+    log(`created VM ${newVmUUID}`)
+
+    // Attach VBDs
+    for (const disk of disks) {
+      const newVdiUUID = newVdiMap.get(disk.userDevice)
+      if (!newVdiUUID) continue
+      const vbdResp = await xcpPost({
+        path:        '/api2/json/vbd/create',
+        xcpBase, bearerToken: xcp.bearerToken, pool,
+        body: {
+          pool_master_url:         pool.masterUrl,
+          username:                pool.username,
+          password:                pool.password,
+          cert_fingerprint_sha256: pool.certFingerprintSha256,
+          vm_uuid:    newVmUUID,
+          vdi_uuid:   newVdiUUID,
+          userdevice: disk.userDevice,
+          bootable:   disk.bootable,
+        },
+      })
+      if (vbdResp.status !== 200) {
+        log(`WARN: vbd.create for ${disk.userDevice} failed (${vbdResp.status}): ${vbdResp.body}`)
+      } else {
+        log(`attached VDI ${newVdiUUID} to VM ${newVmUUID} as device ${disk.userDevice}`)
+      }
+    }
+
+    send({
+      type:      'xcpng_vm_restore_complete',
+      jobId,
+      runId:     msg.runId,
+      success:   true,
+      newVmUUID,
+      log:       logLines.join('\n').slice(0, 1_000_000) || undefined,
+    })
+
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err)
+    log(`FAIL: ${errMsg}`)
+    send({
+      type:    'xcpng_vm_restore_complete',
+      jobId,
+      runId:   msg.runId,
+      success: false,
+      error:   errMsg,
+      log:     logLines.join('\n').slice(0, 1_000_000) || undefined,
+    })
+  }
+}

--- a/packages/restore/src/executor.ts
+++ b/packages/restore/src/executor.ts
@@ -10,6 +10,7 @@ import type {
   RestoreStep,
   ShellStep,
   StepResult,
+  XcpngVmRestoreStep,
 } from './types'
 
 /**
@@ -26,6 +27,12 @@ export type DatabaseRestoreDelivery = (
   snapshotId: string,
   agentId: string,
 ) => Promise<{ success: boolean; output?: string; error?: string; durationSec?: number }>
+
+export type XcpngVmRestoreDelivery = (
+  step: XcpngVmRestoreStep,
+  snapshotId: string,
+  agentId: string,
+) => Promise<{ success: boolean; newVmUUID?: string; error?: string }>
 
 // ── Step executors ────────────────────────────────────────────────────────────
 
@@ -211,6 +218,26 @@ async function execNotify(
   }
 }
 
+async function execXcpngVmRestore(
+  step: XcpngVmRestoreStep,
+  snapshotId: string,
+  agentId: string,
+  xcpngVmRestoreDelivery?: XcpngVmRestoreDelivery,
+): Promise<Omit<StepResult, 'step' | 'durationMs'>> {
+  if (!xcpngVmRestoreDelivery) {
+    return { success: false, error: 'xcpng_vm_restore step requires server-side delivery wiring; no callback provided' }
+  }
+  try {
+    const result = await xcpngVmRestoreDelivery(step, snapshotId, agentId)
+    if (!result.success) {
+      return { success: false, error: result.error ?? 'xcpng_vm_restore failed' }
+    }
+    return { success: true, output: result.newVmUUID ? `Restore dispatched — new VM UUID: ${result.newVmUUID}` : 'VM restore dispatched' }
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
 // ── Step dispatcher ───────────────────────────────────────────────────────────
 
 async function executeStep(
@@ -219,6 +246,7 @@ async function executeStep(
   agentId: string,
   notifyDelivery?: NotifyDelivery,
   databaseRestoreDelivery?: DatabaseRestoreDelivery,
+  xcpngVmRestoreDelivery?: XcpngVmRestoreDelivery,
 ): Promise<StepResult> {
   const start = Date.now()
   let result: Omit<StepResult, 'step' | 'durationMs'>
@@ -242,6 +270,9 @@ async function executeStep(
     case 'notify':
       result = await execNotify(step, notifyDelivery)
       break
+    case 'xcpng_vm_restore':
+      result = await execXcpngVmRestore(step, snapshotId, agentId, xcpngVmRestoreDelivery)
+      break
   }
 
   return { step, durationMs: Date.now() - start, ...result }
@@ -255,11 +286,12 @@ export async function executeRestoreSpec(
   agentId: string,
   notifyDelivery?: NotifyDelivery,
   databaseRestoreDelivery?: DatabaseRestoreDelivery,
+  xcpngVmRestoreDelivery?: XcpngVmRestoreDelivery,
 ): Promise<RestoreRunResult> {
   const results: StepResult[] = []
 
   for (const step of spec.steps) {
-    const stepResult = await executeStep(step, snapshotId, agentId, notifyDelivery, databaseRestoreDelivery)
+    const stepResult = await executeStep(step, snapshotId, agentId, notifyDelivery, databaseRestoreDelivery, xcpngVmRestoreDelivery)
     results.push(stepResult)
 
     if (!stepResult.success && step.onFailure === 'abort') {

--- a/packages/restore/src/index.ts
+++ b/packages/restore/src/index.ts
@@ -1,3 +1,3 @@
 export * from './types'
 export { parseRestoreSpec, RestoreSpecParseError } from './parser'
-export { executeRestoreSpec, type NotifyDelivery, type DatabaseRestoreDelivery } from './executor'
+export { executeRestoreSpec, type NotifyDelivery, type DatabaseRestoreDelivery, type XcpngVmRestoreDelivery } from './executor'

--- a/packages/restore/src/parser.ts
+++ b/packages/restore/src/parser.ts
@@ -1,6 +1,6 @@
 import { load } from 'js-yaml'
 import { z } from 'zod'
-import type { ParsedRestoreSpec, RestoreStep } from './types'
+import type { ParsedRestoreSpec, RestoreStep, XcpngVmRestoreStep } from './types'
 
 // ── Zod schemas ───────────────────────────────────────────────────────────────
 
@@ -61,6 +61,18 @@ const notifyStep = z.object({
   on_failure: onFailure.default('continue'),
 })
 
+const xcpngVmRestoreStep = z.object({
+  name:           z.string(),
+  type:           z.literal('xcpng_vm_restore'),
+  vm_uuid:        z.string(),
+  vm_name:        z.string(),
+  target_sr_uuid: z.string(),
+  backup_job_id:  z.string(),
+  memory_bytes:   z.number().int().positive().optional(),
+  vcpus:          z.number().int().positive().optional(),
+  on_failure:     onFailure.default('abort'),
+})
+
 const restoreStepSchema = z.discriminatedUnion('type', [
   filesystemRestoreStep,
   databaseRestoreStep,
@@ -68,6 +80,7 @@ const restoreStepSchema = z.discriminatedUnion('type', [
   httpCheckStep,
   containerRestartStep,
   notifyStep,
+  xcpngVmRestoreStep,
 ])
 
 const notificationConfig = z.object({
@@ -102,6 +115,20 @@ export class RestoreSpecParseError extends Error {
 }
 
 function toStep(raw: z.infer<typeof restoreStepSchema>): RestoreStep {
+  if (raw.type === 'xcpng_vm_restore') {
+    const s: XcpngVmRestoreStep = {
+      name:         raw.name,
+      type:         'xcpng_vm_restore',
+      vmUUID:       raw.vm_uuid,
+      vmName:       raw.vm_name,
+      targetSrUUID: raw.target_sr_uuid,
+      backupJobId:  raw.backup_job_id,
+      memoryBytes:  raw.memory_bytes,
+      vcpus:        raw.vcpus,
+      onFailure:    raw.on_failure,
+    }
+    return s
+  }
   switch (raw.type) {
     case 'filesystem_restore':
       return {

--- a/packages/restore/src/types.ts
+++ b/packages/restore/src/types.ts
@@ -5,6 +5,7 @@ export type RestoreStepType =
   | 'http_check'
   | 'container_restart'
   | 'notify'
+  | 'xcpng_vm_restore'
 
 export type OnFailure = 'abort' | 'continue' | 'notify_only'
 
@@ -65,6 +66,18 @@ export interface NotifyStep {
   onFailure: OnFailure
 }
 
+export interface XcpngVmRestoreStep {
+  name: string
+  type: 'xcpng_vm_restore'
+  vmUUID: string
+  vmName: string
+  targetSrUUID: string
+  backupJobId: string
+  memoryBytes?: number
+  vcpus?: number
+  onFailure: OnFailure
+}
+
 export type RestoreStep =
   | FilesystemRestoreStep
   | DatabaseRestoreStep
@@ -72,6 +85,7 @@ export type RestoreStep =
   | HttpCheckStep
   | ContainerRestartStep
   | NotifyStep
+  | XcpngVmRestoreStep
 
 // ── Parsed spec ───────────────────────────────────────────────────────────────
 

--- a/services/backupos-xcp/cmd/backupos-xcp/main.go
+++ b/services/backupos-xcp/cmd/backupos-xcp/main.go
@@ -443,6 +443,211 @@ func main() {
 		}
 	})
 
+	apiMux.HandleFunc("/api2/json/sr/list", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("sr-list", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			respondJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		creds := extractGetCreds(r)
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		var srs []xapi.SRInfo
+		if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
+			var err error
+			srs, err = c.FindSRsByPool(ctx)
+			return err
+		}); err != nil {
+			slog.Error("sr-list failed", "error", err)
+			respondJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]any{"srs": srs})
+	})
+
+	apiMux.HandleFunc("/api2/json/vdi/", func(w http.ResponseWriter, r *http.Request) {
+		suffix := strings.TrimPrefix(r.URL.Path, "/api2/json/vdi/")
+
+		switch {
+		case r.Method == http.MethodPost && suffix == "create":
+			slog.Info("vdi-create", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+			var body struct {
+				PoolMasterURL         string `json:"pool_master_url"`
+				Username              string `json:"username"`
+				Password              string `json:"password"`
+				CertFingerprintSHA256 string `json:"cert_fingerprint_sha256"`
+				SrUUID                string `json:"sr_uuid"`
+				NameLabel             string `json:"name_label"`
+				VirtualSize           int64  `json:"virtual_size"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				respondJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+				return
+			}
+			if body.SrUUID == "" || body.VirtualSize <= 0 {
+				respondJSONError(w, http.StatusBadRequest, "sr_uuid and virtual_size required")
+				return
+			}
+			creds := xapi.PerRequestCredentials{
+				PoolMasterURL: body.PoolMasterURL, Username: body.Username,
+				Password: body.Password, CertFingerprintSHA256: body.CertFingerprintSHA256,
+			}
+			ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+			defer cancel()
+			var vdiUUID string
+			if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
+				var err error
+				vdiUUID, err = c.CreateVDI(ctx, body.SrUUID, body.NameLabel, body.VirtualSize)
+				return err
+			}); err != nil {
+				slog.Error("vdi-create failed", "error", err)
+				respondJSONError(w, http.StatusBadGateway, err.Error())
+				return
+			}
+			respondJSON(w, http.StatusOK, map[string]string{"uuid": vdiUUID})
+
+		case r.Method == http.MethodPost && strings.HasSuffix(suffix, "/upload"):
+			vdiUUID := strings.TrimSuffix(suffix, "/upload")
+			slog.Info("vdi-upload", "method", r.Method, "path", r.URL.Path, "uuid", vdiUUID, "remote", r.RemoteAddr)
+			if vdiUUID == "" {
+				respondJSONError(w, http.StatusBadRequest, "vdi uuid required in path")
+				return
+			}
+			// Pool creds in headers (body is the raw VDI image stream).
+			creds := extractGetCreds(r)
+			// Session must span VDINBDInfo + UploadFromReader — export_name encodes session_id.
+			uploadCtx, uploadCancel := context.WithTimeout(r.Context(), 4*time.Hour)
+			defer uploadCancel()
+			var headersSent bool
+			if err := xapi.WithSession(uploadCtx, creds, func(c *xapi.Client) error {
+				infos, err := c.VDINBDInfo(uploadCtx, vdiUUID)
+				if err != nil {
+					return fmt.Errorf("vdi_nbd_info: %w", err)
+				}
+				if len(infos) == 0 {
+					return errors.New("no NBD options for this VDI — is NBD enabled on a network reaching this SR?")
+				}
+				chosen := infos[0]
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				headersSent = true
+				res, uploadErr := nbdread.UploadFromReader(uploadCtx, nbdread.Connection{
+					Address: chosen.Address, Port: chosen.Port,
+					ExportName: chosen.ExportName, CertPEM: chosen.CertPEM, Subject: chosen.Subject,
+				}, r.Body)
+				if uploadErr != nil {
+					var bytesRead int64
+					if res != nil {
+						bytesRead = res.BytesRead
+					}
+					slog.Error("vdi upload failed", "error", uploadErr, "uuid", vdiUUID, "bytes_so_far", bytesRead)
+					return uploadErr
+				}
+				slog.Info("vdi upload complete", "uuid", vdiUUID,
+					"bytes_read", res.BytesRead, "duration_ms", res.DurationMS)
+				return nil
+			}); err != nil {
+				if !headersSent {
+					respondJSONError(w, http.StatusBadGateway, err.Error())
+				}
+			} else if headersSent {
+				_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok", "uuid": vdiUUID})
+			}
+
+		default:
+			w.Header().Set("Allow", "POST")
+			respondJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	})
+
+	apiMux.HandleFunc("/api2/json/vm/create", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("vm-create", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", "POST")
+			respondJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		var body struct {
+			PoolMasterURL         string `json:"pool_master_url"`
+			Username              string `json:"username"`
+			Password              string `json:"password"`
+			CertFingerprintSHA256 string `json:"cert_fingerprint_sha256"`
+			NameLabel             string `json:"name_label"`
+			MemoryBytes           int64  `json:"memory_bytes"`
+			Vcpus                 int    `json:"vcpus"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			respondJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if body.NameLabel == "" {
+			respondJSONError(w, http.StatusBadRequest, "name_label required")
+			return
+		}
+		creds := xapi.PerRequestCredentials{
+			PoolMasterURL: body.PoolMasterURL, Username: body.Username,
+			Password: body.Password, CertFingerprintSHA256: body.CertFingerprintSHA256,
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+		defer cancel()
+		var vmUUID string
+		if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
+			var err error
+			vmUUID, err = c.CreateVM(ctx, body.NameLabel, body.MemoryBytes, body.Vcpus)
+			return err
+		}); err != nil {
+			slog.Error("vm-create failed", "error", err)
+			respondJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]string{"uuid": vmUUID})
+	})
+
+	apiMux.HandleFunc("/api2/json/vbd/create", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("vbd-create", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", "POST")
+			respondJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		var body struct {
+			PoolMasterURL         string `json:"pool_master_url"`
+			Username              string `json:"username"`
+			Password              string `json:"password"`
+			CertFingerprintSHA256 string `json:"cert_fingerprint_sha256"`
+			VmUUID                string `json:"vm_uuid"`
+			VdiUUID               string `json:"vdi_uuid"`
+			Userdevice            string `json:"userdevice"`
+			Bootable              bool   `json:"bootable"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			respondJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if body.VmUUID == "" || body.VdiUUID == "" {
+			respondJSONError(w, http.StatusBadRequest, "vm_uuid and vdi_uuid required")
+			return
+		}
+		creds := xapi.PerRequestCredentials{
+			PoolMasterURL: body.PoolMasterURL, Username: body.Username,
+			Password: body.Password, CertFingerprintSHA256: body.CertFingerprintSHA256,
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+		defer cancel()
+		var vbdUUID string
+		if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
+			var err error
+			vbdUUID, err = c.CreateVBD(ctx, body.VmUUID, body.VdiUUID, body.Userdevice, body.Bootable)
+			return err
+		}); err != nil {
+			slog.Error("vbd-create failed", "error", err)
+			respondJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]string{"uuid": vbdUUID})
+	})
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api2/json/version", func(w http.ResponseWriter, r *http.Request) {
 		slog.Info("version", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)

--- a/services/backupos-xcp/internal/nbdread/write.go
+++ b/services/backupos-xcp/internal/nbdread/write.go
@@ -1,0 +1,83 @@
+package nbdread
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// WriteResult summarises a successful NBD write operation.
+type WriteResult struct {
+	BytesRead  int64
+	DurationMS int64
+}
+
+// UploadFromReader connects to the NBD server described by conn and writes all
+// data from r to the export via nbdcopy. This is the inverse of StreamFullExport:
+// it reads raw bytes from r and writes them to the NBD export.
+//
+// The session in conn.ExportName must remain open for the full duration of the
+// write — call this inside a WithSession block (same constraint as StreamFullExport).
+//
+// Requires nbdcopy on PATH (from libnbd-bin).
+func UploadFromReader(ctx context.Context, conn Connection, r io.Reader) (*WriteResult, error) {
+	if _, err := exec.LookPath("nbdcopy"); err != nil {
+		return nil, fmt.Errorf("nbdread: nbdcopy not found on PATH (install libnbd-bin): %w", err)
+	}
+	if conn.Address == "" || conn.Port == 0 || conn.ExportName == "" {
+		return nil, errors.New("nbdread: connection address, port, and export_name required")
+	}
+	if conn.CertPEM == "" {
+		return nil, errors.New("nbdread: certPEM required (TLS-only)")
+	}
+
+	certDir, err := os.MkdirTemp("", "backupos-nbd-cert-*")
+	if err != nil {
+		return nil, fmt.Errorf("nbdread: tmpdir: %w", err)
+	}
+	defer os.RemoveAll(certDir)
+	if err := os.Chmod(certDir, 0o700); err != nil {
+		return nil, fmt.Errorf("nbdread: chmod cert dir: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(certDir, "ca-cert.pem"), []byte(conn.CertPEM), 0o600); err != nil {
+		return nil, fmt.Errorf("nbdread: write cert: %w", err)
+	}
+
+	uri := buildURI(conn, certDir)
+
+	// nbdcopy - <URI> reads raw bytes from stdin and writes to the NBD export.
+	counter := &countingReader{r: r}
+	cmd := exec.CommandContext(ctx, "nbdcopy", "-", uri)
+	cmd.Stdin = counter
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("nbdread: nbdcopy write exited with error: %w (stderr=%s)",
+			err, strings.TrimSpace(stderr.String()))
+	}
+
+	return &WriteResult{
+		BytesRead:  counter.n,
+		DurationMS: time.Since(start).Milliseconds(),
+	}, nil
+}
+
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}

--- a/services/backupos-xcp/internal/xapi/nbd.go
+++ b/services/backupos-xcp/internal/xapi/nbd.go
@@ -17,6 +17,42 @@ type NBDInfo struct {
 	Subject    string `json:"subject"`
 }
 
+// VDINBDInfo returns NBD connection options for any VDI (snapshot or regular).
+// Use this when writing to a freshly-created VDI via UploadFromReader.
+func (c *Client) VDINBDInfo(ctx context.Context, vdiUUID string) ([]NBDInfo, error) {
+	if vdiUUID == "" {
+		return nil, errors.New("xapi: vdiUUID required")
+	}
+
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	ref, err := raw.VDI.GetByUUID(sess, vdiUUID)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: vdi.get_by_uuid(%s): %w", vdiUUID, err)
+	}
+
+	records, err := raw.VDI.GetNbdInfo(sess, ref)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: vdi.get_nbd_info: %w", err)
+	}
+
+	out := make([]NBDInfo, 0, len(records))
+	for _, r := range records {
+		out = append(out, NBDInfo{
+			ExportName: r.Exportname,
+			Address:    r.Address,
+			Port:       r.Port,
+			CertPEM:    r.Cert,
+			Subject:    r.Subject,
+		})
+	}
+	return out, nil
+}
+
 // SnapshotNBDInfo returns NBD connection options for the given snapshot VDI.
 // The snapshot must be a regular snapshot (not cbt_metadata) — cbt_metadata
 // VDIs cannot be exported over NBD.

--- a/services/backupos-xcp/internal/xapi/vdi.go
+++ b/services/backupos-xcp/internal/xapi/vdi.go
@@ -1,0 +1,88 @@
+package xapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	xenapi "github.com/terra-farm/go-xen-api-client"
+)
+
+// SRInfo describes a storage repository available on the pool.
+type SRInfo struct {
+	UUID       string `json:"uuid"`
+	NameLabel  string `json:"name_label"`
+	Type       string `json:"type"`
+	FreeBytes  int64  `json:"free_bytes"`
+	TotalBytes int64  `json:"total_bytes"`
+}
+
+// FindSRsByPool returns all SRs visible in the current pool session.
+func (c *Client) FindSRsByPool(ctx context.Context) ([]SRInfo, error) {
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	refs, err := raw.SR.GetAll(sess)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: sr.get_all: %w", err)
+	}
+
+	out := make([]SRInfo, 0, len(refs))
+	for _, ref := range refs {
+		uuid, err := raw.SR.GetUUID(sess, ref)
+		if err != nil {
+			continue
+		}
+		name, _ := raw.SR.GetNameLabel(sess, ref)
+		srType, _ := raw.SR.GetType(sess, ref)
+		physSize, _ := raw.SR.GetPhysicalSize(sess, ref)
+		physUtil, _ := raw.SR.GetPhysicalUtilisation(sess, ref)
+		out = append(out, SRInfo{
+			UUID:       uuid,
+			NameLabel:  name,
+			Type:       fmt.Sprintf("%v", srType),
+			FreeBytes:  int64(physSize) - int64(physUtil),
+			TotalBytes: int64(physSize),
+		})
+	}
+	return out, nil
+}
+
+// CreateVDI creates a new writable user-type VDI on the given SR and returns its UUID.
+func (c *Client) CreateVDI(ctx context.Context, srUUID, nameLabel string, virtualSize int64) (string, error) {
+	if srUUID == "" {
+		return "", errors.New("xapi: srUUID required")
+	}
+
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
+	srRef, err := raw.SR.GetByUUID(sess, srUUID)
+	if err != nil {
+		return "", fmt.Errorf("xapi: sr.get_by_uuid(%s): %w", srUUID, err)
+	}
+
+	vdiRef, err := raw.VDI.Create(sess, xenapi.VDIRecord{
+		NameLabel:   nameLabel,
+		SR:          srRef,
+		VirtualSize: int(virtualSize),
+		Type:        xenapi.VdiTypeUser,
+		Sharable:    false,
+		ReadOnly:    false,
+	})
+	if err != nil {
+		return "", fmt.Errorf("xapi: vdi.create: %w", err)
+	}
+
+	uuid, err := raw.VDI.GetUUID(sess, vdiRef)
+	if err != nil {
+		return "", fmt.Errorf("xapi: vdi.get_uuid after create: %w", err)
+	}
+	return uuid, nil
+}

--- a/services/backupos-xcp/internal/xapi/vm.go
+++ b/services/backupos-xcp/internal/xapi/vm.go
@@ -1,0 +1,91 @@
+package xapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	xenapi "github.com/terra-farm/go-xen-api-client"
+)
+
+// CreateVM creates a minimal HVM VM shell and returns its UUID.
+// The VM has no VBDs attached — use CreateVBD to attach disks after creation.
+func (c *Client) CreateVM(ctx context.Context, nameLabel string, memoryBytes int64, vcpus int) (string, error) {
+	if nameLabel == "" {
+		return "", errors.New("xapi: nameLabel required")
+	}
+	if memoryBytes <= 0 {
+		memoryBytes = 1 << 30 // 1 GiB default
+	}
+	if vcpus <= 0 {
+		vcpus = 2
+	}
+
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
+	vmRef, err := raw.VM.Create(sess, xenapi.VMRecord{
+		NameLabel:        nameLabel,
+		MemoryStaticMax:  int(memoryBytes),
+		MemoryStaticMin:  int(memoryBytes / 2),
+		MemoryDynamicMax: int(memoryBytes),
+		MemoryDynamicMin: int(memoryBytes / 2),
+		VCPUsMax:         vcpus,
+		VCPUsAtStartup:   vcpus,
+		HVMBootPolicy:    "BIOS order",
+	})
+	if err != nil {
+		return "", fmt.Errorf("xapi: vm.create: %w", err)
+	}
+
+	uuid, err := raw.VM.GetUUID(sess, vmRef)
+	if err != nil {
+		return "", fmt.Errorf("xapi: vm.get_uuid after create: %w", err)
+	}
+	return uuid, nil
+}
+
+// CreateVBD attaches a VDI to a VM as a virtual block device and returns the VBD UUID.
+func (c *Client) CreateVBD(ctx context.Context, vmUUID, vdiUUID, userDevice string, bootable bool) (string, error) {
+	if vmUUID == "" || vdiUUID == "" {
+		return "", errors.New("xapi: vmUUID and vdiUUID required")
+	}
+
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
+	vmRef, err := raw.VM.GetByUUID(sess, vmUUID)
+	if err != nil {
+		return "", fmt.Errorf("xapi: vm.get_by_uuid(%s): %w", vmUUID, err)
+	}
+
+	vdiRef, err := raw.VDI.GetByUUID(sess, vdiUUID)
+	if err != nil {
+		return "", fmt.Errorf("xapi: vdi.get_by_uuid(%s): %w", vdiUUID, err)
+	}
+
+	vbdRef, err := raw.VBD.Create(sess, xenapi.VBDRecord{
+		VM:         vmRef,
+		VDI:        vdiRef,
+		Userdevice: userDevice,
+		Bootable:   bootable,
+		Mode:       xenapi.VbdModeRW,
+		Type:       xenapi.VbdTypeDisk,
+		Empty:      false,
+	})
+	if err != nil {
+		return "", fmt.Errorf("xapi: vbd.create: %w", err)
+	}
+
+	uuid, err := raw.VBD.GetUUID(sess, vbdRef)
+	if err != nil {
+		return "", fmt.Errorf("xapi: vbd.get_uuid after create: %w", err)
+	}
+	return uuid, nil
+}


### PR DESCRIPTION
## Summary

- **Go (backupos-xcp)**: `xapi/vdi.go` (FindSRsByPool, CreateVDI), `xapi/vm.go` (CreateVM, CreateVBD), `xapi/nbd.go` (VDINBDInfo), `nbdread/write.go` (UploadFromReader — `nbdcopy - URI`). Five new routes: `GET /api2/json/sr/list`, `POST /api2/json/vdi/` (create + `{uuid}/upload`), `POST /api2/json/vm/create`, `POST /api2/json/vbd/create`.
- **Protocol**: `run_xcpng_vm_restore` ServerMessage; `xcpng_vm_restore_started` + `xcpng_vm_restore_complete` AgentMessages.
- **Restore spec**: `xcpng_vm_restore` step type in parser/types/executor; `XcpngVmRestoreDelivery` as optional 6th arg to `executeRestoreSpec`.
- **Agent handler** (`xcpngRestore.ts`): `engine.snapshots(['xcp:vm=<uuid>'])` → group by VDI → `engine.restore` to tmpdir → `POST /vdi/create` → stream upload → `POST /vm/create` → `POST /vbd/create` × N.
- **Backup tag**: `xcp:virtual_size=<bytes>` added to existing `xcpngBackup.ts` tags so restores know the correct VDI size.
- **Server delivery** (`actions/restore.ts`): `xcpngVmRestoreDelivery` looks up backup job → hypervisor integration → pool creds → dispatches `run_xcpng_vm_restore` to built-in agent (fire-and-forget; actual success surfaced via `xcpng_vm_restore_complete` WS message).

## Test plan

- [ ] Integration test via `server-install.sh update` — confirm `backupos-xcp` serves the new routes
- [ ] Verify `GET /api2/json/sr/list` returns pool SRs
- [ ] Run a backup of an XCP-ng VM, confirm `xcp:virtual_size` tag appears in restic snapshot
- [ ] Create a restore spec with `type: xcpng_vm_restore`, `backup_job_id`, `vm_uuid`, `vm_name`, `target_sr_uuid`
- [ ] Trigger spec run — confirm new VM appears in XCP-ng console with attached VBDs
- [ ] Confirm `xcpng_vm_restore_complete` message received in server logs

## Known fixup risks

terra-farm `VMRecord`/`VBDRecord`/`VDIRecord` field names (`VCPUsMax`, `HVMBootPolicy`, `VbdModeRW`, `VdiTypeUser`) are inferred from XenAPI spec — if build fails, field names need correcting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)