### PR TITLE
chore(db): drop dead 'meta' column from hypervisor_targets (closes #422)

### DIFF
--- a/packages/db/migrations/0050_drop_hypervisor_targets_meta.sql
+++ b/packages/db/migrations/0050_drop_hypervisor_targets_meta.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `hypervisor_targets` DROP COLUMN `meta`;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1778284800000,
       "tag": "0049_xcp_constraints_fix",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1778371200000,
+      "tag": "0050_drop_hypervisor_targets_meta",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -338,7 +338,6 @@ export const hypervisorTargets = sqliteTable('hypervisor_targets', {
   status:        text('status'),         // 'running'|'stopped'
   osType:        text('os_type'),
   tags:          text('tags'),           // JSON array
-  meta:          text('meta'),           // JSON — hypervisor-specific fields
   lastSeenAt:    integer('last_seen_at', { mode: 'timestamp_ms' }),
 })
 


### PR DESCRIPTION
## Summary
- Removes the unused `meta` column from the `hypervisor_targets` schema
- Adds migration `0050_drop_hypervisor_targets_meta.sql` with `ALTER TABLE … DROP COLUMN`
- Updates the Drizzle migration journal

## Test plan
- [ ] Apply migration on staging DB; confirm `meta` column is gone
- [ ] Sync a hypervisor integration — no errors referencing `meta`

🤖 Generated with [Claude Code](https://claude.com/claude-code)