### PR TITLE
fix(workspace): publicly hoist @backupos/* packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 public-hoist-pattern[]=better-sqlite3
 public-hoist-pattern[]=bindings
 public-hoist-pattern[]=file-uri-to-path
+public-hoist-pattern[]=@backupos/*


### PR DESCRIPTION
Fix for workspace package resolution. Without publicHoist, newly-added @backupos/* packages don't get top-level symlinks, breaking next build. Add @backupos/* to the existing public-hoist-pattern[] in .npmrc.

Tested: ls node_modules/@backupos/ now shows top-level symlinks for all 12 workspace packages including license-client.

This unblocks redeployment of the license merge (#439).