### PR TITLE
fix(deploy): build @backupos/license-client during install

### DIFF
--- a/scripts/server-install.sh
+++ b/scripts/server-install.sh
@@ -328,6 +328,7 @@ pnpm --filter @backupos/agent-protocol build
 pnpm --filter @backupos/agent       build
 pnpm --filter @backupos/api         build
 pnpm --filter @backupos/docs-content build
+pnpm --filter @backupos/license-client build
 
 log "Building web app..."
 pnpm --filter @backupos/web exec next build


### PR DESCRIPTION
Add @backupos/license-client to the deploy script's package build list.

This was missed in #439 — the build step is a hardcoded list and the new package wasn't added. Without tsc running, packages/license-client/dist/index.js doesn't exist, and apps/web's Next.js build fails to resolve @backupos/license-client even with publicHoist symlinks in place (#440).

Tested locally: deploy script now builds license-client and the next build succeeds.