### PR TITLE
fix(security): add requireAdmin gates to 9 destructive server actions

### DIFF
--- a/apps/web/app/actions/agents.ts
+++ b/apps/web/app/actions/agents.ts
@@ -29,6 +29,7 @@ export async function setAgentUpdateChannel(
   agentId: string,
   channel: 'stable' | 'beta' | 'pinned',
 ): Promise<void> {
+  await requireAdmin()
   const db = getDb()
   await db.update(agents).set({ updateChannel: channel }).where(eq(agents.id, agentId))
   revalidatePath(`/agents/${agentId}`)

--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -63,6 +63,7 @@ function buildConfig(type: string, fd: FormData): Record<string, string> | null 
 }
 
 export async function snoozeAlert(id: string, hours: number): Promise<void> {
+  await requireAdmin()
   if (!id || hours <= 0) return
   const db = getDb()
   const until = new Date(Date.now() + hours * 60 * 60 * 1000)
@@ -194,6 +195,7 @@ export async function updateChannelSubscriptions(channelId: string, events: Aler
 }
 
 export async function saveChannelSubscriptions(channelId: string, formData: FormData): Promise<void> {
+  await requireAdmin()
   const events = ALL_ALERT_TYPES.filter(t => formData.get(`event_${t}`) === 'on')
   await updateChannelSubscriptions(channelId, events)
 }

--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -151,6 +151,7 @@ async function resolveBandwidthLimitKbps(db: ReturnType<typeof getDb>, jobId: st
 }
 
 export async function triggerJob(id: string): Promise<void> {
+  await requireAdmin()
   const db  = getDb()
   const now = new Date()
 
@@ -225,6 +226,7 @@ export async function updateJob(id: string, formData: FormData): Promise<void> {
 }
 
 export async function retryRun(jobId: string): Promise<void> {
+  await requireAdmin()
   const db  = getDb()
   const now = new Date()
 

--- a/apps/web/app/actions/monitors.ts
+++ b/apps/web/app/actions/monitors.ts
@@ -135,6 +135,7 @@ export async function deleteMonitor(id: string): Promise<void> {
 }
 
 export async function syncMonitor(monitorId: string): Promise<{ ok: boolean; error?: string }> {
+  await requireAdmin()
   const db     = getDb()
   const result = await performMonitorSync(monitorId, db)
   if (result.ok) revalidatePath(`/monitors/${monitorId}`)

--- a/apps/web/app/actions/repositories.ts
+++ b/apps/web/app/actions/repositories.ts
@@ -331,6 +331,7 @@ export interface ReplicaEntry {
 }
 
 export async function setReplicas(repoId: string, replicas: ReplicaEntry[]): Promise<void> {
+  await requireAdmin()
   const db = getDb()
   await db
     .update(repositories)
@@ -345,6 +346,7 @@ function parseReplicas(raw: string | null): ReplicaEntry[] {
 }
 
 export async function addReplica(repoId: string, entry: ReplicaEntry): Promise<void> {
+  await requireAdmin()
   const db      = getDb()
   const [repo]  = await db.select({ replicas: repositories.replicas }).from(repositories).where(eq(repositories.id, repoId)).limit(1)
   if (!repo) return
@@ -353,6 +355,7 @@ export async function addReplica(repoId: string, entry: ReplicaEntry): Promise<v
 }
 
 export async function removeReplicaAt(repoId: string, index: number): Promise<void> {
+  await requireAdmin()
   const db      = getDb()
   const [repo]  = await db.select({ replicas: repositories.replicas }).from(repositories).where(eq(repositories.id, repoId)).limit(1)
   if (!repo) return


### PR DESCRIPTION
Audit findings #3 (HIGH) and #4 (HIGH): nine destructive server actions lacked auth gates. Any authenticated user could:

- Change agent update channel (downgrade prod agents to broken beta)
- Snooze any alert (silence active production failures)
- Reconfigure alert subscriptions
- Trigger external monitor sync
- Reconfigure repository replicas
- Trigger arbitrary backup runs

All now gated with requireAdmin(). Default is admin-only until Team-tier RBAC ships.

Replaces #444 (closed — was based on stale fork point).