### PR TITLE
feat(restore): filter half-configured jobs from /restore/new wizard (closes #425)

### DIFF
--- a/apps/web/app/(dashboard)/restore/new/new-restore-spec-wizard.tsx
+++ b/apps/web/app/(dashboard)/restore/new/new-restore-spec-wizard.tsx
@@ -45,7 +45,13 @@ function fmtBytes(b: number): string {
   return b + ' B'
 }
 
-export function NewRestoreSpecWizard({ xcpJobs }: { xcpJobs: XcpJob[] }) {
+export function NewRestoreSpecWizard({
+  xcpJobs,
+  invalidJobs,
+}: {
+  xcpJobs: XcpJob[]
+  invalidJobs: Array<{ id: string; name: string; reason: string }>
+}) {
   const [tab, setTab] = useState<'form' | 'yaml'>('form')
   const [name, setName] = useState('')
 
@@ -165,13 +171,44 @@ export function NewRestoreSpecWizard({ xcpJobs }: { xcpJobs: XcpJob[] }) {
 
       {tab === 'form' && (
         <>
-          {xcpJobs.length === 0 ? (
+          {xcpJobs.length === 0 && invalidJobs.length === 0 && (
             <div style={{ fontSize: 13, color: 'var(--fg-mute)', padding: 12, background: 'var(--surf2)', borderRadius: 'var(--radius-sm)', marginBottom: 16 }}>
               No XCP-ng VM backup jobs found. Create an xcpng_vm backup job first, then come back to author a restore spec for it.
               You can also use the YAML tab to author other step types (filesystem, database, etc.).
             </div>
-          ) : (
+          )}
+
+          {xcpJobs.length === 0 && invalidJobs.length > 0 && (
+            <div style={{ fontSize: 13, color: 'var(--fg-mute)', padding: 12, background: 'var(--surf2)', borderRadius: 'var(--radius-sm)', marginBottom: 16 }}>
+              <div style={{ marginBottom: 8 }}>
+                You have {invalidJobs.length} XCP-ng backup job{invalidJobs.length === 1 ? '' : 's'} but
+                none are fully configured for restore:
+              </div>
+              <ul style={{ margin: 0, paddingLeft: 20 }}>
+                {invalidJobs.map(j => (
+                  <li key={j.id} style={{ marginBottom: 4 }}>
+                    <span style={{ color: 'var(--fg)' }}>{j.name}</span>
+                    {' — '}
+                    <span style={{ color: 'var(--warn)' }}>{j.reason}</span>
+                  </li>
+                ))}
+              </ul>
+              <div style={{ marginTop: 8 }}>
+                Edit the job&apos;s hypervisor target to fix, or use the YAML tab for other step types
+                (filesystem, database, etc.).
+              </div>
+            </div>
+          )}
+
+          {xcpJobs.length > 0 && (
             <>
+              {invalidJobs.length > 0 && (
+                <div style={{ fontSize: 12, color: 'var(--warn)', marginBottom: 12 }}>
+                  {invalidJobs.length} other job{invalidJobs.length === 1 ? '' : 's'} hidden because
+                  {invalidJobs.length === 1 ? ' it is' : ' they are'} not fully configured for restore.
+                </div>
+              )}
+
               <div style={section}>
                 <label style={lbl}>Backup job</label>
                 <select value={selectedJobId} onChange={e => setSelectedJobId(e.target.value)} style={inp}>

--- a/apps/web/app/(dashboard)/restore/new/page.tsx
+++ b/apps/web/app/(dashboard)/restore/new/page.tsx
@@ -67,6 +67,32 @@ export default async function NewRestoreSpecPage() {
     }
   }))
 
+  type InvalidJob = { id: string; name: string; reason: string }
+  const validJobs: typeof xcpJobData = []
+  const invalidJobs: InvalidJob[] = []
+
+  for (const job of xcpJobData) {
+    if (!job.vmUUID && !job.integrationId) {
+      // target was null — check by whether both are empty (target null path sets both to '')
+      // Distinguish: if integrationId is '' and vmUUID is '' it means target was null
+      invalidJobs.push({ id: job.id, name: job.name, reason: 'no target configured' })
+    } else if (!job.integrationId) {
+      invalidJobs.push({ id: job.id, name: job.name, reason: 'target has no integration' })
+    } else if (!job.vmUUID) {
+      invalidJobs.push({ id: job.id, name: job.name, reason: 'target has no VM UUID' })
+    } else {
+      validJobs.push(job)
+    }
+  }
+
+  // Jobs with successful runs first, then alphabetically by name
+  validJobs.sort((a, b) => {
+    const aHasRuns = a.runs.length > 0 ? 0 : 1
+    const bHasRuns = b.runs.length > 0 ? 0 : 1
+    if (aHasRuns !== bHasRuns) return aHasRuns - bHasRuns
+    return a.name.localeCompare(b.name)
+  })
+
   return (
     <div style={{ maxWidth: 800 }}>
       <a href="/restore" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--fg-dim)', textDecoration: 'none', marginBottom: 20 }}>← Restore</a>
@@ -74,7 +100,7 @@ export default async function NewRestoreSpecPage() {
       <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginBottom: 24 }}>
         Define your restore as a sequence of steps. Use the form for guided VM restore, or YAML for advanced multi-step flows.
       </p>
-      <NewRestoreSpecWizard xcpJobs={xcpJobData} />
+      <NewRestoreSpecWizard xcpJobs={validJobs} invalidJobs={invalidJobs} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Closes #425.

A job with `source_config = {}` (or a missing/detached `hypervisorTarget`) was reaching the wizard dropdown, defaulting as the first entry, and producing invalid YAML with empty `vm_uuid` plus a silent SR fetch failure.

## Filter logic (`page.tsx`)

After building `xcpJobData`, partitions into `validJobs` / `invalidJobs`:

| Condition | Reason shown |
|-----------|--------------|
| `target` was null (both `vmUUID` and `integrationId` empty) | `"no target configured"` |
| `integrationId` is empty | `"target has no integration"` |
| `vmUUID` is empty | `"target has no VM UUID"` |

`validJobs` is sorted: jobs with ≥1 successful run come first, then alphabetically by name — so the dropdown defaults to a job the user has actually been backing up.

## Four UI states (`new-restore-spec-wizard.tsx`)

- **Case A** (`validJobs=0, invalidJobs=0`): existing "no jobs found" message unchanged
- **Case B** (`validJobs=0, invalidJobs>0`): lists each invalid job with its reason in warn colour
- **Case C** (`validJobs>0, invalidJobs>0`): small inline hint above dropdown — "N jobs hidden because they are not fully configured"
- **Case D** (`validJobs>0, invalidJobs=0`): no change

## Diff scope

Exactly 2 files changed: `page.tsx` and `new-restore-spec-wizard.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)