### PR TITLE
feat(dr): browse snapshot contents in file restore wizard (closes #381)

### DIFF
--- a/apps/web/app/actions/restore.ts
+++ b/apps/web/app/actions/restore.ts
@@ -9,7 +9,7 @@ import { requireAdmin } from '@/lib/user'
 import { dispatchToChannel, fireRestoreSucceeded, fireRestoreFailed } from '@/lib/alerts'
 import type { AlertType, AlertPayload } from '@/lib/alerts'
 import { decryptField } from '@/lib/repo-crypto'
-import { connectedAgentIds, requestFilesystemRestore, requestDatabaseRestore, requestSnapshotPaths, dispatch } from '@/lib/ws-state'
+import { connectedAgentIds, requestFilesystemRestore, requestDatabaseRestore, requestSnapshotPaths, requestSnapshotContents, dispatch } from '@/lib/ws-state'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 import { appendLog } from '@/lib/logger'
 
@@ -447,6 +447,62 @@ export async function getLatestSnapshotForJob(
   }
 
   return { ok: true, snapshotId: latest.id, createdAt: latest.createdAt }
+}
+
+export async function browseSnapshot(
+  jobId: string,
+): Promise<
+  | { ok: true; entries: Array<{ path: string; type: string; size?: number; mtime?: string }>; snapshotId: string }
+  | { ok: false; error: string }
+> {
+  await requireAdmin()
+  const db = getDb()
+
+  const [job] = await db.select().from(backupJobs).where(eq(backupJobs.id, jobId)).limit(1)
+  if (!job) return { ok: false, error: 'Job not found' }
+  if (!job.agentId) return { ok: false, error: 'Job has no agent assigned' }
+  const agentId = job.agentId
+  if (!connectedAgentIds().includes(agentId)) {
+    return { ok: false, error: `Agent ${agentId} is not currently connected` }
+  }
+
+  const [latest] = await db
+    .select({ id: snapshots.id, repositoryId: snapshots.repositoryId })
+    .from(snapshots)
+    .where(eq(snapshots.jobId, jobId))
+    .orderBy(desc(snapshots.createdAt))
+    .limit(1)
+    .all()
+
+  if (!latest) return { ok: false, error: 'No snapshots available for this job yet' }
+  if (!latest.repositoryId) return { ok: false, error: 'Snapshot has no associated repository' }
+
+  const [repo] = await db.select().from(repositories).where(eq(repositories.id, latest.repositoryId)).limit(1)
+  if (!repo) return { ok: false, error: 'Repository not found' }
+
+  let repoConfig: RepoConfigShape
+  try {
+    repoConfig = JSON.parse(decryptField(repo.config)) as RepoConfigShape
+  } catch (err) {
+    return { ok: false, error: `Failed to decrypt repository config: ${err instanceof Error ? err.message : String(err)}` }
+  }
+  const password = decryptField(repo.resticPassword)
+
+  try {
+    await ensureRepoMountedOnAgent(agentId, latest.repositoryId)
+  } catch (err) {
+    return { ok: false, error: `Repo mount failed: ${err instanceof Error ? err.message : String(err)}` }
+  }
+
+  const result = await requestSnapshotContents(agentId, {
+    repoUrl:      repoConfig.repositoryUrl,
+    repoPassword: password,
+    envVars:      repoConfig.envVars,
+    snapshotId:   latest.id,
+  })
+
+  if (!result.ok) return { ok: false, error: result.error ?? 'list_snapshot_contents failed' }
+  return { ok: true, entries: result.entries ?? [], snapshotId: latest.id }
 }
 
 export interface ApphookService {

--- a/apps/web/components/dr/restore-file-wizard.tsx
+++ b/apps/web/components/dr/restore-file-wizard.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { CheckCircle, AlertTriangle } from 'lucide-react'
 import { logDrAction } from '@/app/actions/dr-audit'
-import { getLatestSnapshotForJob, restoreFromSnapshot } from '@/app/actions/restore'
+import { getLatestSnapshotForJob, restoreFromSnapshot, browseSnapshot } from '@/app/actions/restore'
 
 /* ── HTML escape for runbook export ── */
 export function escHtml(s: string): string {
@@ -104,6 +104,164 @@ export function WizardNav({
   )
 }
 
+/* ── Snapshot Browser ── */
+
+type SnapshotEntry = { path: string; type: string; size?: number; mtime?: string }
+
+function childrenOfPrefix(entries: SnapshotEntry[], prefix: string): SnapshotEntry[] {
+  const normalizedPrefix = prefix === '/' ? '/' : (prefix.endsWith('/') ? prefix : prefix + '/')
+  const prefixDepth = normalizedPrefix === '/' ? 0 : normalizedPrefix.split('/').filter(Boolean).length
+  return entries.filter(e => {
+    if (!e.path.startsWith(normalizedPrefix === '/' ? '/' : normalizedPrefix)) return false
+    if (e.path === normalizedPrefix.replace(/\/$/, '')) return false
+    const segments = e.path.split('/').filter(Boolean)
+    return segments.length === prefixDepth + 1
+  }).sort((a, b) => {
+    if (a.type === 'dir' && b.type !== 'dir') return -1
+    if (a.type !== 'dir' && b.type === 'dir') return 1
+    return a.path.localeCompare(b.path)
+  })
+}
+
+function formatSize(bytes?: number): string {
+  if (bytes == null) return ''
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+interface SnapshotBrowserProps {
+  jobId:    string
+  onPick:   (path: string) => void
+  onCancel: () => void
+}
+
+function SnapshotBrowser({ jobId, onPick, onCancel }: SnapshotBrowserProps) {
+  const [loading, setLoading]   = useState(true)
+  const [error, setError]       = useState<string | null>(null)
+  const [entries, setEntries]   = useState<SnapshotEntry[]>([])
+  const [prefix, setPrefix]     = useState('/')
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    browseSnapshot(jobId).then(result => {
+      setLoading(false)
+      if (!result.ok) { setError(result.error); return }
+      setEntries(result.entries)
+    }).catch(err => {
+      setLoading(false)
+      setError(err instanceof Error ? err.message : 'Failed to load snapshot')
+    })
+  }, [jobId])
+
+  const segments = prefix === '/' ? [] : prefix.split('/').filter(Boolean)
+  const children = childrenOfPrefix(entries, prefix)
+
+  const containerStyle: React.CSSProperties = {
+    marginTop: 12,
+    border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-sm)',
+    backgroundColor: 'var(--surf2)',
+    overflow: 'hidden',
+  }
+
+  if (loading) {
+    return (
+      <div style={containerStyle}>
+        <div style={{ padding: '16px 14px', fontSize: 13, color: 'var(--fg-mute)' }}>
+          Loading snapshot contents…
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div style={containerStyle}>
+        <div style={{ padding: '16px 14px', fontSize: 13, color: 'var(--err)' }}>
+          {error}
+        </div>
+        <div style={{ padding: '0 14px 14px', display: 'flex', gap: 8 }}>
+          <button onClick={onCancel} style={{ padding: '6px 14px', fontSize: 12, cursor: 'pointer', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'none', color: 'var(--fg)' }}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={containerStyle}>
+      {/* Breadcrumb */}
+      <div style={{ padding: '8px 12px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, fontFamily: 'var(--font-mono)', color: 'var(--fg-mute)', flexWrap: 'wrap' }}>
+          <button onClick={() => setPrefix('/')} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--accent)', fontSize: 12, fontFamily: 'var(--font-mono)', padding: 0 }}>/</button>
+          {segments.map((seg, i) => {
+            const segPath = '/' + segments.slice(0, i + 1).join('/')
+            return (
+              <span key={segPath} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                <span style={{ color: 'var(--fg-dim)' }}>›</span>
+                <button onClick={() => setPrefix(segPath)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: i === segments.length - 1 ? 'var(--fg)' : 'var(--accent)', fontSize: 12, fontFamily: 'var(--font-mono)', padding: 0 }}>
+                  {seg}
+                </button>
+              </span>
+            )
+          })}
+        </div>
+        <div style={{ display: 'flex', gap: 6 }}>
+          <button onClick={() => { onPick(prefix); }} style={{ padding: '4px 10px', fontSize: 11, cursor: 'pointer', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'var(--surf)', color: 'var(--fg-mute)' }}>
+            Pick this directory
+          </button>
+          <button onClick={onCancel} style={{ padding: '4px 10px', fontSize: 11, cursor: 'pointer', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'none', color: 'var(--fg-mute)' }}>
+            Cancel
+          </button>
+        </div>
+      </div>
+
+      {/* Listing */}
+      <div style={{ maxHeight: 400, overflow: 'auto' }}>
+        {children.length === 0 && (
+          <div style={{ padding: '12px 14px', fontSize: 12, color: 'var(--fg-dim)' }}>
+            Empty directory
+          </div>
+        )}
+        {children.map((entry, i) => {
+          const isDir = entry.type === 'dir'
+          const name = entry.path.split('/').filter(Boolean).pop() ?? entry.path
+          return (
+            <div
+              key={entry.path}
+              onClick={() => {
+                if (isDir) { setPrefix(entry.path) }
+                else { onPick(entry.path) }
+              }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 10,
+                padding: '7px 14px', cursor: 'pointer', fontSize: 13,
+                borderTop: i > 0 ? '1px solid var(--border)' : undefined,
+                color: 'var(--fg)',
+              }}
+              onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = 'color-mix(in srgb, var(--surf2) 60%, var(--accent) 8%)' }}
+              onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = '' }}
+            >
+              <span style={{ fontSize: 15, flexShrink: 0 }}>{isDir ? '📁' : '📄'}</span>
+              <span style={{ flex: 1, fontFamily: 'var(--font-mono)', fontSize: 12, color: isDir ? 'var(--fg)' : 'var(--fg-mute)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {name}
+              </span>
+              {!isDir && entry.size != null && (
+                <span style={{ fontSize: 11, color: 'var(--fg-dim)', flexShrink: 0 }}>
+                  {formatSize(entry.size)}
+                </span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 /* ── Restore File wizard ── */
 
 interface Props {
@@ -121,6 +279,7 @@ export function RestoreFileWizard({ jobs, onDone }: Props) {
   const [error, setError]           = useState<string | null>(null)
   const [latestSnapshot, setLatestSnapshot] = useState<{ id: string; createdAt: Date | null } | null>(null)
   const [loadingSnapshot, setLoadingSnapshot] = useState(false)
+  const [browserOpen, setBrowserOpen] = useState(false)
 
   async function execute() {
     setSubmitting(true)
@@ -267,17 +426,39 @@ export function RestoreFileWizard({ jobs, onDone }: Props) {
 
       {step === 1 && (
         <WizardCard title="What file or directory do you need?">
-          <label style={labelStyle}>Source path to restore</label>
-          <input
-            type="text"
-            value={filePath}
-            onChange={e => { setFilePath(e.target.value); setDryRunOk(false) }}
-            placeholder="/home/user/documents/report.pdf"
-            style={inputStyle}
-          />
-          <div style={{ fontSize: 12, color: 'var(--fg-dim)', marginTop: 6 }}>
+          <div style={{ display: 'flex', alignItems: 'flex-end', gap: 8, marginBottom: 6 }}>
+            <div style={{ flex: 1 }}>
+              <label style={labelStyle}>Source path to restore</label>
+              <input
+                type="text"
+                value={filePath}
+                onChange={e => { setFilePath(e.target.value); setDryRunOk(false) }}
+                placeholder="/home/user/documents/report.pdf"
+                style={inputStyle}
+              />
+            </div>
+            <button
+              type="button"
+              onClick={() => setBrowserOpen(b => !b)}
+              style={{
+                padding: '8px 14px', fontSize: 12, cursor: 'pointer', whiteSpace: 'nowrap', flexShrink: 0,
+                borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+                background: browserOpen ? 'var(--surf2)' : 'none', color: 'var(--fg)',
+              }}
+            >
+              {browserOpen ? 'Close browser' : 'Browse snapshot →'}
+            </button>
+          </div>
+          <div style={{ fontSize: 12, color: 'var(--fg-dim)', marginBottom: 4 }}>
             Enter the path as it existed in the backup. Use a directory path to restore an entire folder.
           </div>
+          {browserOpen && jobId && (
+            <SnapshotBrowser
+              jobId={jobId}
+              onPick={(path) => { setFilePath(path); setDryRunOk(false); setBrowserOpen(false) }}
+              onCancel={() => setBrowserOpen(false)}
+            />
+          )}
           <WizardNav onBack={() => setStep(0)} onNext={() => setStep(2)} nextDisabled={!filePath.trim()} />
         </WizardCard>
       )}

--- a/apps/web/lib/ws-state.ts
+++ b/apps/web/lib/ws-state.ts
@@ -378,3 +378,46 @@ export function resolveSnapshotPaths(
 ): void {
   pendingSnapshotPaths.get(requestId)?.(result)
 }
+
+type SnapshotEntry = { path: string; type: string; size?: number; mtime?: string }
+type SnapshotContentsResult = { ok: boolean; entries?: SnapshotEntry[]; error?: string }
+
+const pendingSnapshotContents = new Map<string, (result: SnapshotContentsResult) => void>()
+
+export function requestSnapshotContents(
+  agentId: string,
+  args: { repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string },
+): Promise<SnapshotContentsResult> {
+  return new Promise((resolve, reject) => {
+    const requestId = crypto.randomUUID()
+    const timer = setTimeout(() => {
+      pendingSnapshotContents.delete(requestId)
+      reject(new Error('Agent did not respond in time (60s) for list_snapshot_contents'))
+    }, 60_000)
+    pendingSnapshotContents.set(requestId, (result) => {
+      clearTimeout(timer)
+      pendingSnapshotContents.delete(requestId)
+      resolve(result)
+    })
+    const sent = dispatch(agentId, {
+      type:         'list_snapshot_contents',
+      requestId,
+      repoUrl:      args.repoUrl,
+      repoPassword: args.repoPassword,
+      envVars:      args.envVars,
+      snapshotId:   args.snapshotId,
+    })
+    if (!sent) {
+      clearTimeout(timer)
+      pendingSnapshotContents.delete(requestId)
+      reject(new Error('Agent not connected'))
+    }
+  })
+}
+
+export function resolveSnapshotContents(
+  requestId: string,
+  result: SnapshotContentsResult,
+): void {
+  pendingSnapshotContents.get(requestId)?.(result)
+}

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -9,7 +9,7 @@ import { WebSocketServer } from 'ws'
 import type { WebSocket } from 'ws'
 import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, verificationRuns, verificationTests, snapshots, eq, and, desc } from '@backupos/db'
 import { parseExpression } from 'cron-parser'
-import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, requestInitRepository, resolveInitRepository, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository, resolveFilesystemRestoreStarted, resolveDatabaseRestoreStarted, resolveDatabaseRestoreComplete, resolveSnapshotPaths } from './lib/ws-state'
+import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, requestInitRepository, resolveInitRepository, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository, resolveFilesystemRestoreStarted, resolveDatabaseRestoreStarted, resolveDatabaseRestoreComplete, resolveSnapshotPaths, resolveSnapshotContents } from './lib/ws-state'
 import { ensureRepoMountedOnAgent } from './lib/repo-mount'
 import { loadOrCreateInternalToken } from './lib/internal-token'
 import { decryptField } from './lib/repo-crypto'
@@ -830,6 +830,9 @@ void app.prepare().then(async () => {
             error:       msg.error,
             durationSec: msg.durationSec,
           })
+
+        } else if (msg.type === 'list_snapshot_contents_result') {
+          resolveSnapshotContents(msg.requestId, { ok: msg.ok, entries: msg.entries, error: msg.error })
 
         } else if (msg.type === 'list_snapshot_paths_result') {
           resolveSnapshotPaths(msg.requestId, { ok: msg.ok, paths: msg.paths, error: msg.error })

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -169,6 +169,7 @@ export type AgentMessage =
   | { type: 'database_restore_started'; requestId: string; restoreId: string }
   | { type: 'database_restore_complete'; restoreId: string; success: boolean; output?: string; error?: string; durationSec?: number }
   | { type: 'list_snapshot_paths_result'; requestId: string; ok: boolean; paths?: string[]; error?: string }
+  | { type: 'list_snapshot_contents_result'; requestId: string; ok: boolean; entries?: Array<{ path: string; type: string; size?: number; mtime?: string }>; error?: string }
   | { type: 'xcpng_vm_restore_started'; jobId: string; runId: string; diskCount: number }
   | { type: 'xcpng_vm_restore_complete'; jobId: string; runId: string; success: boolean; newVmUUID?: string; error?: string; log?: string }
   | { type: 'forget_prune_complete'; requestId: string; jobId: string; runId: string; success: boolean; error?: string; removed: number; kept: number; durationMs: number }
@@ -262,6 +263,7 @@ export type ServerMessage =
   | { type: 'cancel_filesystem_restore'; restoreId: string }
   | { type: 'run_database_restore'; requestId: string; restoreId: string; app: 'postgres' | 'mysql' | 'mariadb' | 'sqlite' | 'redis' | 'mongodb'; dumpFilePath: string; targetContainer?: string; targetDatabase?: string; targetUsername?: string; targetHost?: string; targetPort?: number; passwordEnv?: string; targetDbPath?: string; targetAuthDatabase?: string }
   | { type: 'list_snapshot_paths'; requestId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string; pattern?: string }
+  | { type: 'list_snapshot_contents'; requestId: string; repoUrl: string; repoPassword: string; envVars?: Record<string, string>; snapshotId: string }
   | { type: 'run_forget_prune'
       requestId:    string
       jobId:        string

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -15,6 +15,7 @@ import { runTestMount } from './handlers/testMount'
 import { handleFilesystemRestore } from './handlers/filesystemRestore'
 import { handleDatabaseRestore } from './handlers/databaseRestore'
 import { handleListSnapshotPaths } from './handlers/listSnapshotPaths'
+import { handleListSnapshotContents } from './handlers/listSnapshotContents'
 
 function requireEnv(name: string): string {
   const v = process.env[name]
@@ -289,6 +290,9 @@ async function handleMessage(raw: WebSocket.RawData): Promise<void> {
 
   } else if (msg.type === 'list_snapshot_paths') {
     void handleListSnapshotPaths(msg, send)
+
+  } else if (msg.type === 'list_snapshot_contents') {
+    void handleListSnapshotContents(msg, send)
 
   } else if (msg.type === 'run_database_restore') {
     void handleDatabaseRestore(msg, send)

--- a/packages/agent/src/handlers/listSnapshotContents.ts
+++ b/packages/agent/src/handlers/listSnapshotContents.ts
@@ -1,0 +1,37 @@
+import { ResticEngine } from '@backupos/engine'
+import type { AgentMessage, ServerMessage } from '@backupos/agent-protocol'
+
+type SendFn = (msg: AgentMessage) => void
+type RequestMsg = Extract<ServerMessage, { type: 'list_snapshot_contents' }>
+
+export async function handleListSnapshotContents(
+  msg: RequestMsg,
+  send: SendFn,
+): Promise<void> {
+  const { requestId, repoUrl, repoPassword, envVars, snapshotId } = msg
+
+  console.log(`[agent] list_snapshot_contents received: snapshotId=${snapshotId}`)
+
+  try {
+    const engine = new ResticEngine({
+      repositoryUrl: repoUrl,
+      password:      repoPassword,
+      envVars:       envVars ?? {},
+    })
+
+    const files = await engine.ls(snapshotId)
+
+    const entries = files.map(f => ({
+      path:  f.path,
+      type:  f.type,
+      size:  f.size,
+      mtime: f.mtime,
+    }))
+
+    send({ type: 'list_snapshot_contents_result', requestId, ok: true, entries })
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    console.error(`[agent] list_snapshot_contents failed: ${error}`)
+    send({ type: 'list_snapshot_contents_result', requestId, ok: false, error })
+  }
+}


### PR DESCRIPTION
## Summary

Closes #381. Adds a **Browse snapshot** affordance to step 1 of the DR file restore wizard, so users can navigate snapshot contents and click to pick a path instead of typing it from memory.

**Strategy:** flat-load-once (Strategy 1 from the issue). Single round-trip loads all entries; tree navigation is client-side. No pagination protocol needed for typical homelab snapshot sizes.

Mirrors the existing `list_snapshot_paths` flow from #380 with richer return values (full file metadata + directories).

**7 files changed:**
- `packages/agent-protocol/src/index.ts` — `list_snapshot_contents` request + `list_snapshot_contents_result` response types
- `packages/agent/src/handlers/listSnapshotContents.ts` — new handler (mirrors `listSnapshotPaths.ts`, returns all entries with type/size/mtime)
- `packages/agent/src/agent.ts` — dispatch case + import
- `apps/web/lib/ws-state.ts` — `pendingSnapshotContents` map + `requestSnapshotContents` + `resolveSnapshotContents`
- `apps/web/server.ts` — `list_snapshot_contents_result` branch
- `apps/web/app/actions/restore.ts` — `browseSnapshot` server action (job → agent → latest snapshot → repo config → contents)
- `apps/web/components/dr/restore-file-wizard.tsx` — `SnapshotBrowser` inline component + "Browse snapshot" toggle in step 1

## Test plan
- [ ] Step 1 of file wizard shows "Browse snapshot →" button
- [ ] Clicking it calls agent, shows loading then breadcrumb + listing
- [ ] Dirs shown first (📁), files after (📄) with size
- [ ] Click dir → navigates in; breadcrumb segments clickable back
- [ ] Click file → path populated, browser closes
- [ ] "Pick this directory" → directory path populated, browser closes
- [ ] Cancel → closes without changing input
- [ ] Agent logs show `[agent] list_snapshot_contents received: snapshotId=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)