### PR TITLE
fix(restore): SR dropdown shows real values and wizard generates valid YAML

### DIFF
--- a/apps/web/app/(dashboard)/restore/new/new-restore-spec-wizard.tsx
+++ b/apps/web/app/(dashboard)/restore/new/new-restore-spec-wizard.tsx
@@ -11,11 +11,12 @@ type XcpJob    = {
   vmName:        string
   vmUUID:        string
   integrationId: string
+  repositoryId:  string
   disks:         DiskInfo[]
   runs:          RunOption[]
 }
 
-type SR = { uuid: string; name_label: string; sr_type: string; physical_size: number; physical_utilisation: number }
+type SR = { uuid: string; name_label: string; type: string; free_bytes: number; total_bytes: number }
 
 const DEFAULT_YAML = `name: my-restore
 description: Description
@@ -101,6 +102,7 @@ export function NewRestoreSpecWizard({
       `name: ${name || 'restore-' + selectedJob.name}`,
       `description: Restore VM ${selectedJob.vmName} from backup`,
       `version: "1.0"`,
+      `repository: "${selectedJob.repositoryId}"`,
       ``,
       `steps:`,
       `  - name: ${stepName}`,
@@ -238,11 +240,10 @@ export function NewRestoreSpecWizard({
                 {srsError && <div style={{ fontSize: 12, color: 'var(--err)', marginBottom: 6 }}>{srsError}</div>}
                 <select value={targetSrUUID} onChange={e => setTargetSrUUID(e.target.value)} style={inp} disabled={srsLoading}>
                   <option value="">— select an SR —</option>
-                  {srs?.filter(s => s.sr_type !== 'iso' && s.sr_type !== 'udev').map(s => {
-                    const free = s.physical_size - s.physical_utilisation
+                  {srs?.filter(s => s.type !== 'iso' && s.type !== 'udev').map(s => {
                     return (
                       <option key={s.uuid} value={s.uuid}>
-                        {s.name_label} ({s.sr_type}, {fmtBytes(free)} free of {fmtBytes(s.physical_size)})
+                        {s.name_label} ({s.type}, {fmtBytes(s.free_bytes)} free of {fmtBytes(s.total_bytes)})
                       </option>
                     )
                   })}

--- a/apps/web/app/(dashboard)/restore/new/page.tsx
+++ b/apps/web/app/(dashboard)/restore/new/page.tsx
@@ -11,6 +11,7 @@ export default async function NewRestoreSpecPage() {
       id:            backupJobs.id,
       name:          backupJobs.name,
       sourceConfig:  backupJobs.sourceConfig,
+      repositoryId:  backupJobs.repositoryId,
     })
     .from(backupJobs)
     .where(eq(backupJobs.sourceType, 'xcpng_vm'))
@@ -58,6 +59,7 @@ export default async function NewRestoreSpecPage() {
       vmName:        target?.name ?? job.name,
       vmUUID:        target?.externalId ?? '',
       integrationId: target?.integrationId ?? '',
+      repositoryId:  job.repositoryId ?? '',
       disks,
       runs: runs.map(r => ({
         id:          r.id,


### PR DESCRIPTION
## Summary

Fixes two bugs shipped by #424.

### Bug 1 — SR dropdown showed "NaN B free of undefined B"

The wizard's `SR` TypeScript type expected `{ sr_type, physical_size, physical_utilisation }` but the backupos-xcp service (`SRInfo` struct in `vdi.go`) actually returns `{ type, free_bytes, total_bytes }`. Field-name mismatch caused all three values to be `undefined`/`NaN` at runtime.

Fix: update the `SR` type and the `<option>` rendering to use the real field names.

### Bug 2 — Validation failed with "repository: Required"

`packages/restore/src/parser.ts` requires a top-level `repository` field on every spec. The wizard's `generateYaml()` did not emit one. Every form-generated spec failed validation immediately.

Fix: select `repositoryId` from `backupJobs` in `page.tsx`, thread it through the `XcpJob` type, and emit `repository: "<uuid>"` between `version` and `steps` in the generated YAML.

## Diff scope

Exactly 2 files: `page.tsx` and `new-restore-spec-wizard.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)