### PR TITLE
feat(hypervisors): add edit and delete actions to hypervisors page (closes #398)

### DIFF
--- a/apps/web/app/(dashboard)/hypervisors/[id]/edit/page.tsx
+++ b/apps/web/app/(dashboard)/hypervisors/[id]/edit/page.tsx
@@ -1,0 +1,167 @@
+import { redirect, notFound } from 'next/navigation'
+import { getDb, hypervisorIntegrations, eq } from '@backupos/db'
+import Link from 'next/link'
+import { updateHypervisorIntegration } from '@/app/actions/hypervisors'
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 12px',
+  backgroundColor: 'var(--surf2)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-sm)',
+  color: 'var(--fg)',
+  fontSize: 14,
+  outline: 'none',
+  boxSizing: 'border-box',
+}
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontSize: 13,
+  color: 'var(--fg-mute)',
+  marginBottom: 6,
+  fontWeight: 500,
+}
+
+const readonlyStyle: React.CSSProperties = {
+  ...inputStyle,
+  backgroundColor: 'var(--surf)',
+  color: 'var(--fg-dim)',
+  cursor: 'not-allowed',
+}
+
+export default async function EditHypervisorPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+
+  const db = getDb()
+  const [integration] = await db
+    .select()
+    .from(hypervisorIntegrations)
+    .where(eq(hypervisorIntegrations.id, id))
+    .limit(1)
+
+  if (!integration) notFound()
+
+  let cfg: {
+    host?: string
+    username?: string
+    port?: number
+    cert_fingerprint_sha256?: string
+  } = {}
+  try {
+    cfg = JSON.parse(integration.config)
+  } catch {
+    cfg = {}
+  }
+
+  async function update(formData: FormData) {
+    'use server'
+    const result = await updateHypervisorIntegration(id, formData)
+    if (result?.error) return
+    redirect('/hypervisors')
+  }
+
+  return (
+    <div style={{ maxWidth: 520 }}>
+      <Link href="/hypervisors" style={{ fontSize: 13, color: 'var(--fg-mute)', textDecoration: 'none' }}>
+        ← Hypervisors
+      </Link>
+      <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginTop: 8, marginBottom: 24 }}>
+        Edit hypervisor
+      </h1>
+
+      <form action={update}>
+        <div style={{
+          backgroundColor: 'var(--surf)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius)',
+          padding: 24,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 16,
+        }}>
+          <div>
+            <label style={labelStyle}>Name</label>
+            <input name="name" required defaultValue={integration.name} style={inputStyle} />
+          </div>
+
+          <div>
+            <label style={labelStyle}>Type</label>
+            <input value={integration.type} readOnly style={readonlyStyle} />
+            <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginTop: 4 }}>
+              Type cannot be changed. Delete and recreate to change type.
+            </div>
+          </div>
+
+          <div>
+            <label style={labelStyle}>Host</label>
+            <input name="host" required defaultValue={cfg.host ?? ''} style={inputStyle} />
+          </div>
+
+          <div>
+            <label style={labelStyle}>Username</label>
+            <input name="username" defaultValue={cfg.username ?? ''} style={inputStyle} />
+          </div>
+
+          <div>
+            <label style={labelStyle}>Password</label>
+            <input
+              name="password"
+              type="password"
+              placeholder="unchanged"
+              autoComplete="new-password"
+              style={inputStyle}
+            />
+            <div style={{ fontSize: 11, color: 'var(--fg-dim)', marginTop: 4 }}>
+              Leave blank to keep the existing password.
+            </div>
+          </div>
+
+          {cfg.port !== undefined && (
+            <div>
+              <label style={labelStyle}>Port</label>
+              <input name="port" type="number" defaultValue={cfg.port} style={inputStyle} />
+            </div>
+          )}
+
+          <div>
+            <label style={labelStyle}>Certificate fingerprint (SHA-256)</label>
+            <input
+              name="cert_fingerprint_sha256"
+              defaultValue={cfg.cert_fingerprint_sha256 ?? ''}
+              style={inputStyle}
+            />
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+            <button
+              type="submit"
+              style={{
+                padding: '8px 18px', fontSize: 13, fontWeight: 600, cursor: 'pointer',
+                borderRadius: 'var(--radius-sm)', border: 'none',
+                background: 'var(--accent)', color: 'var(--accent-fg)',
+              }}
+            >
+              Save changes
+            </button>
+            <Link
+              href="/hypervisors"
+              style={{
+                padding: '8px 18px', fontSize: 13, cursor: 'pointer',
+                borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+                background: 'var(--surf2)', color: 'var(--fg)',
+                textDecoration: 'none',
+              }}
+            >
+              Cancel
+            </Link>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/hypervisors/delete-button.tsx
+++ b/apps/web/app/(dashboard)/hypervisors/delete-button.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { deleteHypervisorIntegration } from '@/app/actions/hypervisors'
+
+export function DeleteHypervisorButton({
+  integrationId,
+  integrationName,
+  targetCount,
+}: {
+  integrationId:   string
+  integrationName: string
+  targetCount:     number
+}) {
+  const [confirming, setConfirming] = useState(false)
+  const [isPending, start]          = useTransition()
+
+  if (!confirming) {
+    return (
+      <button
+        onClick={() => setConfirming(true)}
+        style={{
+          padding: '6px 14px', fontSize: 13, cursor: 'pointer',
+          borderRadius: 'var(--radius-sm)',
+          border: '1px solid color-mix(in srgb, var(--border) 60%, var(--err) 40%)',
+          background: 'var(--surf2)', color: 'var(--err)',
+        }}
+      >
+        Delete
+      </button>
+    )
+  }
+
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 8,
+      padding: '6px 12px',
+      backgroundColor: 'var(--err-dim)',
+      borderRadius: 'var(--radius-sm)',
+      border: '1px solid color-mix(in srgb, var(--border) 50%, var(--err) 50%)',
+    }}>
+      <span style={{ fontSize: 12, color: 'var(--err)' }}>
+        Delete <strong>{integrationName}</strong> and its {targetCount} target
+        {targetCount === 1 ? '' : 's'}? Backup jobs referencing them will fail until reconfigured.
+      </span>
+      <button
+        disabled={isPending}
+        onClick={() => { start(async () => { await deleteHypervisorIntegration(integrationId) }) }}
+        style={{
+          padding: '4px 12px', fontSize: 12, fontWeight: 600,
+          borderRadius: 'var(--radius-sm)', border: 'none',
+          background: 'var(--err)', color: '#fff',
+          cursor: isPending ? 'not-allowed' : 'pointer',
+        }}
+      >
+        {isPending ? 'Deleting…' : 'Confirm'}
+      </button>
+      <button
+        onClick={() => setConfirming(false)}
+        style={{
+          padding: '4px 10px', fontSize: 12,
+          borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+          background: 'var(--surf2)', color: 'var(--fg-mute)', cursor: 'pointer',
+        }}
+      >
+        Cancel
+      </button>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/hypervisors/page.tsx
+++ b/apps/web/app/(dashboard)/hypervisors/page.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { EmptyState } from '@/components/ui/empty-state'
 import { SyncButton } from './sync-button'
+import { DeleteHypervisorButton } from './delete-button'
 
 type BadgeStatus = ComponentProps<typeof Badge>['status']
 
@@ -66,6 +67,14 @@ export default async function HypervisorsPage() {
                   <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                     <Badge status={integrationBadge(integration.status)} label={integration.status ?? 'unknown'} />
                     <SyncButton integrationId={integration.id} />
+                    <Link href={`/hypervisors/${integration.id}/edit`} style={{ textDecoration: 'none' }}>
+                      <Button variant="secondary" size="sm">Edit</Button>
+                    </Link>
+                    <DeleteHypervisorButton
+                      integrationId={integration.id}
+                      integrationName={integration.name}
+                      targetCount={vmList.length}
+                    />
                   </div>
                 </div>
 

--- a/apps/web/app/actions/hypervisors.ts
+++ b/apps/web/app/actions/hypervisors.ts
@@ -130,3 +130,75 @@ export async function discoverHypervisorTargets(integrationId: string): Promise<
   revalidatePath('/hypervisors')
   return { ok: true, count: rows.length }
 }
+
+export async function updateHypervisorIntegration(
+  id: string,
+  formData: FormData,
+): Promise<{ error: string } | undefined> {
+  await requireAdmin()
+
+  const name            = String(formData.get('name') ?? '').trim()
+  const host            = String(formData.get('host') ?? '').trim()
+  const username        = String(formData.get('username') ?? '').trim()
+  const password        = String(formData.get('password') ?? '').trim()
+  const port            = formData.get('port') ? Number(formData.get('port')) : undefined
+  const certFingerprint = String(formData.get('cert_fingerprint_sha256') ?? '').trim()
+
+  if (!name || !host) return { error: 'name and host required' }
+
+  const db = getDb()
+  const [existing] = await db
+    .select()
+    .from(hypervisorIntegrations)
+    .where(eq(hypervisorIntegrations.id, id))
+    .limit(1)
+
+  if (!existing) return { error: 'integration not found' }
+
+  // Preserve existing password if the form left it blank (security: don't require
+  // re-entering the password just to update the host or username).
+  let nextPassword = password
+  if (!nextPassword) {
+    try {
+      const cfg = JSON.parse(existing.config) as { password?: string }
+      nextPassword = cfg.password ?? ''
+    } catch {
+      nextPassword = ''
+    }
+  }
+
+  await db.update(hypervisorIntegrations)
+    .set({
+      name,
+      config: JSON.stringify({
+        host,
+        username,
+        password: nextPassword,
+        port,
+        cert_fingerprint_sha256: certFingerprint,
+      }),
+      // Reset status — the user may have just rotated credentials, so let
+      // the next sync reflect reality rather than carrying over a stale 'ok'.
+      status: 'unknown',
+    })
+    .where(eq(hypervisorIntegrations.id, id))
+
+  revalidatePath('/hypervisors')
+  return undefined
+}
+
+export async function deleteHypervisorIntegration(
+  id: string,
+): Promise<{ error: string } | undefined> {
+  await requireAdmin()
+
+  const db = getDb()
+
+  // Cascade: remove all hypervisor_targets pointing at this integration first
+  // (the schema has no foreign-key cascade — this is application-level).
+  await db.delete(hypervisorTargets).where(eq(hypervisorTargets.integrationId, id))
+  await db.delete(hypervisorIntegrations).where(eq(hypervisorIntegrations.id, id))
+
+  revalidatePath('/hypervisors')
+  return undefined
+}


### PR DESCRIPTION
## Summary

Closes #398.

Four changes, all following existing server-action patterns (not tRPC — the codebase uses server actions for dashboard mutations consistently):

### 1. `actions/hypervisors.ts` — two new exports
- **`updateHypervisorIntegration`**: updates name, host, username, password, port, cert fingerprint. Preserves existing password when the field is left blank (so rotating credentials doesn't require re-entering). Resets `status` to `'unknown'` so the next sync reflects reality.
- **`deleteHypervisorIntegration`**: application-level cascade — deletes `hypervisor_targets` rows first, then the integration (schema has no FK cascade).

### 2. `/hypervisors/page.tsx` — Edit + Delete in each row
Edit is a `<Link>` to `/hypervisors/<id>/edit`. Delete renders `DeleteHypervisorButton` with the integration name and target count for the blast-radius message.

### 3. `/hypervisors/[id]/edit/page.tsx` (new)
Server component, pre-populates from the stored config JSON. Type field is read-only with a note to delete-and-recreate to change type. Password field has placeholder "unchanged".

### 4. `delete-button.tsx` (new)
Client component with two-step confirm. Confirmation message shows `"Delete <name> and its N targets? Backup jobs referencing them will fail until reconfigured."` Mirrors `repositories/[id]/delete-button.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)