### PR TITLE
fix(xcp): cleanup follow-ups (#412 SetIsATemplate, #405 DELETE body, #406 forget/prune in agent NS)

### DIFF
--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -8,7 +8,6 @@ import next from 'next'
 import { WebSocketServer } from 'ws'
 import type { WebSocket } from 'ws'
 import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, verificationRuns, verificationTests, snapshots, eq, and, desc } from '@backupos/db'
-import { ResticEngine } from '@backupos/engine'
 import { parseExpression } from 'cron-parser'
 import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, requestInitRepository, resolveInitRepository, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository, resolveFilesystemRestoreStarted, resolveDatabaseRestoreStarted, resolveDatabaseRestoreComplete, resolveSnapshotPaths } from './lib/ws-state'
 import { ensureRepoMountedOnAgent } from './lib/repo-mount'
@@ -622,7 +621,7 @@ void app.prepare().then(async () => {
             }
           }
 
-          // Run forget/prune using the job's retention policy (falls back to global defaults)
+          // Dispatch forget/prune to the agent — it owns the repo mount namespace
           void (async () => {
             try {
               const [job] = await db.select().from(backupJobs)
@@ -630,7 +629,7 @@ void app.prepare().then(async () => {
               if (!job?.repositoryId) return
 
               const jobHasRetention = job.keepLast || job.keepDaily || job.keepWeekly || job.keepMonthly || job.keepYearly
-              let policy: { keepLast?: number; keepDaily?: number; keepWeekly?: number; keepMonthly?: number; keepYearly?: number; keepTags?: string[] } | null = null
+              let policy: { keepLast?: number; keepDaily?: number; keepWeekly?: number; keepMonthly?: number; keepYearly?: number } | null = null
 
               if (jobHasRetention) {
                 policy = {
@@ -660,22 +659,25 @@ void app.prepare().then(async () => {
               if (!repo) return
 
               const repoCfg = JSON.parse(decryptField(repo.config)) as Record<string, string>
-              const engine = new ResticEngine({
-                repositoryUrl: repoCfg['repositoryUrl'] ?? '',
-                password:      decryptField(repo.resticPassword),
-                envVars:       repoCfg,
-                binaryPath:    process.env['RESTIC_BINARY_PATH'],
-              })
-
               const tags = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${job.id}`]
-              const forget = await engine.forget({ ...policy, keepTags: tags })
 
-              await db.update(backupRuns).set({
-                snapshotsRemoved: forget.removed,
-                snapshotsKept:    forget.kept,
-              }).where(eq(backupRuns.id, run.id))
+              dispatch(agentId, {
+                type:         'run_forget_prune',
+                requestId:    crypto.randomUUID(),
+                jobId:        msg.jobId,
+                runId:        run.id,
+                repoUrl:      repoCfg['repositoryUrl'] ?? '',
+                repoPassword: decryptField(repo.resticPassword),
+                envVars:      repoCfg,
+                keepLast:     policy.keepLast,
+                keepDaily:    policy.keepDaily,
+                keepWeekly:   policy.keepWeekly,
+                keepMonthly:  policy.keepMonthly,
+                keepYearly:   policy.keepYearly,
+                keepTags:     tags,
+              })
             } catch (err) {
-              console.error('[server] forget/prune failed for job', msg.jobId, err)
+              console.error('[server] forget/prune dispatch failed for job', msg.jobId, err)
             }
           })()
 
@@ -822,6 +824,17 @@ void app.prepare().then(async () => {
 
         } else if (msg.type === 'list_snapshot_paths_result') {
           resolveSnapshotPaths(msg.requestId, { ok: msg.ok, paths: msg.paths, error: msg.error })
+
+        } else if (msg.type === 'forget_prune_complete') {
+          await db.update(backupRuns).set({
+            snapshotsRemoved: msg.removed,
+            snapshotsKept:    msg.kept,
+          }).where(eq(backupRuns.id, msg.runId))
+          if (!msg.success) {
+            console.error(`[server] forget/prune failed for job ${msg.jobId}:`, msg.error)
+          } else {
+            console.log(`[server] forget/prune for job ${msg.jobId}: removed ${msg.removed} kept ${msg.kept} in ${msg.durationMs}ms`)
+          }
 
         } else if (msg.type === 'filesystem_restore_started' && agentId) {
           console.log(`[restore] filesystem_restore_started restoreId=${msg.restoreId} agentId=${agentId}`)

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -169,6 +169,7 @@ export type AgentMessage =
   | { type: 'list_snapshot_paths_result'; requestId: string; ok: boolean; paths?: string[]; error?: string }
   | { type: 'xcpng_vm_restore_started'; jobId: string; runId: string; diskCount: number }
   | { type: 'xcpng_vm_restore_complete'; jobId: string; runId: string; success: boolean; newVmUUID?: string; error?: string; log?: string }
+  | { type: 'forget_prune_complete'; requestId: string; jobId: string; runId: string; success: boolean; error?: string; removed: number; kept: number; durationMs: number }
 
 export interface DetectedResources {
   dockerVolumes?: string[]
@@ -259,3 +260,17 @@ export type ServerMessage =
   | { type: 'cancel_filesystem_restore'; restoreId: string }
   | { type: 'run_database_restore'; requestId: string; restoreId: string; app: 'postgres' | 'mysql' | 'mariadb' | 'sqlite' | 'redis'; dumpFilePath: string; targetContainer?: string; targetDatabase?: string; targetUsername?: string; targetHost?: string; targetPort?: number; passwordEnv?: string; targetDbPath?: string }
   | { type: 'list_snapshot_paths'; requestId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; pattern?: string }
+  | { type: 'run_forget_prune'
+      requestId:    string
+      jobId:        string
+      runId:        string
+      repoUrl:      string
+      repoPassword: string
+      envVars?:     Record<string, string>
+      keepLast?:    number
+      keepDaily?:   number
+      keepWeekly?:  number
+      keepMonthly?: number
+      keepYearly?:  number
+      keepTags?:    string[]
+    }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -308,6 +308,12 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
       await runVerificationHandler(msg, send, BINARY)
     })()
 
+  } else if (msg.type === 'run_forget_prune') {
+    void (async () => {
+      const { handleForgetPrune } = await import('./handlers/forgetPrune')
+      await handleForgetPrune(msg, send, BINARY)
+    })()
+
   } else if (msg.type === 'list_compose_project') {
     void (async () => {
       try {

--- a/packages/agent/src/handlers/forgetPrune.ts
+++ b/packages/agent/src/handlers/forgetPrune.ts
@@ -1,0 +1,55 @@
+import { ResticEngine } from '@backupos/engine'
+import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
+
+type SendFn = (msg: AgentMessage) => void
+type RunMsg = Extract<ServerMessage, { type: 'run_forget_prune' }>
+
+export async function handleForgetPrune(
+  msg: RunMsg,
+  send: SendFn,
+  binaryPath: string | undefined,
+): Promise<void> {
+  const start = Date.now()
+
+  const engine = new ResticEngine({
+    repositoryUrl: msg.repoUrl,
+    password:      msg.repoPassword,
+    envVars:       msg.envVars ?? {},
+    binaryPath,
+  })
+
+  try {
+    const result = await engine.forget({
+      keepLast:    msg.keepLast,
+      keepDaily:   msg.keepDaily,
+      keepWeekly:  msg.keepWeekly,
+      keepMonthly: msg.keepMonthly,
+      keepYearly:  msg.keepYearly,
+      keepTags:    msg.keepTags,
+    })
+
+    send({
+      type:       'forget_prune_complete',
+      requestId:  msg.requestId,
+      jobId:      msg.jobId,
+      runId:      msg.runId,
+      success:    true,
+      removed:    result.removed,
+      kept:       result.kept,
+      durationMs: Date.now() - start,
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    send({
+      type:       'forget_prune_complete',
+      requestId:  msg.requestId,
+      jobId:      msg.jobId,
+      runId:      msg.runId,
+      success:    false,
+      error:      message,
+      removed:    0,
+      kept:       0,
+      durationMs: Date.now() - start,
+    })
+  }
+}

--- a/packages/agent/src/handlers/xcpngBackup.ts
+++ b/packages/agent/src/handlers/xcpngBackup.ts
@@ -31,6 +31,7 @@ async function xcpRequest(opts: {
       'X-XAPI-Password':                opts.pool.password,
       'X-XAPI-Cert-Fingerprint-SHA256': opts.pool.certFingerprintSha256,
     } : {}
+    const bodyStr = opts.body ? JSON.stringify(opts.body) : ''
     const req = https.request({
       hostname:           url.hostname,
       port:               url.port ? parseInt(url.port) : 443,
@@ -38,9 +39,11 @@ async function xcpRequest(opts: {
       method:             opts.method,
       rejectUnauthorized: false, // self-signed cert; bearer token provides auth. TODO: proper pinning
       headers: {
-        'Content-Type':  'application/json',
-        'Authorization': `Bearer ${opts.bearerToken}`,
+        'Content-Type':   'application/json',
+        'Authorization':  `Bearer ${opts.bearerToken}`,
         ...poolHeaders,
+        // Explicit Content-Length prevents Node from dropping the body on DELETE
+        ...(bodyStr ? { 'Content-Length': String(Buffer.byteLength(bodyStr)) } : {}),
       },
     }, (res) => {
       const chunks: Buffer[] = []
@@ -48,8 +51,8 @@ async function xcpRequest(opts: {
       res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') }))
     })
     req.on('error', reject)
-    if (opts.body) req.end(JSON.stringify(opts.body))
-    else req.end()
+    if (bodyStr) req.write(bodyStr)
+    req.end()
   })
 }
 

--- a/services/backupos-xcp/internal/xapi/vm.go
+++ b/services/backupos-xcp/internal/xapi/vm.go
@@ -87,6 +87,20 @@ func (c *Client) CloneVMFromTemplate(ctx context.Context, opts CloneVMOpts) (*Cl
 		_ = raw.VBD.Destroy(sess, vbdRef)
 	}
 
+	// Convert from template to VM. VM.Clone returns a template by default;
+	// without this the result is invisible to xe vm-list and cannot be started.
+	// Must come before SetNameLabel — XAPI auto-appends "(restored)" to template
+	// clones but only applies the auto-name during the conversion step.
+	if err := raw.VM.SetIsATemplate(sess, vmRef, false); err != nil {
+		_ = raw.VM.Destroy(sess, vmRef)
+		return nil, fmt.Errorf("xapi: vm.set_is_a_template(false): %w", err)
+	}
+
+	// Override the auto-applied "(restored)" suffix that SetIsATemplate triggers.
+	if err := raw.VM.SetNameLabel(sess, vmRef, opts.NewNameLabel); err != nil {
+		return nil, fmt.Errorf("xapi: vm.set_name_label: %w", err)
+	}
+
 	if opts.MemoryBytes > 0 {
 		_ = raw.VM.SetMemoryStaticMax(sess, vmRef, int(opts.MemoryBytes))
 		_ = raw.VM.SetMemoryDynamicMax(sess, vmRef, int(opts.MemoryBytes))


### PR DESCRIPTION
## Summary

- **#412 — Restored VM stuck as template**: `CloneVMFromTemplate` now calls `SetIsATemplate(false)` after removing stub VBDs, converting the clone from a template to a startable VM. `SetNameLabel` follows immediately to override the `(restored)` suffix XAPI auto-applies during conversion.
- **#405 — DELETE body silently dropped**: Node's `https.request` drops bodies written via `req.end(buf)` on DELETE. Fixed by setting explicit `Content-Length` header and using `req.write(body) + req.end()`. Snapshot destroy now reaches the Go server with its credentials body intact.
- **#406 — Forget/prune fails on NFS repos**: Web server ran `engine.forget()` inline after `backup_complete`, but `/mnt/backupos/<uuid>` only exists in the agent's mount namespace. Replaced with `dispatch(agentId, run_forget_prune)`. New `forgetPrune.ts` handler runs forget on the agent and sends `forget_prune_complete` back. Server handles the response to write `snapshotsRemoved/Kept`. `ResticEngine` import removed from `server.ts`.

## Test plan

- [ ] Deploy via `server-install.sh update --source ~/backupos`
- [ ] Run xcp-test-3: confirm snapshot destroy returns 200, no accumulated `backupos-*` VDIs on host
- [ ] Confirm cloned VM appears in `xe vm-list` (not `xe template-list`), with exact YAML name, no `(restored)` suffix
- [ ] Confirm `[server] forget/prune for job ...: removed N kept M` appears in journal after backup completes
- [ ] Confirm `backupRuns.snapshotsRemoved/Kept` populated in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)