### PR TITLE
fix(install): auto-install NFS client (nfs-common/nfs-utils) for NFS-backed repos (closes #407)

### DIFF
--- a/scripts/server-install.sh
+++ b/scripts/server-install.sh
@@ -212,6 +212,27 @@ else
   log "WARN: nbdsh not found — NBD snapshot read endpoint will return errors until installed"
 fi
 
+# ── NFS client ────────────────────────────────────────────────────────────────
+# Required for restic repositories on NFS-backed datastores (the built-in
+# agent mounts NFS in its own namespace via `mount -t nfs`). Without this,
+# `mount.nfs` is missing and the first NFS backup fails with "you might
+# need a /sbin/mount.<type> helper program".
+if ! command -v mount.nfs &>/dev/null; then
+  log "Installing NFS client..."
+  if command -v apt-get &>/dev/null; then
+    apt-get install -y nfs-common
+  elif command -v yum &>/dev/null; then
+    yum install -y nfs-utils
+  else
+    log "WARN: cannot auto-install NFS client — install nfs-common (Debian/Ubuntu) or nfs-utils (RHEL/Fedora) manually if you plan to use NFS-backed repositories"
+  fi
+fi
+if command -v mount.nfs &>/dev/null; then
+  ok "NFS client (mount.nfs)"
+else
+  log "WARN: mount.nfs not found — NFS-backed repositories will fail to mount until installed"
+fi
+
 # Go (1.22+) for backupos-pbs service.
 #
 # Users typically install Go from the official tarball at /usr/local/go/.


### PR DESCRIPTION
## Summary

Closes #407.

Without `nfs-common` (Debian/Ubuntu) or `nfs-utils` (RHEL/Fedora), `mount.nfs` is absent on the server host and the first backup targeting an NFS-backed restic repository fails with:

```
mount: bad option; for several filesystems (e.g. nfs, cifs) you might need a /sbin/mount.<type> helper program
```

## Fix

Adds an NFS-client install block to `scripts/server-install.sh` after the existing `nbdsh` block, following the same detection-and-install pattern used throughout section 1:

- Detects by `command -v mount.nfs` (binary-based, not package-name-based — works cross-distro)
- Installs `nfs-common` on Debian/Ubuntu (`apt-get`)
- Installs `nfs-utils` on RHEL/Fedora (`yum`)
- Logs a WARN and continues on unknown distros (matches `nbdsh` fallback behaviour)
- Reports success/warn with `ok`/`log` helpers consistent with the rest of the script

Purely additive — no existing lines modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)