### PR TITLE
fix(security): gate triggerComposeRestore with requireAdmin

### DIFF
--- a/apps/web/app/actions/compose-restore.ts
+++ b/apps/web/app/actions/compose-restore.ts
@@ -7,8 +7,10 @@ import { dispatchToAgent } from '@/lib/internal-dispatch'
 import { connectedAgentIds } from '@/lib/ws-state'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 import type { ComposeProjectConfig } from '@backupos/agent-protocol'
+import { requireAdmin } from '@/lib/user'
 
 export async function triggerComposeRestore(formData: FormData): Promise<void> {
+  await requireAdmin()
   const jobId                 = (formData.get('jobId')                 as string | null)?.trim() ?? ''
   const sourceRunId           = (formData.get('sourceRunId')           as string | null)?.trim() ?? ''
   const rawMode = (formData.get('mode') as string | null)?.trim()


### PR DESCRIPTION
Audit finding #5 (HIGH): triggerComposeRestore had no auth gate. Any authenticated user could overwrite running compose services in-place or restore the compose YAML itself.

Adds requireAdmin() at the top of the function. Default is admin-only until Team-tier RBAC ships.

Replaces #442 (closed — was based on a stale fork point that had merge conflicts with the license PR).