### PR TITLE
feat(restore): visual builder for /restore/new (closes #410)

### DIFF
--- a/apps/web/app/(dashboard)/restore/new/new-restore-spec-wizard.tsx
+++ b/apps/web/app/(dashboard)/restore/new/new-restore-spec-wizard.tsx
@@ -1,0 +1,307 @@
+'use client'
+
+import { useState, useEffect, useTransition } from 'react'
+import { validateSpec, createSpec } from '@/app/actions/restore'
+
+type RunOption = { id: string; startedAt: string; snapshotIds: string[] }
+type DiskInfo  = { uuid: string; user_device: string; virtual_size: number }
+type XcpJob    = {
+  id:            string
+  name:          string
+  vmName:        string
+  vmUUID:        string
+  integrationId: string
+  disks:         DiskInfo[]
+  runs:          RunOption[]
+}
+
+type SR = { uuid: string; name_label: string; sr_type: string; physical_size: number; physical_utilisation: number }
+
+const DEFAULT_YAML = `name: my-restore
+description: Description
+version: "1.0"
+
+steps:
+  - name: Restore step
+    type: filesystem_restore
+    snapshot_path: /data/myservice
+    target_path:   /data/myservice
+    on_failure: abort`
+
+const inp: React.CSSProperties = {
+  width: '100%', padding: '8px 12px', boxSizing: 'border-box',
+  backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-sm)', color: 'var(--fg)', fontSize: 13, outline: 'none',
+}
+const lbl: React.CSSProperties = {
+  display: 'block', fontSize: 12, color: 'var(--fg-mute)', marginBottom: 4, fontWeight: 500,
+}
+const section: React.CSSProperties = { marginBottom: 20 }
+
+function fmtBytes(b: number): string {
+  if (b >= 1024**4) return (b / 1024**4).toFixed(1) + ' TiB'
+  if (b >= 1024**3) return (b / 1024**3).toFixed(1) + ' GiB'
+  if (b >= 1024**2) return (b / 1024**2).toFixed(1) + ' MiB'
+  return b + ' B'
+}
+
+export function NewRestoreSpecWizard({ xcpJobs }: { xcpJobs: XcpJob[] }) {
+  const [tab, setTab] = useState<'form' | 'yaml'>('form')
+  const [name, setName] = useState('')
+
+  // YAML mode state
+  const [yaml, setYaml] = useState(DEFAULT_YAML)
+  const [validation, setValidation] = useState<{ ok: boolean; message: string } | null>(null)
+  const [error, setError] = useState('')
+  const [isValidating, startValidating] = useTransition()
+  const [isSaving, startSaving] = useTransition()
+
+  // Form mode state
+  const [stepName, setStepName] = useState('Restore VM')
+  const [selectedJobId, setSelectedJobId] = useState(xcpJobs[0]?.id ?? '')
+  const selectedJob = xcpJobs.find(j => j.id === selectedJobId)
+
+  const [vmName, setVmName] = useState(() => selectedJob ? `${selectedJob.vmName}-restored` : '')
+  useEffect(() => {
+    if (selectedJob) setVmName(`${selectedJob.vmName}-restored`)
+  }, [selectedJobId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const [targetSrUUID, setTargetSrUUID] = useState('')
+  const [memoryMiB, setMemoryMiB] = useState<number | ''>('')
+  const [vcpus, setVcpus] = useState<number | ''>('')
+
+  const [srs, setSrs] = useState<SR[] | null>(null)
+  const [srsLoading, setSrsLoading] = useState(false)
+  const [srsError, setSrsError] = useState('')
+
+  useEffect(() => {
+    if (!selectedJob?.integrationId) { setSrs(null); return }
+    setSrsLoading(true)
+    setSrsError('')
+    setTargetSrUUID('')
+    fetch(`/api/internal/integration/${selectedJob.integrationId}/srs`)
+      .then(r => r.json())
+      .then((j: { error?: string; srs?: SR[] }) => {
+        if (j.error) { setSrsError(j.error); setSrs([]) }
+        else { setSrs(j.srs ?? []) }
+      })
+      .catch((e: unknown) => setSrsError(String(e)))
+      .finally(() => setSrsLoading(false))
+  }, [selectedJob?.integrationId])
+
+  function generateYaml(): string {
+    if (!selectedJob) return DEFAULT_YAML
+    const lines: string[] = [
+      `name: ${name || 'restore-' + selectedJob.name}`,
+      `description: Restore VM ${selectedJob.vmName} from backup`,
+      `version: "1.0"`,
+      ``,
+      `steps:`,
+      `  - name: ${stepName}`,
+      `    type: xcpng_vm_restore`,
+      `    backup_job_id: "${selectedJob.id}"`,
+      `    vm_uuid: "${selectedJob.vmUUID}"`,
+      `    vm_name: "${vmName}"`,
+      `    target_sr_uuid: "${targetSrUUID}"`,
+    ]
+    if (memoryMiB && memoryMiB > 0) lines.push(`    memory_bytes: ${Number(memoryMiB) * 1024 * 1024}`)
+    if (vcpus && vcpus > 0) lines.push(`    vcpus: ${vcpus}`)
+    lines.push(`    on_failure: abort`)
+    return lines.join('\n')
+  }
+
+  function handleValidate(yamlContent: string) {
+    setValidation(null)
+    startValidating(async () => {
+      const result = await validateSpec(yamlContent)
+      setValidation(result.ok
+        ? { ok: true, message: 'YAML is valid — all steps parsed successfully.' }
+        : { ok: false, message: result.error })
+    })
+  }
+
+  function handleSave(yamlContent: string) {
+    setError('')
+    startSaving(async () => {
+      const result = await createSpec(name, yamlContent)
+      if (result && 'error' in result) setError(result.error)
+    })
+  }
+
+  const formIsValid = name.trim() !== '' && selectedJob != null && vmName.trim() !== '' && targetSrUUID !== ''
+  const activeYaml  = tab === 'form' ? generateYaml() : yaml
+
+  return (
+    <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)', padding: 24 }}>
+      <div style={{ marginBottom: 20 }}>
+        <label style={lbl}>Restore spec name</label>
+        <input
+          type="text"
+          placeholder="my-vm-restore"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          style={inp}
+        />
+      </div>
+
+      {/* Tabs */}
+      <div style={{ display: 'flex', borderBottom: '1px solid var(--border)', marginBottom: 20 }}>
+        {(['form', 'yaml'] as const).map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            style={{
+              padding: '10px 16px', fontSize: 13, fontWeight: 500, cursor: 'pointer',
+              background: 'transparent', border: 'none',
+              borderBottom: tab === t ? '2px solid var(--accent)' : '2px solid transparent',
+              color: tab === t ? 'var(--fg)' : 'var(--fg-dim)',
+              marginBottom: -1,
+            }}
+          >
+            {t === 'form' ? 'Form (XCP-ng VM)' : 'YAML (advanced)'}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'form' && (
+        <>
+          {xcpJobs.length === 0 ? (
+            <div style={{ fontSize: 13, color: 'var(--fg-mute)', padding: 12, background: 'var(--surf2)', borderRadius: 'var(--radius-sm)', marginBottom: 16 }}>
+              No XCP-ng VM backup jobs found. Create an xcpng_vm backup job first, then come back to author a restore spec for it.
+              You can also use the YAML tab to author other step types (filesystem, database, etc.).
+            </div>
+          ) : (
+            <>
+              <div style={section}>
+                <label style={lbl}>Backup job</label>
+                <select value={selectedJobId} onChange={e => setSelectedJobId(e.target.value)} style={inp}>
+                  {xcpJobs.map(j => (
+                    <option key={j.id} value={j.id}>
+                      {j.name} (VM: {j.vmName}, {j.disks.length} disk{j.disks.length === 1 ? '' : 's'}, {j.runs.length} successful run{j.runs.length === 1 ? '' : 's'})
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div style={section}>
+                <label style={lbl}>Step name</label>
+                <input type="text" value={stepName} onChange={e => setStepName(e.target.value)} style={inp} placeholder="Restore VM" />
+              </div>
+
+              <div style={section}>
+                <label style={lbl}>New VM name</label>
+                <input type="text" value={vmName} onChange={e => setVmName(e.target.value)} style={inp} placeholder={`${selectedJob?.vmName ?? ''}-restored`} />
+              </div>
+
+              <div style={section}>
+                <label style={lbl}>
+                  Target storage (SR)
+                  {srsLoading && <span style={{ marginLeft: 8, color: 'var(--fg-dim)', fontWeight: 400 }}>loading…</span>}
+                </label>
+                {srsError && <div style={{ fontSize: 12, color: 'var(--err)', marginBottom: 6 }}>{srsError}</div>}
+                <select value={targetSrUUID} onChange={e => setTargetSrUUID(e.target.value)} style={inp} disabled={srsLoading}>
+                  <option value="">— select an SR —</option>
+                  {srs?.filter(s => s.sr_type !== 'iso' && s.sr_type !== 'udev').map(s => {
+                    const free = s.physical_size - s.physical_utilisation
+                    return (
+                      <option key={s.uuid} value={s.uuid}>
+                        {s.name_label} ({s.sr_type}, {fmtBytes(free)} free of {fmtBytes(s.physical_size)})
+                      </option>
+                    )
+                  })}
+                </select>
+              </div>
+
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 20 }}>
+                <div>
+                  <label style={lbl}>Memory (MiB) — optional, defaults to source VM</label>
+                  <input
+                    type="number"
+                    placeholder="e.g. 2048"
+                    value={memoryMiB}
+                    onChange={e => setMemoryMiB(e.target.value === '' ? '' : Number(e.target.value))}
+                    style={inp}
+                  />
+                </div>
+                <div>
+                  <label style={lbl}>vCPUs — optional, defaults to source VM</label>
+                  <input
+                    type="number"
+                    placeholder="e.g. 2"
+                    value={vcpus}
+                    onChange={e => setVcpus(e.target.value === '' ? '' : Number(e.target.value))}
+                    style={inp}
+                  />
+                </div>
+              </div>
+
+              <details style={{ marginBottom: 16, padding: 12, background: 'var(--surf2)', borderRadius: 'var(--radius-sm)' }}>
+                <summary style={{ cursor: 'pointer', fontSize: 12, color: 'var(--fg-mute)' }}>Generated YAML preview</summary>
+                <pre style={{ marginTop: 12, fontSize: 12, fontFamily: 'var(--font-mono)', whiteSpace: 'pre-wrap', color: 'var(--fg)', margin: '12px 0 0' }}>
+                  {generateYaml()}
+                </pre>
+              </details>
+            </>
+          )}
+        </>
+      )}
+
+      {tab === 'yaml' && (
+        <div style={section}>
+          <label style={lbl}>YAML spec</label>
+          <textarea
+            value={yaml}
+            onChange={e => { setYaml(e.target.value); setValidation(null) }}
+            rows={28}
+            style={{ ...inp, fontSize: 12, fontFamily: 'var(--font-mono)', lineHeight: 1.6, resize: 'vertical' }}
+          />
+        </div>
+      )}
+
+      {validation && (
+        <div style={{
+          padding: '10px 14px', marginBottom: 16, borderRadius: 'var(--radius-sm)', fontSize: 13,
+          backgroundColor: validation.ok ? 'var(--ok-dim)' : 'var(--err-dim)',
+          border: `1px solid ${validation.ok ? 'color-mix(in srgb, var(--ok) 30%, transparent)' : 'color-mix(in srgb, var(--err) 30%, transparent)'}`,
+          color: validation.ok ? 'var(--ok)' : 'var(--err)',
+        }}>
+          {validation.message}
+        </div>
+      )}
+
+      {error && (
+        <div style={{ padding: '10px 14px', marginBottom: 16, borderRadius: 'var(--radius-sm)', fontSize: 13, backgroundColor: 'var(--err-dim)', color: 'var(--err)' }}>
+          {error}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 12 }}>
+        <button
+          onClick={() => handleValidate(activeYaml)}
+          disabled={isValidating || (tab === 'form' && !formIsValid)}
+          style={{
+            padding: '8px 18px', fontSize: 13, fontWeight: 500, cursor: 'pointer',
+            borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+            background: 'var(--surf2)', color: 'var(--fg)',
+            opacity: (isValidating || (tab === 'form' && !formIsValid)) ? 0.6 : 1,
+          }}
+        >
+          {isValidating ? 'Validating…' : 'Validate'}
+        </button>
+        <button
+          onClick={() => handleSave(activeYaml)}
+          disabled={isSaving || !name.trim() || (tab === 'form' && !formIsValid)}
+          style={{
+            padding: '8px 18px', fontSize: 13, fontWeight: 600,
+            cursor: (isSaving || !name.trim() || (tab === 'form' && !formIsValid)) ? 'not-allowed' : 'pointer',
+            borderRadius: 'var(--radius-sm)', border: 'none',
+            background: 'var(--accent)', color: 'var(--accent-fg)',
+            opacity: (isSaving || !name.trim() || (tab === 'form' && !formIsValid)) ? 0.6 : 1,
+          }}
+        >
+          {isSaving ? 'Saving…' : 'Save spec'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/restore/new/page.tsx
+++ b/apps/web/app/(dashboard)/restore/new/page.tsx
@@ -1,158 +1,80 @@
-'use client'
+import { getDb, backupJobs, backupRuns, hypervisorTargets, eq, and, desc } from '@backupos/db'
+import { NewRestoreSpecWizard } from './new-restore-spec-wizard'
 
-import { useState, useTransition } from 'react'
-import { useRouter } from 'next/navigation'
-import { validateSpec, createSpec } from '@/app/actions/restore'
+export const dynamic = 'force-dynamic'
 
-const EXAMPLE_YAML = `name: my-service-full
-description: Full restore of my-service
-version: "1.0"
-repository: homelab-r2
+export default async function NewRestoreSpecPage() {
+  const db = getDb()
 
-steps:
-  - name: Restore database
-    type: database_restore
-    app: postgres
-    snapshot_path: /tmp/backupos-pg-myservice.sql.gz
-    target:
-      container: myservice-db
-      database: myservice
-      username: myservice
-    on_failure: abort
+  const xcpJobs = await db
+    .select({
+      id:            backupJobs.id,
+      name:          backupJobs.name,
+      sourceConfig:  backupJobs.sourceConfig,
+    })
+    .from(backupJobs)
+    .where(eq(backupJobs.sourceType, 'xcpng_vm'))
+    .all()
 
-  - name: Restore data volume
-    type: filesystem_restore
-    snapshot_path: /data/myservice
-    target_path: /data/myservice
-    on_failure: abort
-
-  - name: Restart service
-    type: shell
-    command: docker compose -f /opt/myservice/docker-compose.yml up -d
-    on_failure: abort
-
-  - name: Health check
-    type: http_check
-    url: http://localhost:8080/health
-    expected_status: 200
-    timeout_seconds: 30
-    retry_count: 5
-    on_failure: notify_only`
-
-const inputStyle: React.CSSProperties = {
-  width: '100%', padding: '8px 12px', boxSizing: 'border-box',
-  backgroundColor: 'var(--surf2)', border: '1px solid var(--border)',
-  borderRadius: 'var(--radius-sm)', color: 'var(--fg)', fontSize: 14, outline: 'none',
-}
-
-export default function NewRestoreSpecPage() {
-  const router = useRouter()
-  const [name, setName] = useState('')
-  const [yaml, setYaml] = useState(EXAMPLE_YAML)
-  const [validation, setValidation] = useState<{ ok: boolean; message: string } | null>(null)
-  const [error, setError] = useState('')
-  const [isValidating, startValidating] = useTransition()
-  const [isSaving, startSaving] = useTransition()
-
-  function handleValidate() {
-    setValidation(null)
-    startValidating(async () => {
-      const result = await validateSpec(yaml)
-      if (result.ok) {
-        setValidation({ ok: true, message: 'YAML is valid — all steps parsed successfully.' })
-      } else {
-        setValidation({ ok: false, message: result.error })
+  const xcpJobData = await Promise.all(xcpJobs.map(async job => {
+    let target: { id: string; name: string; externalId: string; integrationId: string | null; tags: string | null } | null = null
+    try {
+      const cfg = JSON.parse(job.sourceConfig) as { targetId?: string }
+      if (cfg.targetId) {
+        const [t] = await db
+          .select({
+            id:            hypervisorTargets.id,
+            name:          hypervisorTargets.name,
+            externalId:    hypervisorTargets.externalId,
+            integrationId: hypervisorTargets.integrationId,
+            tags:          hypervisorTargets.tags,
+          })
+          .from(hypervisorTargets)
+          .where(eq(hypervisorTargets.id, cfg.targetId))
+          .limit(1)
+        target = t ?? null
       }
-    })
-  }
+    } catch { /* malformed sourceConfig */ }
 
-  function handleSave() {
-    setError('')
-    startSaving(async () => {
-      const result = await createSpec(name, yaml)
-      if (result && 'error' in result) setError(result.error)
-      // on success createSpec calls redirect() — nothing else needed
-    })
-  }
+    const runs = await db
+      .select({ id: backupRuns.id, startedAt: backupRuns.startedAt, snapshotIds: backupRuns.snapshotIds })
+      .from(backupRuns)
+      .where(and(eq(backupRuns.jobId, job.id), eq(backupRuns.status, 'success')))
+      .orderBy(desc(backupRuns.startedAt))
+      .limit(10)
+      .all()
+
+    let disks: Array<{ uuid: string; user_device: string; virtual_size: number }> = []
+    if (target?.tags) {
+      try {
+        const t = JSON.parse(target.tags) as { disks?: Array<{ uuid: string; user_device: string; virtual_size: number }> }
+        disks = t.disks ?? []
+      } catch { /* malformed tags */ }
+    }
+
+    return {
+      id:            job.id,
+      name:          job.name,
+      vmName:        target?.name ?? job.name,
+      vmUUID:        target?.externalId ?? '',
+      integrationId: target?.integrationId ?? '',
+      disks,
+      runs: runs.map(r => ({
+        id:          r.id,
+        startedAt:   r.startedAt ? r.startedAt.toISOString() : new Date(0).toISOString(),
+        snapshotIds: r.snapshotIds ? (JSON.parse(r.snapshotIds) as string[]) : [],
+      })),
+    }
+  }))
 
   return (
-    <div style={{ maxWidth: 700 }}>
+    <div style={{ maxWidth: 800 }}>
       <a href="/restore" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--fg-dim)', textDecoration: 'none', marginBottom: 20 }}>← Restore</a>
       <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginBottom: 8 }}>New restore spec</h1>
       <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginBottom: 24 }}>
-        Define your restore procedure as YAML. Validate before saving to catch errors early.
+        Define your restore as a sequence of steps. Use the form for guided VM restore, or YAML for advanced multi-step flows.
       </p>
-
-      <div style={{ backgroundColor: 'var(--surf)', border: '1px solid var(--border)', borderRadius: 'var(--radius)', padding: 24 }}>
-        <div style={{ marginBottom: 20 }}>
-          <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6, fontWeight: 500 }}>Name</label>
-          <input
-            type="text"
-            placeholder="my-service-full"
-            value={name}
-            onChange={e => setName(e.target.value)}
-            style={inputStyle}
-          />
-        </div>
-
-        <div style={{ marginBottom: 20 }}>
-          <label style={{ display: 'block', fontSize: 13, color: 'var(--fg-mute)', marginBottom: 6, fontWeight: 500 }}>YAML spec</label>
-          <textarea
-            value={yaml}
-            onChange={e => { setYaml(e.target.value); setValidation(null) }}
-            rows={28}
-            style={{
-              ...inputStyle,
-              fontSize: 12, fontFamily: 'var(--font-mono)',
-              lineHeight: 1.6, resize: 'vertical',
-            }}
-          />
-        </div>
-
-        {validation && (
-          <div style={{
-            padding: '10px 14px', marginBottom: 16, borderRadius: 'var(--radius-sm)', fontSize: 13,
-            backgroundColor: validation.ok ? 'var(--ok-dim)' : 'var(--err-dim)',
-            border: `1px solid ${validation.ok ? 'color-mix(in srgb, var(--ok) 30%, transparent)' : 'color-mix(in srgb, var(--err) 30%, transparent)'}`,
-            color: validation.ok ? 'var(--ok)' : 'var(--err)',
-          }}>
-            {validation.message}
-          </div>
-        )}
-
-        {error && (
-          <div style={{ padding: '10px 14px', marginBottom: 16, borderRadius: 'var(--radius-sm)', fontSize: 13, backgroundColor: 'var(--err-dim)', color: 'var(--err)' }}>
-            {error}
-          </div>
-        )}
-
-        <div style={{ display: 'flex', gap: 12 }}>
-          <button
-            onClick={handleValidate}
-            disabled={isValidating}
-            style={{
-              padding: '8px 18px', fontSize: 13, fontWeight: 500, cursor: 'pointer',
-              borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
-              background: 'var(--surf2)', color: 'var(--fg)',
-              opacity: isValidating ? 0.6 : 1,
-            }}
-          >
-            {isValidating ? 'Validating…' : 'Validate'}
-          </button>
-          <button
-            onClick={handleSave}
-            disabled={isSaving || !name.trim()}
-            style={{
-              padding: '8px 18px', fontSize: 13, fontWeight: 600, cursor: isSaving || !name.trim() ? 'not-allowed' : 'pointer',
-              borderRadius: 'var(--radius-sm)', border: 'none',
-              background: 'var(--accent)', color: 'var(--accent-fg)',
-              opacity: isSaving || !name.trim() ? 0.6 : 1,
-            }}
-          >
-            {isSaving ? 'Saving…' : 'Save spec'}
-          </button>
-        </div>
-      </div>
+      <NewRestoreSpecWizard xcpJobs={xcpJobData} />
     </div>
   )
 }

--- a/apps/web/app/api/internal/integration/[id]/srs/route.ts
+++ b/apps/web/app/api/internal/integration/[id]/srs/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDb, hypervisorIntegrations, eq } from '@backupos/db'
+import { getCurrentUser } from '@/lib/user'
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const { id } = await params
+
+  const db = getDb()
+  const [integration] = await db
+    .select()
+    .from(hypervisorIntegrations)
+    .where(eq(hypervisorIntegrations.id, id))
+    .limit(1)
+  if (!integration) return NextResponse.json({ error: 'integration not found' }, { status: 404 })
+
+  const xcpUrl = process.env['BACKUPOS_XCP_URL']
+  const internalSecret = process.env['BACKUPOS_INTERNAL_SECRET']
+  if (!xcpUrl || !internalSecret) {
+    return NextResponse.json({ error: 'BACKUPOS_XCP_URL or BACKUPOS_INTERNAL_SECRET not set' }, { status: 500 })
+  }
+
+  let cfg: { host?: string; username?: string; password?: string; cert_fingerprint_sha256?: string }
+  try {
+    cfg = JSON.parse(integration.config) as typeof cfg
+  } catch {
+    return NextResponse.json({ error: 'malformed integration config' }, { status: 500 })
+  }
+
+  const host = cfg.host ?? ''
+  const poolMasterUrl = host.startsWith('http') ? host : `https://${host}`
+  const username = cfg.username ?? 'root'
+  const password = cfg.password ?? ''
+  const certFingerprint = cfg.cert_fingerprint_sha256 ?? ''
+
+  let resp: Response
+  try {
+    resp = await fetch(`${xcpUrl}/api2/json/sr/list`, {
+      method: 'GET',
+      headers: {
+        'Authorization':                  `Bearer ${internalSecret}`,
+        'X-XAPI-Pool-Master-URL':         poolMasterUrl,
+        'X-XAPI-Username':                username,
+        'X-XAPI-Password':                password,
+        'X-XAPI-Cert-Fingerprint-SHA256': certFingerprint,
+      },
+    })
+  } catch (e) {
+    return NextResponse.json({ error: `failed to reach xcp service: ${String(e)}` }, { status: 502 })
+  }
+
+  if (!resp.ok) {
+    const text = await resp.text()
+    return NextResponse.json({ error: `xcp service ${resp.status}: ${text}` }, { status: 502 })
+  }
+
+  const j = await resp.json() as { srs?: unknown[] }
+  return NextResponse.json({ srs: j.srs ?? [] })
+}


### PR DESCRIPTION
## Summary
- Replaces bare YAML textarea at `/restore/new` with a tabbed interface
- **Form tab** (default): wizard for `xcpng_vm_restore` — backup job picker, VM name auto-fill, live SR dropdown (free space shown), optional memory/vCPUs, generated YAML preview via `<details>`
- **YAML tab**: existing raw editor kept as escape hatch for power users and non-XCP step types
- Page converted from `'use client'` to server component for data fetching; wizard is a separate client component
- Adds `GET /api/internal/integration/[id]/srs` — proxies xcp service SR list, protected by user cookie session

## Notes
- Integration config read as plain JSON (matches existing `hypervisors.ts` pattern — no decrypt)
- Tab state is independent (no form↔YAML sync, per spec — Phase 2 follow-up)
- SR dropdown filters out `iso` and `udev` SR types

## Test plan
- [ ] Deploy via `server-install.sh update --source ~/backupos`
- [ ] Visit `/restore/new` — Form tab is default
- [ ] Backup job dropdown lists xcpng_vm jobs with disk/run counts
- [ ] Selecting a job auto-fills VM name as `<vmname>-restored`
- [ ] SR dropdown populates with name + free space
- [ ] Memory/vCPUs optional; YAML preview updates in real-time
- [ ] Save creates spec, redirects to `/restore`
- [ ] YAML tab still works for legacy authoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)