### PR TITLE
fix(xcp): base64-encode VIF JSON in restic tags (commas split tags otherwise)

### DIFF
--- a/packages/agent/src/handlers/xcpngBackup.ts
+++ b/packages/agent/src/handlers/xcpngBackup.ts
@@ -111,7 +111,8 @@ export async function runXcpngBackup(
       if (vifsResp.status === 200) {
         const parsed = JSON.parse(vifsResp.body) as { vifs: VIFInfo[] }
         for (const vif of parsed.vifs ?? []) {
-          vifTags.push(`xcp:vif=${vif.device}=${JSON.stringify(vif)}`)
+          const encoded = Buffer.from(JSON.stringify(vif)).toString('base64')
+          vifTags.push(`xcp:vif=${vif.device}=${encoded}`)
         }
         log(`captured ${parsed.vifs?.length ?? 0} VIF(s) for VM ${target.vmUUID}`)
       } else {

--- a/packages/agent/src/handlers/xcpngRestore.ts
+++ b/packages/agent/src/handlers/xcpngRestore.ts
@@ -288,9 +288,12 @@ export async function runXcpngVmRestore(
       const rest   = tag.slice(vifPrefix.length)
       const eqIdx  = rest.indexOf('=')
       if (eqIdx < 0) continue
-      const jsonStr = rest.slice(eqIdx + 1)
+      const encoded = rest.slice(eqIdx + 1)
       let vifInfo: { device: string; network_label: string; mac: string; mtu: number; locking_mode: string }
-      try { vifInfo = JSON.parse(jsonStr) } catch { log(`WARN: could not parse VIF tag JSON: ${jsonStr}`); continue }
+      try {
+        const jsonStr = Buffer.from(encoded, 'base64').toString('utf-8')
+        vifInfo = JSON.parse(jsonStr)
+      } catch { log(`WARN: could not parse VIF tag JSON: ${encoded}`); continue }
       try {
         const vifResp = await xcpPost({
           path: '/api2/json/vif/create',


### PR DESCRIPTION
## Summary

Restic uses `,` as its internal tag separator. A raw JSON VIF tag like `xcp:vif=0={"device":"0","network_label":"Pool-wide...","mac":"06:a1:..."}` is silently truncated at the first comma, so the restore handler receives partial JSON and fails to parse it.

Fix: base64-encode the JSON blob in `xcpngBackup.ts` and decode it in `xcpngRestore.ts`.

- **Before:** `xcp:vif=0={"device":"0","network_label":"Pool-wide network associated with eth0",...}` → truncated at first `,`
- **After:** `xcp:vif=0=eyJkZXZpY2UiOiIwIiwibmV0d29ya19sYWJlbCI6...` → no commas, round-trips cleanly

## Test plan

- [ ] Deploy via `server-install.sh update --source ~/backupos`
- [ ] Run backup; check restic snapshot tags — VIF tag value should be a base64 string with no commas
- [ ] Run restore; verify log shows `VIF created: device=0 mac=...` (not a parse error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)