### PR TITLE
feat(xcp): preserve VIF metadata across backup/restore (closes #413)

### DIFF
--- a/packages/agent/src/handlers/xcpngBackup.ts
+++ b/packages/agent/src/handlers/xcpngBackup.ts
@@ -89,8 +89,37 @@ export async function runXcpngBackup(
   const logLines: string[] = []
   const log = (line: string) => logLines.push(`[${new Date().toISOString()}] ${line}`)
 
+  interface VIFInfo { device: string; network_label: string; mac: string; mtu: number; locking_mode: string }
+
   try {
     await ensureRepo(engine, repoId)
+
+    // Capture VIFs before the disk loop — same for all disks, added to each snapshot's tags
+    let vifTags: string[] = []
+    try {
+      const vifsResp = await xcpRequest({
+        method: 'POST', path: '/api2/json/vm/get-vifs',
+        xcpBase, bearerToken: xcp.bearerToken, pool,
+        body: {
+          pool_master_url:         pool.masterUrl,
+          username:                pool.username,
+          password:                pool.password,
+          cert_fingerprint_sha256: pool.certFingerprintSha256,
+          vm_uuid:                 target.vmUUID,
+        },
+      })
+      if (vifsResp.status === 200) {
+        const parsed = JSON.parse(vifsResp.body) as { vifs: VIFInfo[] }
+        for (const vif of parsed.vifs ?? []) {
+          vifTags.push(`xcp:vif=${vif.device}=${JSON.stringify(vif)}`)
+        }
+        log(`captured ${parsed.vifs?.length ?? 0} VIF(s) for VM ${target.vmUUID}`)
+      } else {
+        log(`WARN: vm/get-vifs returned ${vifsResp.status} — VIF tags will not be captured`)
+      }
+    } catch (vifErr) {
+      log(`WARN: failed to fetch VIFs: ${vifErr instanceof Error ? vifErr.message : String(vifErr)}`)
+    }
 
     for (const disk of target.disks) {
       if (ctrl.signal.aborted) throw new Error('cancelled')
@@ -158,6 +187,7 @@ export async function runXcpngBackup(
             `xcp:user_device=${disk.userDevice}`,
             `xcp:virtual_size=${disk.virtualSize}`,
             `xcp:job=${jobId}`,
+            ...vifTags,
           ],
           signal: ctrl.signal,
         })

--- a/packages/agent/src/handlers/xcpngRestore.ts
+++ b/packages/agent/src/handlers/xcpngRestore.ts
@@ -279,6 +279,50 @@ export async function runXcpngVmRestore(
       }
     }
 
+    // Recreate VIFs from snapshot tags
+    const vifPrefix = 'xcp:vif='
+    const refSnap    = allSnaps.find(s => disks[0] && s.id === disks[0].snapshotId)
+    const vifTags    = (refSnap?.tags ?? []).filter(t => t.startsWith(vifPrefix))
+    log(`found ${vifTags.length} VIF tag(s) to restore`)
+    for (const tag of vifTags) {
+      const rest   = tag.slice(vifPrefix.length)
+      const eqIdx  = rest.indexOf('=')
+      if (eqIdx < 0) continue
+      const jsonStr = rest.slice(eqIdx + 1)
+      let vifInfo: { device: string; network_label: string; mac: string; mtu: number; locking_mode: string }
+      try { vifInfo = JSON.parse(jsonStr) } catch { log(`WARN: could not parse VIF tag JSON: ${jsonStr}`); continue }
+      try {
+        const vifResp = await xcpPost({
+          path: '/api2/json/vif/create',
+          xcpBase, bearerToken: xcp.bearerToken, pool,
+          body: {
+            pool_master_url:         pool.masterUrl,
+            username:                pool.username,
+            password:                pool.password,
+            cert_fingerprint_sha256: pool.certFingerprintSha256,
+            vm_uuid:                 newVmUUID,
+            device:                  vifInfo.device,
+            network_label:           vifInfo.network_label,
+            mac:                     vifInfo.mac,
+            mtu:                     vifInfo.mtu,
+            locking_mode:            vifInfo.locking_mode,
+          },
+        })
+        if (vifResp.status !== 200) {
+          log(`WARN: vif/create for device=${vifInfo.device} failed (${vifResp.status}): ${vifResp.body}`)
+        } else {
+          const result = JSON.parse(vifResp.body) as { uuid: string; mac_used: string }
+          if (result.mac_used !== vifInfo.mac) {
+            log(`VIF created with new MAC ${result.mac_used} (original ${vifInfo.mac} was in use) device=${vifInfo.device}`)
+          } else {
+            log(`VIF created: device=${vifInfo.device} mac=${vifInfo.mac} network="${vifInfo.network_label}"`)
+          }
+        }
+      } catch (vifErr) {
+        log(`WARN: vif/create threw: ${vifErr instanceof Error ? vifErr.message : String(vifErr)}`)
+      }
+    }
+
     send({
       type:      'xcpng_vm_restore_complete',
       jobId,

--- a/services/backupos-xcp/cmd/backupos-xcp/main.go
+++ b/services/backupos-xcp/cmd/backupos-xcp/main.go
@@ -673,6 +673,99 @@ func main() {
 		respondJSON(w, http.StatusOK, map[string]string{"uuid": vbdUUID})
 	})
 
+	apiMux.HandleFunc("/api2/json/vm/get-vifs", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("vm-get-vifs", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", "POST")
+			respondJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		var body struct {
+			PoolMasterURL         string `json:"pool_master_url"`
+			Username              string `json:"username"`
+			Password              string `json:"password"`
+			CertFingerprintSHA256 string `json:"cert_fingerprint_sha256"`
+			VMUUID                string `json:"vm_uuid"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			respondJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if body.VMUUID == "" {
+			respondJSONError(w, http.StatusBadRequest, "vm_uuid required")
+			return
+		}
+		creds := xapi.PerRequestCredentials{
+			PoolMasterURL: body.PoolMasterURL, Username: body.Username,
+			Password: body.Password, CertFingerprintSHA256: body.CertFingerprintSHA256,
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		var vifs []xapi.VIFInfo
+		if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
+			var err error
+			vifs, err = c.GetVIFsForVM(ctx, body.VMUUID)
+			return err
+		}); err != nil {
+			slog.Error("vm-get-vifs failed", "error", err, "vm_uuid", body.VMUUID)
+			respondJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]any{"vifs": vifs})
+	})
+
+	apiMux.HandleFunc("/api2/json/vif/create", func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("vif-create", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", "POST")
+			respondJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		var body struct {
+			PoolMasterURL         string `json:"pool_master_url"`
+			Username              string `json:"username"`
+			Password              string `json:"password"`
+			CertFingerprintSHA256 string `json:"cert_fingerprint_sha256"`
+			VMUUID                string `json:"vm_uuid"`
+			Device                string `json:"device"`
+			NetworkLabel          string `json:"network_label"`
+			MAC                   string `json:"mac"`
+			MTU                   int    `json:"mtu"`
+			LockingMode           string `json:"locking_mode"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			respondJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if body.VMUUID == "" {
+			respondJSONError(w, http.StatusBadRequest, "vm_uuid required")
+			return
+		}
+		creds := xapi.PerRequestCredentials{
+			PoolMasterURL: body.PoolMasterURL, Username: body.Username,
+			Password: body.Password, CertFingerprintSHA256: body.CertFingerprintSHA256,
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		var vifUUID, macUsed string
+		if err := xapi.WithSession(ctx, creds, func(c *xapi.Client) error {
+			var err error
+			vifUUID, macUsed, err = c.CreateVIFFromInfo(ctx, body.VMUUID, xapi.VIFInfo{
+				Device:       body.Device,
+				NetworkLabel: body.NetworkLabel,
+				MAC:          body.MAC,
+				MTU:          body.MTU,
+				LockingMode:  body.LockingMode,
+			})
+			return err
+		}); err != nil {
+			slog.Error("vif-create failed", "error", err, "vm_uuid", body.VMUUID)
+			respondJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]any{"uuid": vifUUID, "mac_used": macUsed, "status": "ok"})
+	})
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api2/json/version", func(w http.ResponseWriter, r *http.Request) {
 		slog.Info("version", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)

--- a/services/backupos-xcp/internal/xapi/inventory.go
+++ b/services/backupos-xcp/internal/xapi/inventory.go
@@ -35,7 +35,7 @@ type InventoryDisk struct {
 	Bootable    bool   `json:"bootable"`
 }
 
-// InventoryVM is one VM with its disks.
+// InventoryVM is one VM with its disks and network interfaces.
 type InventoryVM struct {
 	UUID            string          `json:"uuid"`
 	NameLabel       string          `json:"name_label"`
@@ -43,6 +43,7 @@ type InventoryVM struct {
 	IsTemplate      bool            `json:"is_template"`
 	IsControlDomain bool            `json:"is_control_domain"`
 	Disks           []InventoryDisk `json:"disks"`
+	VIFs            []VIFInfo       `json:"vifs"`
 }
 
 // InventoryResult is the full inventory of one pool.
@@ -201,6 +202,33 @@ func InventoryPool(ctx context.Context, creds PoolCredentials) (*InventoryResult
 			})
 		}
 
+		vifs := make([]VIFInfo, 0)
+		if !isControlDomain {
+			vifRefs, vifErr := raw.VM.GetVIFs(sess, vmRef)
+			if vifErr == nil {
+				for _, vifRef := range vifRefs {
+					device, _ := raw.VIF.GetDevice(sess, vifRef)
+					mac, _ := raw.VIF.GetMAC(sess, vifRef)
+					mtuRaw, _ := raw.VIF.GetMTU(sess, vifRef)
+					netRef, _ := raw.VIF.GetNetwork(sess, vifRef)
+					lockingMode, _ := raw.VIF.GetLockingMode(sess, vifRef)
+					var networkLabel string
+					if string(netRef) != "" {
+						if label, lerr := raw.Network.GetNameLabel(sess, netRef); lerr == nil {
+							networkLabel = label
+						}
+					}
+					vifs = append(vifs, VIFInfo{
+						Device:       device,
+						NetworkLabel: networkLabel,
+						MAC:          mac,
+						MTU:          int(mtuRaw),
+						LockingMode:  string(lockingMode),
+					})
+				}
+			}
+		}
+
 		out.VMs = append(out.VMs, InventoryVM{
 			UUID:            vmUUID,
 			NameLabel:       vmName,
@@ -208,6 +236,7 @@ func InventoryPool(ctx context.Context, creds PoolCredentials) (*InventoryResult
 			IsTemplate:      isTemplate,
 			IsControlDomain: isControlDomain,
 			Disks:           disks,
+			VIFs:            vifs,
 		})
 	}
 

--- a/services/backupos-xcp/internal/xapi/vif.go
+++ b/services/backupos-xcp/internal/xapi/vif.go
@@ -1,0 +1,204 @@
+package xapi
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"strings"
+
+	xenapi "github.com/terra-farm/go-xen-api-client"
+)
+
+// VIFInfo is the preserved-and-replayable VIF state captured at backup time
+// and recreated at restore time. JSON-serialized into a restic snapshot tag.
+type VIFInfo struct {
+	Device       string `json:"device"`        // "0", "1", etc.
+	NetworkLabel string `json:"network_label"` // exact name_label of the network on source pool
+	MAC          string `json:"mac"`           // colon-separated, lowercase hex
+	MTU          int    `json:"mtu"`           // octets, typically 1500
+	LockingMode  string `json:"locking_mode"`  // network_default | locked | unlocked | disabled
+}
+
+// GetVIFsForVM returns the preserved VIF info for each VIF attached to the given VM.
+func (c *Client) GetVIFsForVM(ctx context.Context, vmUUID string) ([]VIFInfo, error) {
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	vmRef, err := raw.VM.GetByUUID(sess, vmUUID)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: vm.get_by_uuid(%s): %w", vmUUID, err)
+	}
+
+	vifRefs, err := raw.VM.GetVIFs(sess, vmRef)
+	if err != nil {
+		return nil, fmt.Errorf("xapi: vm.get_vifs: %w", err)
+	}
+
+	out := make([]VIFInfo, 0, len(vifRefs))
+	for _, vifRef := range vifRefs {
+		device, _ := raw.VIF.GetDevice(sess, vifRef)
+		mac, _ := raw.VIF.GetMAC(sess, vifRef)
+		mtuRaw, _ := raw.VIF.GetMTU(sess, vifRef)
+		netRef, _ := raw.VIF.GetNetwork(sess, vifRef)
+		lockingMode, _ := raw.VIF.GetLockingMode(sess, vifRef)
+
+		var networkLabel string
+		if string(netRef) != "" {
+			label, lerr := raw.Network.GetNameLabel(sess, netRef)
+			if lerr == nil {
+				networkLabel = label
+			}
+		}
+
+		out = append(out, VIFInfo{
+			Device:       device,
+			NetworkLabel: networkLabel,
+			MAC:          mac,
+			MTU:          int(mtuRaw),
+			LockingMode:  string(lockingMode),
+		})
+	}
+	return out, nil
+}
+
+// CreateVIFFromInfo creates a new VIF on the given VM from preserved VIFInfo.
+//
+// Network lookup fallback chain:
+//  1. Exact name_label match on target pool
+//  2. First non-internal network (excludes bridge=xenapi)
+//  3. Error — caller logs and continues; restore is not aborted
+//
+// MAC collision: if the requested MAC is in use, generates a new locally-administered
+// unicast MAC and returns it as macUsed so the caller can log the substitution.
+func (c *Client) CreateVIFFromInfo(ctx context.Context, vmUUID string, info VIFInfo) (uuid string, macUsed string, err error) {
+	raw, sess, release, err := c.Session(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	defer release()
+
+	vmRef, err := raw.VM.GetByUUID(sess, vmUUID)
+	if err != nil {
+		return "", "", fmt.Errorf("xapi: vm.get_by_uuid(%s): %w", vmUUID, err)
+	}
+
+	netRef, err := findTargetNetwork(raw, sess, info.NetworkLabel)
+	if err != nil {
+		return "", "", err
+	}
+
+	mac := info.MAC
+	if mac != "" {
+		inUse, _ := isMACInUse(raw, sess, mac)
+		if inUse {
+			newMAC, mErr := generateRandomMAC()
+			if mErr != nil {
+				return "", "", fmt.Errorf("xapi: generate random mac: %w", mErr)
+			}
+			mac = newMAC
+		}
+	}
+
+	device := info.Device
+	if device == "" {
+		device = "0"
+	}
+	mtu := info.MTU
+	if mtu <= 0 {
+		mtu = 1500
+	}
+
+	vifRef, err := raw.VIF.Create(sess, xenapi.VIFRecord{
+		Device:             device,
+		Network:            netRef,
+		VM:                 vmRef,
+		MAC:                mac,
+		MTU:                mtu,
+		OtherConfig:        map[string]string{},
+		QosAlgorithmType:   "",
+		QosAlgorithmParams: map[string]string{},
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("xapi: vif.create: %w", err)
+	}
+
+	if info.LockingMode != "" && info.LockingMode != "network_default" {
+		var mode xenapi.VifLockingMode
+		switch strings.ToLower(info.LockingMode) {
+		case "locked":
+			mode = xenapi.VifLockingModeLocked
+		case "unlocked":
+			mode = xenapi.VifLockingModeUnlocked
+		case "disabled":
+			mode = xenapi.VifLockingModeDisabled
+		default:
+			mode = xenapi.VifLockingModeNetworkDefault
+		}
+		_ = raw.VIF.SetLockingMode(sess, vifRef, mode)
+	}
+
+	uuid, err = raw.VIF.GetUUID(sess, vifRef)
+	if err != nil {
+		return "", "", fmt.Errorf("xapi: vif.get_uuid: %w", err)
+	}
+	return uuid, mac, nil
+}
+
+func findTargetNetwork(raw *xenapi.Client, sess xenapi.SessionRef, label string) (xenapi.NetworkRef, error) {
+	netRefs, err := raw.Network.GetAll(sess)
+	if err != nil {
+		return "", fmt.Errorf("xapi: network.get_all: %w", err)
+	}
+
+	type netInfo struct {
+		ref    xenapi.NetworkRef
+		label  string
+		bridge string
+	}
+	all := make([]netInfo, 0, len(netRefs))
+	for _, ref := range netRefs {
+		l, _ := raw.Network.GetNameLabel(sess, ref)
+		b, _ := raw.Network.GetBridge(sess, ref)
+		all = append(all, netInfo{ref: ref, label: l, bridge: b})
+	}
+
+	for _, n := range all {
+		if n.label == label {
+			return n.ref, nil
+		}
+	}
+
+	for _, n := range all {
+		if n.bridge != "xenapi" && !strings.HasPrefix(n.bridge, "host-internal") {
+			return n.ref, nil
+		}
+	}
+
+	return "", fmt.Errorf("xapi: no usable network on target pool (looking for %q, no fallback found)", label)
+}
+
+func isMACInUse(raw *xenapi.Client, sess xenapi.SessionRef, mac string) (bool, error) {
+	vifRecs, err := raw.VIF.GetAllRecords(sess)
+	if err != nil {
+		return false, err
+	}
+	for _, rec := range vifRecs {
+		if strings.EqualFold(rec.MAC, mac) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// generateRandomMAC returns a locally-administered unicast MAC address.
+func generateRandomMAC() (string, error) {
+	buf := make([]byte, 6)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	buf[0] = (buf[0] | 0x02) & 0xFE
+	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]), nil
+}


### PR DESCRIPTION
## Summary

- **`xapi/vif.go`** (new) — `VIFInfo` type, `GetVIFsForVM`, `CreateVIFFromInfo` with network fallback and MAC collision handling
- **`POST /api2/json/vm/get-vifs`** — returns `{ vifs: VIFInfo[] }` for a VM UUID
- **`POST /api2/json/vif/create`** — creates a VIF with network lookup (exact label → first non-internal fallback), preserves MAC or generates a new one on collision
- **`inventory.go`** — `InventoryVM` now includes `VIFs []VIFInfo` (populated for non-control-domain VMs)
- **`xcpngBackup.ts`** — fetches VIFs before disk loop; adds `xcp:vif=<device>=<json>` tags to every restic snapshot
- **`xcpngRestore.ts`** — after VBDs attached, parses `xcp:vif=` tags from snapshot and calls `vif/create` for each; VIF failures are logged and skipped (restore is not aborted)

## Test plan

- [ ] Deploy via `server-install.sh update --source ~/backupos`
- [ ] Run a backup of `xcp-test-3`; verify log line `captured 1 VIF(s) for VM ...`
- [ ] Check restic snapshot tags include `xcp:vif=0={...}`
- [ ] Run restore via UI or smoke script
- [ ] Verify log line `VIF created: device=0 mac=06:a1:d0:8b:3a:5d ...`
- [ ] On XCP-ng host: `xe vif-list vm-uuid=<new-vm-uuid> params=device,MAC,MTU,network-uuid`
- [ ] Boot restored VM and confirm NIC is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)