### PR TITLE
fix(xcp): bypass terra-farm VIFRecord wrapper for VIF.create — use raw APICall

### DIFF
--- a/services/backupos-xcp/internal/xapi/vif.go
+++ b/services/backupos-xcp/internal/xapi/vif.go
@@ -111,19 +111,30 @@ func (c *Client) CreateVIFFromInfo(ctx context.Context, vmUUID string, info VIFI
 		mtu = 1500
 	}
 
-	vifRef, err := raw.VIF.Create(sess, xenapi.VIFRecord{
-		Device:             device,
-		Network:            netRef,
-		VM:                 vmRef,
-		MAC:                mac,
-		MTU:                mtu,
-		OtherConfig:        map[string]string{},
-		QosAlgorithmType:   "",
-		QosAlgorithmParams: map[string]string{},
-	})
+	// XAPI's VIF.create rejects terra-farm's VIFRecord wrapper because it
+	// includes runtime/output-only fields. Use only the 11 input fields per XAPI docs.
+	argsMap := map[string]interface{}{
+		"device":               device,
+		"network":              string(netRef),
+		"VM":                   string(vmRef),
+		"MAC":                  mac,
+		"MTU":                  mtu,
+		"other_config":         map[string]string{},
+		"qos_algorithm_type":   "",
+		"qos_algorithm_params": map[string]string{},
+		"locking_mode":         "network_default",
+		"ipv4_allowed":         []string{},
+		"ipv6_allowed":         []string{},
+	}
+	result, err := raw.APICall("VIF.create", sess, argsMap)
 	if err != nil {
 		return "", "", fmt.Errorf("xapi: vif.create: %w", err)
 	}
+	vifRefStr, ok := result.Value.(string)
+	if !ok {
+		return "", "", fmt.Errorf("xapi: vif.create returned non-string ref: %T", result.Value)
+	}
+	vifRef := xenapi.VIFRef(vifRefStr)
 
 	if info.LockingMode != "" && info.LockingMode != "network_default" {
 		var mode xenapi.VifLockingMode


### PR DESCRIPTION
## Summary
- `raw.VIF.Create(sess, VIFRecord{})` sends runtime-only struct fields (UUID, AllowedOperations, RuntimeProperties, etc.) that XAPI rejects with `INTERNAL_ERROR Failure("Unknown tag/contents")`
- Replace with `raw.APICall("VIF.create", sess, argsMap)` passing only the 11 XAPI-specified input fields
- Same pattern already used for `VM.clone` workaround elsewhere in the codebase

## Test plan
- [ ] Deploy via `server-install.sh update --source ~/backupos`
- [ ] Run smoke test: trigger backup → trigger restore → confirm VIFs are recreated on new VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)