### PR TITLE
feat(license): LicenseClient stub + tier gates (LicenseOS prep)

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -10,9 +10,10 @@ import { FaviconManager }         from '@/components/favicon-manager'
 import { BreadcrumbProvider }     from '@/components/breadcrumb-provider'
 import { unstable_cache }         from 'next/cache'
 import {
-  getDb, backupJobs, backupRuns,
+  getDb, backupJobs, backupRuns, licenseState,
   eq, and, gte,
 } from '@backupos/db'
+import type { TierName } from '@backupos/license-client'
 
 const getLayoutData = unstable_cache(
   async () => {
@@ -29,7 +30,9 @@ const getLayoutData = unstable_cache(
         .where(eq(backupJobs.enabled, true))
         .all(),
     ])
-    return { hasFailed24h: failedRuns.length > 0, jobs }
+    const [licRow] = await db.select({ tier: licenseState.tier }).from(licenseState).limit(1).all()
+    const tier = (licRow?.tier ?? 'free') as TierName
+    return { hasFailed24h: failedRuns.length > 0, jobs, tier }
   },
   ['dashboard-layout'],
   { revalidate: 30 },
@@ -39,7 +42,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
   const currentUser = await getCurrentUser()
   if (!currentUser) redirect('/login')
 
-  const { hasFailed24h, jobs } = await getLayoutData()
+  const { hasFailed24h, jobs, tier } = await getLayoutData()
 
   const sidebarUser = {
     name:  currentUser.name,
@@ -52,7 +55,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
       <FaviconManager />
       <DrModeProvider hasFailed24h={hasFailed24h}>
         <div style={{ display: 'flex', height: '100vh', overflow: 'hidden', backgroundColor: 'var(--bg)' }}>
-          <Sidebar user={sidebarUser} />
+          <Sidebar user={sidebarUser} tier={tier} />
           <BreadcrumbProvider>
             <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minWidth: 0 }}>
               <Topbar />

--- a/apps/web/app/(dashboard)/settings/license/client.tsx
+++ b/apps/web/app/(dashboard)/settings/license/client.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useActionState } from 'react'
+import { applyLicenseKey, clearLicenseKey } from '@/app/actions/license'
+
+export function LicenseClient({ currentKey }: { currentKey: string | null }) {
+  const [state, formAction, pending] = useActionState(applyLicenseKey, undefined)
+
+  return (
+    <div style={{
+      backgroundColor: 'var(--surf)', border: '1px solid var(--border)',
+      borderRadius: 'var(--radius)', padding: '20px',
+    }}>
+      <div style={{ fontSize: 14, fontWeight: 500, marginBottom: 4 }}>License key</div>
+      <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginBottom: 16, lineHeight: 1.5 }}>
+        Enter a license key from <strong>license.backupos.app</strong> to unlock higher tiers.
+      </p>
+
+      {currentKey && (
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '10px 14px', backgroundColor: 'var(--bg)', border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-sm)', marginBottom: 12, fontSize: 13,
+        }}>
+          <span style={{ color: 'var(--fg-mute)', fontFamily: 'monospace' }}>
+            {currentKey.slice(0, 8)}••••••••
+          </span>
+          <button
+            onClick={() => clearLicenseKey()}
+            style={{
+              fontSize: 12, color: 'var(--danger)', background: 'none',
+              border: 'none', cursor: 'pointer', padding: 0,
+            }}
+          >
+            Remove
+          </button>
+        </div>
+      )}
+
+      <form action={formAction} style={{ display: 'flex', gap: 8 }}>
+        <input
+          name="licenseKey"
+          placeholder="bkpos_live_xxxxxxxxxxxx"
+          style={{
+            flex: 1, padding: '8px 12px', fontSize: 13,
+            border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)',
+            backgroundColor: 'var(--bg)', color: 'var(--fg)',
+          }}
+        />
+        <button
+          type="submit"
+          disabled={pending}
+          style={{
+            padding: '8px 16px', fontSize: 13, fontWeight: 500,
+            backgroundColor: 'var(--accent)', color: '#fff',
+            border: 'none', borderRadius: 'var(--radius-sm)', cursor: 'pointer',
+          }}
+        >
+          {pending ? 'Applying…' : 'Apply'}
+        </button>
+      </form>
+
+      {state?.error && (
+        <p style={{ fontSize: 12, color: 'var(--danger)', marginTop: 8 }}>{state.error}</p>
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/license/page.tsx
+++ b/apps/web/app/(dashboard)/settings/license/page.tsx
@@ -1,0 +1,68 @@
+import { getLicenseSummary } from '@/app/actions/license'
+import { getTierConfig } from '@backupos/license-client'
+import { LicenseClient } from './client'
+
+export default async function LicensePage() {
+  const { tier, licenseKey, expiresAt } = await getLicenseSummary()
+  const cfg = getTierConfig(tier)
+
+  const limits = [
+    { label: 'Agents',         value: cfg.limits.agents        === -1 ? 'Unlimited' : cfg.limits.agents },
+    { label: 'Repositories',   value: cfg.limits.repositories   === -1 ? 'Unlimited' : cfg.limits.repositories },
+    { label: 'Operators',      value: cfg.limits.operators      === -1 ? 'Unlimited' : cfg.limits.operators },
+    { label: 'Alert channels', value: cfg.limits.alertChannels  === -1 ? 'Unlimited' : cfg.limits.alertChannels },
+    { label: 'API tokens',     value: cfg.limits.apiTokens      === -1 ? 'Unlimited' : cfg.limits.apiTokens },
+    { label: 'Retention',      value: cfg.limits.retentionDays  === -1 ? 'Unlimited' : `${cfg.limits.retentionDays} days` },
+  ]
+
+  const features = cfg.features.length > 0 ? cfg.features : ['None on this tier']
+
+  return (
+    <div style={{ maxWidth: 560 }}>
+      <h1 style={{ fontSize: 22, fontWeight: 600, color: 'var(--fg)', marginBottom: 24 }}>License</h1>
+
+      <div style={{
+        backgroundColor: 'var(--surf)', border: '1px solid var(--border)',
+        borderRadius: 'var(--radius)', marginBottom: 16,
+      }}>
+        <div style={{ padding: '14px 20px', borderBottom: '1px solid var(--border2)', fontSize: 14, fontWeight: 500 }}>
+          Active plan
+        </div>
+        <div style={{ padding: '20px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 20 }}>
+            <span style={{
+              fontSize: 20, fontWeight: 700, textTransform: 'capitalize', color: 'var(--fg)',
+            }}>{tier}</span>
+            {expiresAt && (
+              <span style={{ fontSize: 12, color: 'var(--fg-mute)' }}>
+                expires {expiresAt.toLocaleDateString()}
+              </span>
+            )}
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px 24px', marginBottom: 20 }}>
+            {limits.map(l => (
+              <div key={l.label} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, padding: '6px 0', borderBottom: '1px solid var(--border2)' }}>
+                <span style={{ color: 'var(--fg-mute)' }}>{l.label}</span>
+                <span style={{ color: 'var(--fg)', fontWeight: 500 }}>{l.value}</span>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ fontSize: 13, color: 'var(--fg-mute)', marginBottom: 4 }}>Features</div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            {features.map(f => (
+              <span key={f} style={{
+                fontSize: 11, padding: '2px 8px', borderRadius: 4,
+                backgroundColor: 'var(--accent-dim)', color: 'var(--accent-deep)',
+                textTransform: 'capitalize',
+              }}>{f.replace(/_/g, ' ')}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <LicenseClient currentKey={licenseKey} />
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -18,6 +18,7 @@ const LINKED_ITEMS: Record<string, string> = {
   'Coverage':           '/settings/infra-os',
   'Logging':            '/settings/logging',
   'Profile':            '/settings/profile',
+  'License':            '/settings/license',
 }
 
 const chevron = (
@@ -50,6 +51,7 @@ export default async function SettingsPage() {
         { title: 'Security', items: ['Users', 'Change password', 'API tokens', 'Session management'] },
         { title: 'Backup defaults', items: ['Retention policy', 'Bandwidth limits', 'Schedule windows', 'Coverage'] },
         { title: 'Logging', items: ['Logging'] },
+        { title: 'License', items: ['License'] },
       ].map(section => (
         <div key={section.title} style={{
           backgroundColor: 'var(--surf)', border: '1px solid var(--border)',

--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -85,7 +85,8 @@ export async function createAlertChannel(formData: FormData): Promise<void> {
 
   // License gate: count non-email channels (email is always free).
   if (type !== 'email') {
-    const [{ ch }] = await db.select({ ch: count(alertChannels.id) }).from(alertChannels).where(ne(alertChannels.type, 'email')).all()
+    const rows = await db.select({ ch: count(alertChannels.id) }).from(alertChannels).where(ne(alertChannels.type, 'email')).all()
+    const ch = rows[0]?.ch ?? 0
     try {
       await enforceLimit('maxAlertChannelsBeyondEmail', ch)
     } catch (e) {

--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -70,7 +70,7 @@ export async function snoozeAlert(id: string, hours: number): Promise<void> {
   revalidatePath('/alerts')
 }
 
-export async function createAlertChannel(formData: FormData): Promise<{ error?: string } | void> {
+export async function createAlertChannel(formData: FormData): Promise<void> {
   await requireAdmin() // admin only
   const name = str(formData, 'name')
   const type = str(formData, 'type')
@@ -82,10 +82,19 @@ export async function createAlertChannel(formData: FormData): Promise<{ error?: 
   if (!config) return
 
   const db = getDb()
-  const [{ ch }] = await db.select({ ch: count(alertChannels.id) }).from(alertChannels).all()
-  try { await enforceLimit('alertChannels', ch) } catch (e) {
-    if (e instanceof LicenseLimitError) return { error: e.message }
-    throw e
+
+  // License gate: count non-email channels (email is always free).
+  if (type !== 'email') {
+    const [{ ch }] = await db.select({ ch: count(alertChannels.id) }).from(alertChannels).where(ne(alertChannels.type, 'email')).all()
+    try {
+      await enforceLimit('maxAlertChannelsBeyondEmail', ch)
+    } catch (e) {
+      if (e instanceof LicenseLimitError) {
+        console.warn('[license] alert channel limit reached:', e.message)
+        return
+      }
+      throw e
+    }
   }
   await db.insert(alertChannels).values({
     id: crypto.randomUUID(),

--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -88,7 +88,7 @@ export async function createAlertChannel(formData: FormData): Promise<void> {
     const rows = await db.select({ ch: count(alertChannels.id) }).from(alertChannels).where(ne(alertChannels.type, 'email')).all()
     const ch = rows[0]?.ch ?? 0
     try {
-      await enforceLimit('maxAlertChannelsBeyondEmail', ch)
+      await enforceLimit('alertChannels', ch)
     } catch (e) {
       if (e instanceof LicenseLimitError) {
         console.warn('[license] alert channel limit reached:', e.message)

--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
-import { getDb, alerts, alertChannels, eq, count } from '@backupos/db'
+import { getDb, alerts, alertChannels, eq, ne, count } from '@backupos/db'
 import { requireAdmin } from '@/lib/user'
 import { enforceLimit, LicenseLimitError } from '@/lib/license'
 import { dispatchToChannel, ALL_ALERT_TYPES, type AlertType } from '@/lib/alerts'

--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -2,8 +2,9 @@
 
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
-import { getDb, alerts, alertChannels, eq } from '@backupos/db'
+import { getDb, alerts, alertChannels, eq, count } from '@backupos/db'
 import { requireAdmin } from '@/lib/user'
+import { enforceLimit, LicenseLimitError } from '@/lib/license'
 import { dispatchToChannel, ALL_ALERT_TYPES, type AlertType } from '@/lib/alerts'
 import { encryptChannelConfig } from '@/lib/alert-channel-crypto'
 
@@ -69,7 +70,7 @@ export async function snoozeAlert(id: string, hours: number): Promise<void> {
   revalidatePath('/alerts')
 }
 
-export async function createAlertChannel(formData: FormData): Promise<void> {
+export async function createAlertChannel(formData: FormData): Promise<{ error?: string } | void> {
   await requireAdmin() // admin only
   const name = str(formData, 'name')
   const type = str(formData, 'type')
@@ -81,6 +82,11 @@ export async function createAlertChannel(formData: FormData): Promise<void> {
   if (!config) return
 
   const db = getDb()
+  const [{ ch }] = await db.select({ ch: count(alertChannels.id) }).from(alertChannels).all()
+  try { await enforceLimit('alertChannels', ch) } catch (e) {
+    if (e instanceof LicenseLimitError) return { error: e.message }
+    throw e
+  }
   await db.insert(alertChannels).values({
     id: crypto.randomUUID(),
     name,

--- a/apps/web/app/actions/integration-tokens.ts
+++ b/apps/web/app/actions/integration-tokens.ts
@@ -1,8 +1,9 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { getDb, integrationTokens, eq } from '@backupos/db'
+import { getDb, integrationTokens, eq, count } from '@backupos/db'
 import { requireAdmin } from '@/lib/user'
+import { enforceLimit, LicenseLimitError } from '@/lib/license'
 import { appendAuditEntry } from '@/lib/audit'
 import { generateRawToken, hashToken, extractPrefix, ALL_SCOPES } from '@/lib/integration-tokens'
 
@@ -15,6 +16,13 @@ export async function createIntegrationToken(formData: FormData): Promise<{ toke
   if (!name) return { error: 'Name is required' }
   if (scopesRaw.length === 0) return { error: 'At least one scope is required' }
 
+  const db = getDb()
+  const [{ tkCount }] = await db.select({ tkCount: count(integrationTokens.id) }).from(integrationTokens).all()
+  try { await enforceLimit('apiTokens', tkCount) } catch (e) {
+    if (e instanceof LicenseLimitError) return { error: e.message }
+    throw e
+  }
+
   const validScopes = scopesRaw.filter(s => (ALL_SCOPES as string[]).includes(s))
   if (validScopes.length !== scopesRaw.length) return { error: 'Invalid scope detected' }
 
@@ -26,7 +34,6 @@ export async function createIntegrationToken(formData: FormData): Promise<{ toke
     : null
 
   const id = crypto.randomUUID()
-  const db = getDb()
 
   await db.insert(integrationTokens).values({
     id,

--- a/apps/web/app/actions/integration-tokens.ts
+++ b/apps/web/app/actions/integration-tokens.ts
@@ -17,7 +17,8 @@ export async function createIntegrationToken(formData: FormData): Promise<{ toke
   if (scopesRaw.length === 0) return { error: 'At least one scope is required' }
 
   const db = getDb()
-  const [{ tkCount }] = await db.select({ tkCount: count(integrationTokens.id) }).from(integrationTokens).all()
+  const tkRows = await db.select({ tkCount: count(integrationTokens.id) }).from(integrationTokens).all()
+  const tkCount = tkRows[0]?.tkCount ?? 0
   try { await enforceLimit('apiTokens', tkCount) } catch (e) {
     if (e instanceof LicenseLimitError) return { error: e.message }
     throw e

--- a/apps/web/app/actions/invite.ts
+++ b/apps/web/app/actions/invite.ts
@@ -29,7 +29,8 @@ export async function createInvite(
   if (!email) return { error: 'Email is required' }
 
   const db    = getDb()
-  const [{ userCount }] = await db.select({ userCount: count(user.id) }).from(user).all()
+  const userRows = await db.select({ userCount: count(user.id) }).from(user).all()
+  const userCount = userRows[0]?.userCount ?? 0
   try { await enforceLimit('operators', userCount) } catch (e) {
     if (e instanceof LicenseLimitError) return { error: e.message }
     throw e

--- a/apps/web/app/actions/invite.ts
+++ b/apps/web/app/actions/invite.ts
@@ -3,9 +3,10 @@
 import { revalidatePath }           from 'next/cache'
 import { randomBytes }              from 'crypto'
 import { getDb, invite, user }      from '@backupos/db'
-import { eq, and, isNull }          from '@backupos/db'
+import { eq, and, isNull, count }   from '@backupos/db'
 import { auth }                     from '@/lib/auth'
 import { getCurrentUser, requireAdmin } from '@/lib/user'
+import { enforceLimit, LicenseLimitError } from '@/lib/license'
 import { sendInviteEmail }          from '@/lib/mailer'
 import { appendAuditEntry }         from '@/lib/audit'
 
@@ -28,6 +29,11 @@ export async function createInvite(
   if (!email) return { error: 'Email is required' }
 
   const db    = getDb()
+  const [{ userCount }] = await db.select({ userCount: count(user.id) }).from(user).all()
+  try { await enforceLimit('operators', userCount) } catch (e) {
+    if (e instanceof LicenseLimitError) return { error: e.message }
+    throw e
+  }
   const id    = crypto.randomUUID()
   const token = crypto.randomUUID()
   const now   = Date.now()

--- a/apps/web/app/actions/license.ts
+++ b/apps/web/app/actions/license.ts
@@ -21,7 +21,7 @@ export async function getLicenseSummary(): Promise<{
   }
 }
 
-export async function applyLicenseKey(formData: FormData): Promise<{ error?: string }> {
+export async function applyLicenseKey(_prevState: { error?: string } | undefined, formData: FormData): Promise<{ error?: string }> {
   await requireAdmin()
   const key = (formData.get('licenseKey') as string | null)?.trim()
   if (!key) return { error: 'License key is required' }

--- a/apps/web/app/actions/license.ts
+++ b/apps/web/app/actions/license.ts
@@ -1,0 +1,47 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { getDb, licenseState } from '@backupos/db'
+import { eq } from '@backupos/db'
+import { requireAdmin } from '@/lib/user'
+import type { TierName } from '@backupos/license-client'
+
+export async function getLicenseSummary(): Promise<{
+  tier: TierName
+  licenseKey: string | null
+  expiresAt: Date | null
+}> {
+  const db = getDb()
+  const [row] = await db.select().from(licenseState).limit(1).all()
+  if (!row) return { tier: 'free', licenseKey: null, expiresAt: null }
+  return {
+    tier:       (row.tier as TierName) ?? 'free',
+    licenseKey: row.licenseKey ?? null,
+    expiresAt:  row.expiresAt ?? null,
+  }
+}
+
+export async function applyLicenseKey(formData: FormData): Promise<{ error?: string }> {
+  await requireAdmin()
+  const key = (formData.get('licenseKey') as string | null)?.trim()
+  if (!key) return { error: 'License key is required' }
+
+  // Stub: accept any non-empty key and store it. Real validation lands when
+  // LicenseOS is live — the client will verify the signature before persisting.
+  const db = getDb()
+  await db.insert(licenseState)
+    .values({ id: 'singleton', tier: 'free', licenseKey: key, updatedAt: new Date() })
+    .onConflictDoUpdate({ target: licenseState.id, set: { licenseKey: key, updatedAt: new Date() } })
+
+  revalidatePath('/settings/license')
+  return {}
+}
+
+export async function clearLicenseKey(): Promise<void> {
+  await requireAdmin()
+  const db = getDb()
+  await db.update(licenseState)
+    .set({ licenseKey: null, tier: 'free', updatedAt: new Date() })
+    .where(eq(licenseState.id, 'singleton'))
+  revalidatePath('/settings/license')
+}

--- a/apps/web/app/actions/oidc-config.ts
+++ b/apps/web/app/actions/oidc-config.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache'
 import { requireAdmin } from '@/lib/user'
 import { upsertOidcConfig, disableOidc as disableOidcDb } from '@/lib/oidc-config'
 import { appendAuditEntry } from '@/lib/audit'
+import { requireFeature, LicenseFeatureError } from '@/lib/license'
 
 export async function saveOidcConfig(input: {
   enabled:       boolean
@@ -15,6 +16,11 @@ export async function saveOidcConfig(input: {
   buttonLabel:   string
 }): Promise<{ error?: string }> {
   const admin = await requireAdmin()
+
+  try { await requireFeature('oidc_sso') } catch (e) {
+    if (e instanceof LicenseFeatureError) return { error: e.message }
+    throw e
+  }
 
   if (!input.discoveryUrl?.trim()) return { error: 'Discovery URL is required' }
   if (!input.clientId?.trim())     return { error: 'Client ID is required' }

--- a/apps/web/app/actions/repositories.ts
+++ b/apps/web/app/actions/repositories.ts
@@ -34,7 +34,8 @@ export async function createRepository(formData: FormData): Promise<{ error: str
   if (!password) return { error: 'Repository password is required' }
 
   const db = getDb()
-  const [{ count: repoCount }] = await db.select({ count: count() }).from(repositories).all()
+  const repoRows = await db.select({ count: count() }).from(repositories).all()
+  const repoCount = repoRows[0]?.count ?? 0
   try { await enforceLimit('repositories', repoCount) } catch (e) {
     if (e instanceof LicenseLimitError) return { error: e.message }
     throw e

--- a/apps/web/app/actions/repositories.ts
+++ b/apps/web/app/actions/repositories.ts
@@ -2,10 +2,11 @@
 
 import { revalidatePath }           from 'next/cache'
 import { redirect }                 from 'next/navigation'
-import { getDb, repositories, backupJobs, backupDefaults, eq, and } from '@backupos/db'
+import { getDb, repositories, backupJobs, backupDefaults, eq, and, count } from '@backupos/db'
 import { ResticEngine }             from '@backupos/engine'
 import { encryptField, decryptField } from '@/lib/repo-crypto'
 import { requireAdmin } from '@/lib/user'
+import { enforceLimit, LicenseLimitError } from '@/lib/license'
 
 function parseRepoConfig(raw: string): Record<string, string> {
   return JSON.parse(decryptField(raw)) as Record<string, string>
@@ -33,6 +34,11 @@ export async function createRepository(formData: FormData): Promise<{ error: str
   if (!password) return { error: 'Repository password is required' }
 
   const db = getDb()
+  const [{ count: repoCount }] = await db.select({ count: count() }).from(repositories).all()
+  try { await enforceLimit('repositories', repoCount) } catch (e) {
+    if (e instanceof LicenseLimitError) return { error: e.message }
+    throw e
+  }
   const id = crypto.randomUUID()
 
   const config: Record<string, string> = {}

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -14,6 +14,8 @@ interface NavItem  { href: string; label: string; icon: React.ReactNode }
 interface NavGroup { label: string; items: NavItem[] }
 interface SidebarUser { name: string; email: string; image?: string | null }
 
+type TierName = 'free' | 'solo' | 'team' | 'business'
+
 const NAV: NavGroup[] = [
   {
     label: 'Overview',
@@ -99,7 +101,7 @@ function Logo() {
   )
 }
 
-export function Sidebar({ user }: { user: SidebarUser }) {
+export function Sidebar({ user, tier = 'free' }: { user: SidebarUser; tier?: TierName }) {
   const pathname = usePathname()
   const allHrefs = NAV.flatMap(g => g.items.map(i => i.href))
 
@@ -161,8 +163,12 @@ export function Sidebar({ user }: { user: SidebarUser }) {
         borderTop: '1px solid var(--border2)',
       }}>
         <ProfilePopover user={user} />
-        <div style={{ fontSize: 10, color: 'var(--fg-faint)', marginTop: 4 }}>
-          Solo · v0.1.0
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4 }}>
+          <span style={{
+            fontSize: 10, padding: '1px 6px', borderRadius: 3, textTransform: 'capitalize',
+            backgroundColor: 'var(--accent-dim)', color: 'var(--accent-deep)', fontWeight: 600,
+          }}>{tier}</span>
+          <span style={{ fontSize: 10, color: 'var(--fg-faint)' }}>v0.1.0</span>
         </div>
       </div>
     </aside>

--- a/apps/web/lib/license.ts
+++ b/apps/web/lib/license.ts
@@ -1,0 +1,64 @@
+import { getDb } from '@backupos/db'
+import { licenseState } from '@backupos/db'
+import { getTierConfig } from '@backupos/license-client'
+import type { TierName, FeatureFlag, TierLimits } from '@backupos/license-client'
+
+export class LicenseLimitError extends Error {
+  constructor(resource: string, limit: number) {
+    super(`Your ${tierDisplayName()} plan allows up to ${limit} ${resource}. Upgrade to add more.`)
+    this.name = 'LicenseLimitError'
+  }
+}
+
+export class LicenseFeatureError extends Error {
+  constructor(feature: string) {
+    super(`${feature} is not available on the ${tierDisplayName()} plan. Upgrade to access this feature.`)
+    this.name = 'LicenseFeatureError'
+  }
+}
+
+function tierDisplayName(): string {
+  // Called synchronously — returns a generic label; callers that need the
+  // real tier embed it in the message via enforceLimit / requireFeature.
+  return 'current'
+}
+
+async function getRow(): Promise<{ tier: TierName; licenseKey: string | null; expiresAt: Date | null }> {
+  const db = getDb()
+  const [row] = await db.select().from(licenseState).limit(1).all()
+  if (!row) return { tier: 'free', licenseKey: null, expiresAt: null }
+  return {
+    tier:       (row.tier as TierName) ?? 'free',
+    licenseKey: row.licenseKey ?? null,
+    expiresAt:  row.expiresAt ?? null,
+  }
+}
+
+export async function getLicenseState() {
+  return getRow()
+}
+
+export async function getCurrentTierConfig() {
+  const { tier } = await getRow()
+  return getTierConfig(tier)
+}
+
+type LimitKey = keyof TierLimits
+
+export async function enforceLimit(resource: LimitKey, currentCount: number): Promise<void> {
+  const { tier } = await getRow()
+  const cfg = getTierConfig(tier)
+  const limit = cfg.limits[resource]
+  if (limit === -1) return // unlimited
+  if (currentCount >= limit) {
+    throw new LicenseLimitError(resource, limit)
+  }
+}
+
+export async function requireFeature(feature: FeatureFlag): Promise<void> {
+  const { tier } = await getRow()
+  const cfg = getTierConfig(tier)
+  if (!cfg.features.includes(feature)) {
+    throw new LicenseFeatureError(feature)
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@backupos/agent-protocol": "workspace:*",
+    "@backupos/license-client": "workspace:*",
     "@backupos/pbs-storage": "workspace:*",
     "@backupos/api": "workspace:*",
     "@backupos/db": "workspace:*",

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -7,7 +7,7 @@ import type { IncomingMessage } from 'http'
 import next from 'next'
 import { WebSocketServer } from 'ws'
 import type { WebSocket } from 'ws'
-import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, verificationRuns, verificationTests, snapshots, eq, and, desc } from '@backupos/db'
+import { getDb, runMigrations, agents, backupRuns, backupJobs, repositories, restoreRuns, auditLog, backupDefaults, verificationRuns, verificationTests, snapshots, eq, and, desc, count } from '@backupos/db'
 import { parseExpression } from 'cron-parser'
 import { registerAgent, unregisterAgent, resolveDetect, requestDetect, resolveTestRepo, requestTestRepo, resolveTestMount, requestTestMount, requestInitRepository, resolveInitRepository, connectedAgentIds, dispatch, requestListCompose, resolveListCompose, resolveMountRepository, resolveFilesystemRestoreStarted, resolveDatabaseRestoreStarted, resolveDatabaseRestoreComplete, resolveSnapshotPaths } from './lib/ws-state'
 import { ensureRepoMountedOnAgent } from './lib/repo-mount'
@@ -18,6 +18,7 @@ import { migrateAlertChannelEncryption } from './lib/alert-channel-crypto'
 import { appendLog } from './lib/logger'
 import { auth } from './lib/auth'
 import type { AgentMessage, ServerMessage, MountConfig } from '@backupos/agent-protocol'
+import { enforceLimit, LicenseLimitError } from './lib/license'
 
 async function requireSession(req: IncomingMessage): Promise<{ userId: string } | null> {
   const headers = new Headers()
@@ -436,6 +437,14 @@ void app.prepare().then(async () => {
             .limit(1)
 
           if (!agent) { ws.close(4001, 'Unauthorized'); return }
+
+          const [{ agentCount }] = await db.select({ agentCount: count(agents.id) }).from(agents).all()
+          try {
+            await enforceLimit('agents', agentCount)
+          } catch (e) {
+            if (e instanceof LicenseLimitError) { ws.close(4029, e.message); return }
+            throw e
+          }
 
           agentId = agent.id
           registerAgent(agentId, ws)

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -438,7 +438,8 @@ void app.prepare().then(async () => {
 
           if (!agent) { ws.close(4001, 'Unauthorized'); return }
 
-          const [{ agentCount }] = await db.select({ agentCount: count(agents.id) }).from(agents).all()
+          const agentRows = await db.select({ agentCount: count(agents.id) }).from(agents).all()
+          const agentCount = agentRows[0]?.agentCount ?? 0
           try {
             await enforceLimit('agents', agentCount)
           } catch (e) {

--- a/packages/db/migrations/0051_license_state.sql
+++ b/packages/db/migrations/0051_license_state.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `license_state` (
+  `id`          text PRIMARY KEY NOT NULL DEFAULT 'singleton',
+  `tier`        text NOT NULL DEFAULT 'free',
+  `license_key` text,
+  `expires_at`  integer,
+  `updated_at`  integer NOT NULL
+);
+--> statement-breakpoint
+INSERT OR IGNORE INTO `license_state` (`id`, `tier`, `updated_at`) VALUES ('singleton', 'free', unixepoch() * 1000);

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1778371200000,
       "tag": "0050_drop_hypervisor_targets_meta",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1778457600000,
+      "tag": "0051_license_state",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -742,3 +742,14 @@ export const xcpBackupChains = sqliteTable('xcp_backup_chains', {
 }, t => ({
   pk: primaryKey({ columns: [t.jobId, t.vdiUuid] }),
 }))
+
+// ── License ───────────────────────────────────────────────────────────────
+// Singleton row (id = 'singleton') tracking the active license tier.
+
+export const licenseState = sqliteTable('license_state', {
+  id:         text('id').primaryKey().default('singleton'),
+  tier:       text('tier').notNull().default('free'),
+  licenseKey: text('license_key'),
+  expiresAt:  integer('expires_at',  { mode: 'timestamp_ms' }),
+  updatedAt:  integer('updated_at',  { mode: 'timestamp_ms' }).notNull(),
+})

--- a/packages/license-client/package.json
+++ b/packages/license-client/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@backupos/license-client",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/license-client/src/client.ts
+++ b/packages/license-client/src/client.ts
@@ -1,0 +1,14 @@
+import type { LicenseState, TierConfig } from './types'
+import { getTierConfig } from './tiers'
+
+// Stub client — all instances run Free tier until LicenseOS integration is live.
+// Network validation will be wired here in a future PR.
+export class LicenseClient {
+  getState(): LicenseState {
+    return { tier: 'free', licenseKey: null, expiresAt: null }
+  }
+
+  getTierConfig(): TierConfig {
+    return getTierConfig(this.getState().tier)
+  }
+}

--- a/packages/license-client/src/index.ts
+++ b/packages/license-client/src/index.ts
@@ -1,0 +1,3 @@
+export type { TierName, TierLimits, TierConfig, FeatureFlag, LicenseState } from './types'
+export { getTierConfig } from './tiers'
+export { LicenseClient } from './client'

--- a/packages/license-client/src/tiers.ts
+++ b/packages/license-client/src/tiers.ts
@@ -1,0 +1,56 @@
+import type { TierConfig, TierName } from './types'
+
+const TIERS: Record<TierName, TierConfig> = {
+  free: {
+    name: 'free',
+    limits: {
+      agents:        1,
+      repositories:  3,
+      operators:     1,
+      alertChannels: 1,
+      apiTokens:     2,
+      retentionDays: 30,
+    },
+    features: [],
+  },
+  solo: {
+    name: 'solo',
+    limits: {
+      agents:        3,
+      repositories:  10,
+      operators:     1,
+      alertChannels: 3,
+      apiTokens:     10,
+      retentionDays: 365,
+    },
+    features: [],
+  },
+  team: {
+    name: 'team',
+    limits: {
+      agents:        10,
+      repositories:  30,
+      operators:     10,
+      alertChannels: 10,
+      apiTokens:     50,
+      retentionDays: 365,
+    },
+    features: ['oidc_sso', 'multi_user_rbac', 'compliance_export', 'scheduled_verification'],
+  },
+  business: {
+    name: 'business',
+    limits: {
+      agents:        -1,
+      repositories:  -1,
+      operators:     -1,
+      alertChannels: -1,
+      apiTokens:     -1,
+      retentionDays: -1,
+    },
+    features: ['oidc_sso', 'multi_user_rbac', 'compliance_export', 'scheduled_verification', 'priority_support'],
+  },
+}
+
+export function getTierConfig(tier: TierName): TierConfig {
+  return TIERS[tier]
+}

--- a/packages/license-client/src/tiers.ts
+++ b/packages/license-client/src/tiers.ts
@@ -4,11 +4,11 @@ const TIERS: Record<TierName, TierConfig> = {
   free: {
     name: 'free',
     limits: {
-      agents:        1,
-      repositories:  3,
+      agents:        3,
+      repositories:  2,
       operators:     1,
       alertChannels: 1,
-      apiTokens:     2,
+      apiTokens:     0,
       retentionDays: 30,
     },
     features: [],
@@ -16,26 +16,26 @@ const TIERS: Record<TierName, TierConfig> = {
   solo: {
     name: 'solo',
     limits: {
-      agents:        3,
-      repositories:  10,
+      agents:        10,
+      repositories:  5,
       operators:     1,
-      alertChannels: 3,
-      apiTokens:     10,
-      retentionDays: 365,
+      alertChannels: 9,
+      apiTokens:     1,
+      retentionDays: -1,
     },
-    features: [],
+    features: ['scheduled_verification'],
   },
   team: {
     name: 'team',
     limits: {
-      agents:        10,
-      repositories:  30,
+      agents:        50,
+      repositories:  25,
       operators:     10,
-      alertChannels: 10,
-      apiTokens:     50,
-      retentionDays: 365,
+      alertChannels: 9,
+      apiTokens:     10,
+      retentionDays: -1,
     },
-    features: ['oidc_sso', 'multi_user_rbac', 'compliance_export', 'scheduled_verification'],
+    features: ['scheduled_verification', 'oidc_sso', 'multi_user_rbac', 'compliance_export'],
   },
   business: {
     name: 'business',
@@ -47,7 +47,7 @@ const TIERS: Record<TierName, TierConfig> = {
       apiTokens:     -1,
       retentionDays: -1,
     },
-    features: ['oidc_sso', 'multi_user_rbac', 'compliance_export', 'scheduled_verification', 'priority_support'],
+    features: ['scheduled_verification', 'oidc_sso', 'multi_user_rbac', 'compliance_export', 'priority_support'],
   },
 }
 

--- a/packages/license-client/src/types.ts
+++ b/packages/license-client/src/types.ts
@@ -1,0 +1,29 @@
+export type TierName = 'free' | 'solo' | 'team' | 'business'
+
+export type FeatureFlag =
+  | 'oidc_sso'
+  | 'multi_user_rbac'
+  | 'compliance_export'
+  | 'scheduled_verification'
+  | 'priority_support'
+
+export interface TierLimits {
+  agents:        number  // -1 = unlimited
+  repositories:  number
+  operators:     number
+  alertChannels: number
+  apiTokens:     number
+  retentionDays: number
+}
+
+export interface TierConfig {
+  name:     TierName
+  limits:   TierLimits
+  features: FeatureFlag[]
+}
+
+export interface LicenseState {
+  tier:       TierName
+  licenseKey: string | null
+  expiresAt:  Date | null
+}

--- a/packages/license-client/tsconfig.json
+++ b/packages/license-client/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       '@backupos/hypervisors':
         specifier: workspace:*
         version: link:../../packages/hypervisors
+      '@backupos/license-client':
+        specifier: workspace:*
+        version: link:../../packages/license-client
       '@backupos/monitors':
         specifier: workspace:*
         version: link:../../packages/monitors
@@ -330,6 +333,12 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/license-client:
+    devDependencies:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3


### PR DESCRIPTION
## Summary

- New `@backupos/license-client` package: type-safe tier system (free/solo/team/business) with limits and feature flags; stub `LicenseClient` always returns Free tier, no network calls
- Migration `0051`: `license_state` singleton table, seeded to `free`
- `apps/web/lib/license.ts`: `enforceLimit()`, `requireFeature()`, `LicenseLimitError`, `LicenseFeatureError`
- `/settings/license` page: active plan summary with limits grid, feature badges, license key apply/remove form
- Sidebar tier badge driven from layout server component
- Gates wired across 6 action files + `server.ts`:
  - `createRepository` → `enforceLimit('repositories')`
  - `createInvite` → `enforceLimit('operators')`
  - `createAlertChannel` → `enforceLimit('alertChannels')`
  - `createIntegrationToken` → `enforceLimit('apiTokens')`
  - `saveOidcConfig` → `requireFeature('oidc_sso')`
  - `server.ts` hello handler → `enforceLimit('agents')`

## Test plan

- [ ] Deploy and verify `/settings/license` loads showing Free plan limits
- [ ] Confirm sidebar shows "free" tier badge
- [ ] Create 3 repositories (Free limit) — 4th should return limit error
- [ ] Attempt to save OIDC SSO config — should return feature-not-available error
- [ ] Verify existing agent connects without hitting limit (1 agent allowed on Free)
- [ ] Confirm migration 0051 applies cleanly and `license_state` has singleton row

🤖 Generated with [Claude Code](https://claude.com/claude-code)