### PR TITLE
debug(agent): add diagnostic logging to list_snapshot_contents handler

### DIFF
--- a/packages/agent/src/handlers/listSnapshotContents.ts
+++ b/packages/agent/src/handlers/listSnapshotContents.ts
@@ -10,16 +10,21 @@ export async function handleListSnapshotContents(
 ): Promise<void> {
   const { requestId, repoUrl, repoPassword, envVars, snapshotId } = msg
 
-  console.log(`[agent] list_snapshot_contents received: snapshotId=${snapshotId}`)
+  console.log(`[agent] list_snapshot_contents received: snapshotId=${snapshotId} repoUrl=${repoUrl} envVarsKeys=${Object.keys(envVars ?? {}).join(',') || '(none)'}`)
 
   try {
+    console.log(`[agent] list_snapshot_contents: constructing ResticEngine`)
     const engine = new ResticEngine({
       repositoryUrl: repoUrl,
       password:      repoPassword,
       envVars:       envVars ?? {},
     })
+    console.log(`[agent] list_snapshot_contents: ResticEngine constructed, calling ls(${snapshotId})`)
 
+    const tStart = Date.now()
     const files = await engine.ls(snapshotId)
+    const tEnd = Date.now()
+    console.log(`[agent] list_snapshot_contents: ls() returned ${files.length} files in ${tEnd - tStart}ms`)
 
     const entries = files.map(f => ({
       path:  f.path,
@@ -27,11 +32,15 @@ export async function handleListSnapshotContents(
       size:  f.size,
       mtime: f.mtime,
     }))
+    console.log(`[agent] list_snapshot_contents: mapped ${entries.length} entries, sending result`)
 
     send({ type: 'list_snapshot_contents_result', requestId, ok: true, entries })
+    console.log(`[agent] list_snapshot_contents: result sent successfully`)
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err)
+    const stack = err instanceof Error ? err.stack ?? '(no stack)' : '(no stack)'
     console.error(`[agent] list_snapshot_contents failed: ${error}`)
+    console.error(`[agent] stack: ${stack}`)
     send({ type: 'list_snapshot_contents_result', requestId, ok: false, error })
   }
 }


### PR DESCRIPTION
## Summary

Temporary diagnostic for the production hang in `list_snapshot_contents` (from PR #436).

The agent logs entry but then silently times out — no restic process spawns, no error surfaces. This PR adds five log points so we can identify exactly where execution stalls:

1. Entry — confirms receipt, prints `repoUrl` shape and `envVarsKeys`
2. Before `new ResticEngine(...)` — proves we got past destructuring
3. After construction, before `engine.ls()` — proves the ctor returned
4. After `ls()` returns — with timing (ms)
5. After mapping entries, before `send()` — proves mapping completed
6. After `send()` returns — proves the wire call returned

**Reading the logs:**
- Missing "constructed, calling ls()" → hang is in the ResticEngine constructor
- Missing "ls() returned" → hang is in `engine.ls()` / restic spawn
- Missing "result sent" → hang is in the WebSocket send
- All lines present → bug is server-side correlation (resolveSnapshotContents never fires)

This PR will be replaced by the actual fix once the hang point is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)