### PR TITLE
feat(test): XCP-ng round-trip smoke test (Phase 2 PR E — closes Phase 2)

### DIFF
--- a/apps/web/app/api/v1/integration/restore-runs/[id]/route.ts
+++ b/apps/web/app/api/v1/integration/restore-runs/[id]/route.ts
@@ -1,0 +1,31 @@
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getDb, restoreRuns, eq }    from '@backupos/db'
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const expected = process.env.BACKUPOS_INTERNAL_SECRET
+  if (!expected) return NextResponse.json({ error: 'internal auth not configured' }, { status: 503 })
+  if (req.headers.get('authorization') !== `Bearer ${expected}`) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const db    = getDb()
+  const [run] = await db.select().from(restoreRuns).where(eq(restoreRuns.id, params.id)).limit(1)
+  if (!run) return NextResponse.json({ error: 'not found' }, { status: 404 })
+
+  let newVmUUID: string | null = null
+  if (run.log) {
+    try { newVmUUID = (JSON.parse(run.log) as { newVmUUID?: string }).newVmUUID ?? null }
+    catch { /* log may be plain text */ }
+  }
+
+  return NextResponse.json({
+    id:           run.id,
+    status:       run.status,
+    new_vm_uuid:  newVmUUID,
+    started_at:   run.startedAt.toISOString(),
+    completed_at: run.completedAt?.toISOString() ?? null,
+  })
+}

--- a/apps/web/app/api/v1/integration/restore-runs/[id]/route.ts
+++ b/apps/web/app/api/v1/integration/restore-runs/[id]/route.ts
@@ -4,7 +4,8 @@ export const dynamic = 'force-dynamic'
 import { NextRequest, NextResponse } from 'next/server'
 import { getDb, restoreRuns, eq }    from '@backupos/db'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
   const expected = process.env.BACKUPOS_INTERNAL_SECRET
   if (!expected) return NextResponse.json({ error: 'internal auth not configured' }, { status: 503 })
   if (req.headers.get('authorization') !== `Bearer ${expected}`) {
@@ -12,7 +13,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   }
 
   const db    = getDb()
-  const [run] = await db.select().from(restoreRuns).where(eq(restoreRuns.id, params.id)).limit(1)
+  const [run] = await db.select().from(restoreRuns).where(eq(restoreRuns.id, id)).limit(1)
   if (!run) return NextResponse.json({ error: 'not found' }, { status: 404 })
 
   let newVmUUID: string | null = null

--- a/apps/web/app/api/v1/integration/restore-runs/route.ts
+++ b/apps/web/app/api/v1/integration/restore-runs/route.ts
@@ -1,0 +1,103 @@
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse }                                                from 'next/server'
+import { getDb, backupJobs, repositories, restoreRuns, hypervisorTargets, hypervisorIntegrations, eq } from '@backupos/db'
+import { decryptField }                                                             from '@/lib/repo-crypto'
+import { connectedAgentIds, dispatch }                                              from '@/lib/ws-state'
+
+export async function POST(req: NextRequest) {
+  const expected = process.env.BACKUPOS_INTERNAL_SECRET
+  if (!expected) return NextResponse.json({ error: 'internal auth not configured' }, { status: 503 })
+  if (req.headers.get('authorization') !== `Bearer ${expected}`) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  let body: { job_id?: string; target_sr_uuid?: string; vm_name?: string; target_template_name_label?: string }
+  try { body = await req.json() as typeof body }
+  catch { return NextResponse.json({ error: 'invalid JSON' }, { status: 400 }) }
+
+  if (!body.job_id)        return NextResponse.json({ error: 'job_id required' },        { status: 400 })
+  if (!body.target_sr_uuid) return NextResponse.json({ error: 'target_sr_uuid required' }, { status: 400 })
+
+  const xcpServiceUrl  = process.env['BACKUPOS_XCP_URL']
+  const internalSecret = process.env['BACKUPOS_INTERNAL_SECRET']
+  if (!xcpServiceUrl || !internalSecret) {
+    return NextResponse.json({ error: 'BACKUPOS_XCP_URL or BACKUPOS_INTERNAL_SECRET not set' }, { status: 503 })
+  }
+
+  const db    = getDb()
+  const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, body.job_id)).limit(1)
+  if (!job) return NextResponse.json({ error: `job ${body.job_id} not found` }, { status: 404 })
+  if (job.sourceType !== 'xcpng_vm') {
+    return NextResponse.json({ error: 'job is not xcpng_vm type' }, { status: 422 })
+  }
+
+  const srcConfig = JSON.parse(job.sourceConfig) as { targetId?: string }
+  const [target]  = await db.select().from(hypervisorTargets).where(eq(hypervisorTargets.id, srcConfig.targetId ?? '')).limit(1)
+  if (!target) return NextResponse.json({ error: 'hypervisor target not found' }, { status: 422 })
+
+  const [integration] = await db.select().from(hypervisorIntegrations).where(eq(hypervisorIntegrations.id, target.integrationId ?? '')).limit(1)
+  if (!integration) return NextResponse.json({ error: 'hypervisor integration not found' }, { status: 422 })
+
+  const [repo] = await db.select().from(repositories).where(eq(repositories.id, job.repositoryId ?? '')).limit(1)
+  if (!repo) return NextResponse.json({ error: 'repository not found' }, { status: 422 })
+
+  const integrationConfig = JSON.parse(decryptField(integration.config)) as Record<string, string>
+  const repoCfg           = JSON.parse(decryptField(repo.config))        as Record<string, string>
+  const repoPassword      = decryptField(repo.resticPassword)
+
+  const poolMasterUrl = (integrationConfig['host'] ?? '').startsWith('http')
+    ? (integrationConfig['host'] ?? '')
+    : `https://${integrationConfig['host'] ?? ''}${integrationConfig['port'] ? `:${integrationConfig['port']}` : ''}`
+
+  const tagsData = JSON.parse(target.tags ?? '{}') as {
+    disks?: Array<{ uuid: string; virtual_size: number; user_device: string; bootable: boolean }>
+  }
+
+  const builtInAgentId = connectedAgentIds().find(id => id.startsWith('00000000-0000-0000-0000-'))
+  if (!builtInAgentId) return NextResponse.json({ error: 'XCP-ng built-in agent is not connected' }, { status: 503 })
+
+  const restoreRunId = crypto.randomUUID()
+
+  await db.insert(restoreRuns).values({
+    id:        restoreRunId,
+    status:    'running',
+    trigger:   'api',
+    startedAt: new Date(),
+  })
+
+  const sent = dispatch(builtInAgentId, {
+    type:    'run_xcpng_vm_restore',
+    jobId:   job.id,
+    runId:   restoreRunId,
+    pool: {
+      masterUrl:             poolMasterUrl,
+      username:              integrationConfig['username'] ?? '',
+      password:              integrationConfig['password'] ?? '',
+      certFingerprintSha256: integrationConfig['cert_fingerprint_sha256'] ?? '',
+    },
+    xcp: { serviceUrl: xcpServiceUrl, bearerToken: internalSecret },
+    vmUUID:                  target.externalId,
+    vmName:                  body.vm_name ?? `${target.name}-restored`,
+    targetSrUUID:            body.target_sr_uuid,
+    targetTemplateNameLabel: body.target_template_name_label ?? 'Other install media',
+    repoId:                  job.repositoryId ?? '',
+    repoUrl:                 repoCfg['repositoryUrl'] ?? '',
+    repoPassword,
+    envVars:  repoCfg,
+    disks: (tagsData.disks ?? []).map(d => ({
+      originalVdiUUID: d.uuid,
+      virtualSize:     d.virtual_size,
+      userDevice:      d.user_device,
+      bootable:        d.bootable,
+    })),
+  })
+
+  if (!sent) {
+    await db.update(restoreRuns).set({ status: 'failed', completedAt: new Date() }).where(eq(restoreRuns.id, restoreRunId))
+    return NextResponse.json({ error: 'built-in agent disconnected before dispatch' }, { status: 503 })
+  }
+
+  return NextResponse.json({ restore_run_id: restoreRunId }, { status: 201 })
+}

--- a/apps/web/app/api/v1/integration/runs/[id]/route.ts
+++ b/apps/web/app/api/v1/integration/runs/[id]/route.ts
@@ -4,7 +4,8 @@ export const dynamic = 'force-dynamic'
 import { NextRequest, NextResponse } from 'next/server'
 import { getDb, backupRuns, eq }     from '@backupos/db'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
   const expected = process.env.BACKUPOS_INTERNAL_SECRET
   if (!expected) return NextResponse.json({ error: 'internal auth not configured' }, { status: 503 })
   if (req.headers.get('authorization') !== `Bearer ${expected}`) {
@@ -12,7 +13,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   }
 
   const db    = getDb()
-  const [run] = await db.select().from(backupRuns).where(eq(backupRuns.id, params.id)).limit(1)
+  const [run] = await db.select().from(backupRuns).where(eq(backupRuns.id, id)).limit(1)
   if (!run) return NextResponse.json({ error: 'not found' }, { status: 404 })
 
   return NextResponse.json({

--- a/apps/web/app/api/v1/integration/runs/[id]/route.ts
+++ b/apps/web/app/api/v1/integration/runs/[id]/route.ts
@@ -1,0 +1,26 @@
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getDb, backupRuns, eq }     from '@backupos/db'
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const expected = process.env.BACKUPOS_INTERNAL_SECRET
+  if (!expected) return NextResponse.json({ error: 'internal auth not configured' }, { status: 503 })
+  if (req.headers.get('authorization') !== `Bearer ${expected}`) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const db    = getDb()
+  const [run] = await db.select().from(backupRuns).where(eq(backupRuns.id, params.id)).limit(1)
+  if (!run) return NextResponse.json({ error: 'not found' }, { status: 404 })
+
+  return NextResponse.json({
+    id:            run.id,
+    job_id:        run.jobId,
+    status:        run.status,
+    error_message: run.errorMessage ?? null,
+    started_at:    run.startedAt.toISOString(),
+    completed_at:  run.completedAt?.toISOString() ?? null,
+  })
+}

--- a/apps/web/app/api/v1/integration/runs/route.ts
+++ b/apps/web/app/api/v1/integration/runs/route.ts
@@ -5,6 +5,31 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getDb, backupRuns }         from '@backupos/db'
 import { lt, eq, and, desc }         from '@backupos/db'
 import { authenticate }              from '@/lib/integration-auth'
+import { triggerJobById }            from '@/lib/scheduler'
+
+function checkInternalAuth(req: NextRequest): NextResponse | null {
+  const expected = process.env.BACKUPOS_INTERNAL_SECRET
+  if (!expected) return NextResponse.json({ error: 'internal auth not configured' }, { status: 503 })
+  if (req.headers.get('authorization') !== `Bearer ${expected}`) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  return null
+}
+
+export async function POST(req: NextRequest) {
+  const deny = checkInternalAuth(req)
+  if (deny) return deny
+
+  let body: { job_id?: string }
+  try { body = await req.json() as { job_id?: string } }
+  catch { return NextResponse.json({ error: 'invalid JSON' }, { status: 400 }) }
+
+  if (!body.job_id) return NextResponse.json({ error: 'job_id required' }, { status: 400 })
+
+  const result = await triggerJobById(body.job_id)
+  if (!result.ok) return NextResponse.json({ error: result.error }, { status: 422 })
+  return NextResponse.json({ run_id: result.runId }, { status: 201 })
+}
 
 function decodeCursor(cursor: string): { startedAt: Date; id: string } | null {
   try {

--- a/apps/web/lib/scheduler.ts
+++ b/apps/web/lib/scheduler.ts
@@ -99,12 +99,12 @@ async function resolveJobWindow(db: Db, job: Job): Promise<{ start: number | nul
   return { start: defaults?.scheduleStart ?? null, end: defaults?.scheduleEnd ?? null }
 }
 
-async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Promise<boolean> {
-  if (!job.agentId || !job.repositoryId) return false
+async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Promise<string | null> {
+  if (!job.agentId || !job.repositoryId) return null
 
   const [repo] = await db.select().from(repositories)
     .where(eq(repositories.id, job.repositoryId)).limit(1)
-  if (!repo) return false
+  if (!repo) return null
 
   const cfg      = JSON.parse(decryptField(repo.config)) as Record<string, string>
   const password = decryptField(repo.resticPassword)
@@ -166,7 +166,7 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
         status: 'failed', completedAt: now,
         errorMessage: `hypervisor target ${srcConfig.targetId ?? '(unset)'} not found`,
       }).where(eq(backupRuns.id, runId))
-      return false
+      return null
     }
     const [integration] = await db.select().from(hypervisorIntegrations)
       .where(eq(hypervisorIntegrations.id, target.integrationId ?? '')).limit(1)
@@ -175,7 +175,7 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
         status: 'failed', completedAt: now,
         errorMessage: `hypervisor integration ${target.integrationId ?? '(unset)'} not found`,
       }).where(eq(backupRuns.id, runId))
-      return false
+      return null
     }
     const xcpServiceUrl    = process.env['BACKUPOS_XCP_URL']
     const internalSecret   = process.env['BACKUPOS_INTERNAL_SECRET']
@@ -184,7 +184,7 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
         status: 'failed', completedAt: now,
         errorMessage: 'BACKUPOS_XCP_URL or BACKUPOS_INTERNAL_SECRET not set on server',
       }).where(eq(backupRuns.id, runId))
-      return false
+      return null
     }
     const integrationConfig = JSON.parse(integration.config) as Record<string, string>
     const tagsData = JSON.parse(target.tags ?? '{}') as {
@@ -230,7 +230,7 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
       : (srcConfig.paths ?? [])
     if (paths.length === 0) {
       await db.update(backupRuns).set({ status: 'failed', completedAt: now, errorMessage: 'No backup paths resolved' }).where(eq(backupRuns.id, runId))
-      return false
+      return null
     }
     const tags        = job.tags ? (JSON.parse(job.tags) as string[]) : [`job:${job.id}`]
     const mountConfig = cfg['mountConfig'] ? (JSON.parse(cfg['mountConfig']) as MountConfig) : undefined
@@ -259,7 +259,7 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
     await db.update(backupRuns).set({
       status: 'failed', completedAt: now, errorMessage: `NFS mount failed: ${errorMessage}`,
     }).where(eq(backupRuns.id, runId))
-    return false
+    return null
   }
 
   const sent = dispatch(job.agentId, msg)
@@ -268,14 +268,23 @@ async function dispatchToAgent(db: Db, job: Job, trigger: 'cron' | 'manual'): Pr
       status: 'failed', completedAt: now,
       errorMessage: 'Agent disconnected before dispatch',
     }).where(eq(backupRuns.id, runId))
-    return false
+    return null
   }
 
   // Reset nextRunAt so the trigger tick doesn't re-fire this job
   await stampNextRun(db, job.id, job.schedule)
   console.log(`[scheduler] Dispatched job "${job.name}" (${job.sourceType}) to agent ${job.agentId}`)
   try { appendLog({ level: 'info', component: 'web', message: `Backup dispatched for job "${job.name}"`, entityType: 'job', entityId: job.id, payload: { trigger, runId } }) } catch (err) { console.error('[logger]', err) }
-  return true
+  return runId
+}
+
+export async function triggerJobById(jobId: string): Promise<{ ok: true; runId: string } | { ok: false; error: string }> {
+  const db    = getDb()
+  const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, jobId)).limit(1)
+  if (!job) return { ok: false, error: `job ${jobId} not found` }
+  const runId = await dispatchToAgent(db, job, 'manual')
+  if (!runId) return { ok: false, error: 'dispatch failed — check agent connectivity and job configuration' }
+  return { ok: true, runId }
 }
 
 /**

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -800,6 +800,15 @@ void app.prepare().then(async () => {
             console.error('[alerts] restore alert failed:', err)
           }
 
+        } else if (msg.type === 'xcpng_vm_restore_complete' && agentId) {
+          await db.update(restoreRuns).set({
+            status:      msg.success ? 'success' : 'failed',
+            completedAt: new Date(),
+            log:         JSON.stringify({ log: msg.log ?? '', newVmUUID: msg.newVmUUID ?? null }),
+          }).where(eq(restoreRuns.id, msg.runId))
+          console.log(`[xcpng-restore] ${msg.runId} — ${msg.success ? 'success' : 'failed'} newVm=${msg.newVmUUID ?? 'none'}`)
+          try { appendLog({ level: msg.success ? 'info' : 'error', component: 'web', message: msg.success ? `XCP-ng VM restore succeeded, new VM=${msg.newVmUUID ?? 'unknown'}` : `XCP-ng VM restore failed: ${msg.error ?? ''}`, entityType: 'restore_run', entityId: msg.runId }) } catch (err) { console.error('[logger]', err) }
+
         } else if (msg.type === 'filesystem_restore_cancelled' && agentId) {
           console.log(`[restore] filesystem_restore_cancelled restoreId=${msg.restoreId} agentId=${agentId} reason=${msg.reason}`)
           await db.update(restoreRuns).set({

--- a/scripts/smoke/xcp-roundtrip-smoke.sh
+++ b/scripts/smoke/xcp-roundtrip-smoke.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# XCP-ng backup → restore round-trip smoke test
+#
+# Required env vars:
+#   BACKUPOS_URL              https://your-backupos-host
+#   BACKUPOS_INTERNAL_SECRET  matches the server's BACKUPOS_INTERNAL_SECRET
+#   SMOKE_JOB_ID              UUID of the xcpng_vm backup job to test
+#   SMOKE_TARGET_SR_UUID      UUID of the SR where the restored VM should be created
+#
+# Optional:
+#   SMOKE_VM_NAME             name for the restored VM (default: smoke-restored-<timestamp>)
+#   SMOKE_TEMPLATE_LABEL      XCP-ng template label (default: "Other install media")
+#   SMOKE_BACKUP_TIMEOUT      seconds to wait for backup  (default: 1800)
+#   SMOKE_RESTORE_TIMEOUT     seconds to wait for restore (default: 1800)
+#   SMOKE_POLL_INTERVAL       seconds between status polls (default: 15)
+
+set -euo pipefail
+
+BASE_URL="${BACKUPOS_URL:?BACKUPOS_URL is required}"
+SECRET="${BACKUPOS_INTERNAL_SECRET:?BACKUPOS_INTERNAL_SECRET is required}"
+JOB_ID="${SMOKE_JOB_ID:?SMOKE_JOB_ID is required}"
+TARGET_SR="${SMOKE_TARGET_SR_UUID:?SMOKE_TARGET_SR_UUID is required}"
+VM_NAME="${SMOKE_VM_NAME:-smoke-restored-$(date +%Y%m%d-%H%M%S)}"
+TEMPLATE="${SMOKE_TEMPLATE_LABEL:-Other install media}"
+BACKUP_TIMEOUT="${SMOKE_BACKUP_TIMEOUT:-1800}"
+RESTORE_TIMEOUT="${SMOKE_RESTORE_TIMEOUT:-1800}"
+POLL="${SMOKE_POLL_INTERVAL:-15}"
+
+AUTH="Authorization: Bearer ${SECRET}"
+
+die() { echo "FAIL: $*" >&2; exit 1; }
+
+# ── Step 1: trigger backup ────────────────────────────────────────────────────
+echo "==> Step 1: triggering backup for job ${JOB_ID}"
+resp=$(curl -sf -X POST "${BASE_URL}/api/v1/integration/runs" \
+  -H "${AUTH}" -H 'Content-Type: application/json' \
+  -d "{\"job_id\":\"${JOB_ID}\"}")
+RUN_ID=$(echo "$resp" | grep -o '"run_id":"[^"]*"' | cut -d'"' -f4)
+[[ -n "$RUN_ID" ]] || die "no run_id in response: $resp"
+echo "    run_id=${RUN_ID}"
+
+# ── Step 2: poll backup ───────────────────────────────────────────────────────
+echo "==> Step 2: polling backup (timeout ${BACKUP_TIMEOUT}s)"
+deadline=$(( $(date +%s) + BACKUP_TIMEOUT ))
+while true; do
+  [[ $(date +%s) -lt $deadline ]] || die "backup timed out after ${BACKUP_TIMEOUT}s"
+  status_resp=$(curl -sf "${BASE_URL}/api/v1/integration/runs/${RUN_ID}" -H "${AUTH}")
+  status=$(echo "$status_resp" | grep -o '"status":"[^"]*"' | cut -d'"' -f4)
+  echo "    status=${status}"
+  [[ "$status" == "running" ]] || break
+  sleep "$POLL"
+done
+[[ "$status" == "success" ]] || die "backup ended with status=${status}"
+echo "    backup succeeded"
+
+# ── Step 3: trigger restore ───────────────────────────────────────────────────
+echo "==> Step 3: triggering restore → SR=${TARGET_SR} VM=${VM_NAME}"
+restore_body=$(printf '{"job_id":"%s","target_sr_uuid":"%s","vm_name":"%s","target_template_name_label":"%s"}' \
+  "$JOB_ID" "$TARGET_SR" "$VM_NAME" "$TEMPLATE")
+restore_resp=$(curl -sf -X POST "${BASE_URL}/api/v1/integration/restore-runs" \
+  -H "${AUTH}" -H 'Content-Type: application/json' \
+  -d "$restore_body")
+RESTORE_ID=$(echo "$restore_resp" | grep -o '"restore_run_id":"[^"]*"' | cut -d'"' -f4)
+[[ -n "$RESTORE_ID" ]] || die "no restore_run_id in response: $restore_resp"
+echo "    restore_run_id=${RESTORE_ID}"
+
+# ── Step 4: poll restore ──────────────────────────────────────────────────────
+echo "==> Step 4: polling restore (timeout ${RESTORE_TIMEOUT}s)"
+deadline=$(( $(date +%s) + RESTORE_TIMEOUT ))
+while true; do
+  [[ $(date +%s) -lt $deadline ]] || die "restore timed out after ${RESTORE_TIMEOUT}s"
+  rstatus_resp=$(curl -sf "${BASE_URL}/api/v1/integration/restore-runs/${RESTORE_ID}" -H "${AUTH}")
+  rstatus=$(echo "$rstatus_resp" | grep -o '"status":"[^"]*"' | cut -d'"' -f4)
+  echo "    status=${rstatus}"
+  [[ "$rstatus" == "running" ]] || break
+  sleep "$POLL"
+done
+[[ "$rstatus" == "success" ]] || die "restore ended with status=${rstatus}"
+
+NEW_VM=$(echo "$rstatus_resp" | grep -o '"new_vm_uuid":"[^"]*"' | cut -d'"' -f4)
+echo "==> PASS — new VM UUID: ${NEW_VM:-unknown}"
+echo "    Remember to destroy ${NEW_VM} from XCP-ng if no longer needed."


### PR DESCRIPTION
## Summary

- **`POST /api/v1/integration/runs`** — trigger a backup job by ID (BACKUPOS_INTERNAL_SECRET auth); returns `{ run_id }`
- **`GET  /api/v1/integration/runs/[id]`** — poll backup run status (`status`, `error_message`, timestamps)
- **`POST /api/v1/integration/restore-runs`** — trigger an XCP-ng VM restore from a job's repo; body: `job_id`, `target_sr_uuid`, optional `vm_name`/`target_template_name_label`; returns `{ restore_run_id }`
- **`GET  /api/v1/integration/restore-runs/[id]`** — poll restore status; includes `new_vm_uuid` on success
- **`server.ts`** — new `xcpng_vm_restore_complete` handler updates `restoreRuns` row and stores `newVmUUID` in `log` JSON
- **`scheduler.ts`** — `dispatchToAgent` now returns `runId | null` instead of `boolean`; new exported `triggerJobById` wrapper
- **`scripts/smoke/xcp-roundtrip-smoke.sh`** — executable 4-step smoke test: trigger backup → poll → trigger restore → poll → print new VM UUID

## Test plan

- [ ] Set env vars: `BACKUPOS_URL`, `BACKUPOS_INTERNAL_SECRET`, `SMOKE_JOB_ID`, `SMOKE_TARGET_SR_UUID`
- [ ] Deploy via `server-install.sh update --source ~/backupos`
- [ ] Run `bash scripts/smoke/xcp-roundtrip-smoke.sh`
- [ ] Confirm script prints `PASS — new VM UUID: <uuid>`
- [ ] Verify restored VM appears in XCP-ng console
- [ ] Destroy smoke VM from XCP-ng after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)