### PR TITLE
fix(security): use timing-safe comparison for internal secret

### DIFF
--- a/apps/web/app/api/v1/integration/restore-runs/[id]/route.ts
+++ b/apps/web/app/api/v1/integration/restore-runs/[id]/route.ts
@@ -3,14 +3,12 @@ export const dynamic = 'force-dynamic'
 
 import { NextRequest, NextResponse } from 'next/server'
 import { getDb, restoreRuns, eq }    from '@backupos/db'
+import { checkInternalAuth }         from '@/lib/internal-auth'
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const expected = process.env.BACKUPOS_INTERNAL_SECRET
-  if (!expected) return NextResponse.json({ error: 'internal auth not configured' }, { status: 503 })
-  if (req.headers.get('authorization') !== `Bearer ${expected}`) {
-    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
-  }
+  const deny = checkInternalAuth(req)
+  if (deny) return deny
 
   const db    = getDb()
   const [run] = await db.select().from(restoreRuns).where(eq(restoreRuns.id, id)).limit(1)

--- a/apps/web/app/api/v1/integration/restore-runs/route.ts
+++ b/apps/web/app/api/v1/integration/restore-runs/route.ts
@@ -5,13 +5,11 @@ import { NextRequest, NextResponse }                                            
 import { getDb, backupJobs, repositories, restoreRuns, hypervisorTargets, hypervisorIntegrations, eq } from '@backupos/db'
 import { decryptField }                                                             from '@/lib/repo-crypto'
 import { connectedAgentIds, dispatch }                                              from '@/lib/ws-state'
+import { checkInternalAuth }                                                       from '@/lib/internal-auth'
 
 export async function POST(req: NextRequest) {
-  const expected = process.env.BACKUPOS_INTERNAL_SECRET
-  if (!expected) return NextResponse.json({ error: 'internal auth not configured' }, { status: 503 })
-  if (req.headers.get('authorization') !== `Bearer ${expected}`) {
-    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
-  }
+  const deny = checkInternalAuth(req)
+  if (deny) return deny
 
   let body: { job_id?: string; target_sr_uuid?: string; vm_name?: string; target_template_name_label?: string }
   try { body = await req.json() as typeof body }

--- a/apps/web/app/api/v1/integration/runs/[id]/route.ts
+++ b/apps/web/app/api/v1/integration/runs/[id]/route.ts
@@ -3,14 +3,12 @@ export const dynamic = 'force-dynamic'
 
 import { NextRequest, NextResponse } from 'next/server'
 import { getDb, backupRuns, eq }     from '@backupos/db'
+import { checkInternalAuth }         from '@/lib/internal-auth'
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const expected = process.env.BACKUPOS_INTERNAL_SECRET
-  if (!expected) return NextResponse.json({ error: 'internal auth not configured' }, { status: 503 })
-  if (req.headers.get('authorization') !== `Bearer ${expected}`) {
-    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
-  }
+  const deny = checkInternalAuth(req)
+  if (deny) return deny
 
   const db    = getDb()
   const [run] = await db.select().from(backupRuns).where(eq(backupRuns.id, id)).limit(1)

--- a/apps/web/app/api/v1/integration/runs/route.ts
+++ b/apps/web/app/api/v1/integration/runs/route.ts
@@ -6,15 +6,7 @@ import { getDb, backupRuns }         from '@backupos/db'
 import { lt, eq, and, desc }         from '@backupos/db'
 import { authenticate }              from '@/lib/integration-auth'
 import { triggerJobById }            from '@/lib/scheduler'
-
-function checkInternalAuth(req: NextRequest): NextResponse | null {
-  const expected = process.env.BACKUPOS_INTERNAL_SECRET
-  if (!expected) return NextResponse.json({ error: 'internal auth not configured' }, { status: 503 })
-  if (req.headers.get('authorization') !== `Bearer ${expected}`) {
-    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
-  }
-  return null
-}
+import { checkInternalAuth }         from '@/lib/internal-auth'
 
 export async function POST(req: NextRequest) {
   const deny = checkInternalAuth(req)

--- a/apps/web/lib/internal-auth.test.ts
+++ b/apps/web/lib/internal-auth.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { checkInternalAuth } from './internal-auth'
+import { NextRequest } from 'next/server'
+
+describe('checkInternalAuth', () => {
+  const ORIG = process.env['BACKUPOS_INTERNAL_SECRET']
+  const TEST_SECRET = 'test-secret-32bytes-aaaaaaaaaaaaa'
+
+  beforeEach(() => {
+    process.env['BACKUPOS_INTERNAL_SECRET'] = TEST_SECRET
+  })
+
+  afterEach(() => {
+    if (ORIG === undefined) delete process.env['BACKUPOS_INTERNAL_SECRET']
+    else process.env['BACKUPOS_INTERNAL_SECRET'] = ORIG
+  })
+
+  function makeReq(authHeader?: string): NextRequest {
+    const headers = new Headers()
+    if (authHeader) headers.set('authorization', authHeader)
+    return new NextRequest('http://localhost/test', { headers })
+  }
+
+  it('returns 503 if BACKUPOS_INTERNAL_SECRET is not set', () => {
+    delete process.env['BACKUPOS_INTERNAL_SECRET']
+    const res = checkInternalAuth(makeReq(`Bearer ${TEST_SECRET}`))
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(503)
+  })
+
+  it('returns 401 with no Authorization header', () => {
+    const res = checkInternalAuth(makeReq())
+    expect(res!.status).toBe(401)
+  })
+
+  it('returns 401 with wrong secret', () => {
+    const res = checkInternalAuth(makeReq('Bearer wrong-secret'))
+    expect(res!.status).toBe(401)
+  })
+
+  it('returns 401 with right length but wrong content', () => {
+    // Same length as `Bearer ${TEST_SECRET}` but different content
+    const wrongSameLength = 'Bearer ' + 'X'.repeat(TEST_SECRET.length)
+    const res = checkInternalAuth(makeReq(wrongSameLength))
+    expect(res!.status).toBe(401)
+  })
+
+  it('returns 401 if header is "Bearer " prefix only (length mismatch)', () => {
+    const res = checkInternalAuth(makeReq('Bearer '))
+    expect(res!.status).toBe(401)
+  })
+
+  it('returns null with correct bearer', () => {
+    const res = checkInternalAuth(makeReq(`Bearer ${TEST_SECRET}`))
+    expect(res).toBeNull()
+  })
+})

--- a/apps/web/lib/internal-auth.ts
+++ b/apps/web/lib/internal-auth.ts
@@ -1,0 +1,38 @@
+import { timingSafeEqual } from 'node:crypto'
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * Verifies the request's Authorization: Bearer header matches the
+ * configured internal secret using a timing-safe comparison.
+ *
+ * Returns NextResponse with the appropriate error status if invalid,
+ * or null if valid (continue processing).
+ *
+ * Used by internal /api/v1/integration/* routes that are called by the
+ * backupos-pbs and backupos-xcp Go services on the same host. The shared
+ * secret is loaded from BACKUPOS_INTERNAL_SECRET (set by server-install.sh
+ * via lib/internal-token.ts).
+ */
+export function checkInternalAuth(req: NextRequest): NextResponse | null {
+  const expected = process.env['BACKUPOS_INTERNAL_SECRET']
+  if (!expected) {
+    return NextResponse.json({ error: 'internal auth not configured' }, { status: 503 })
+  }
+
+  const auth = req.headers.get('authorization') ?? ''
+  const expectedHeader = `Bearer ${expected}`
+
+  // Length check first to avoid timing-leak via comparison-length variance
+  if (auth.length !== expectedHeader.length) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  // Timing-safe equality
+  const a = Buffer.from(auth)
+  const b = Buffer.from(expectedHeader)
+  if (!timingSafeEqual(a, b)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  return null
+}


### PR DESCRIPTION
Audit finding #8 (MEDIUM): the 4 internal routes that authenticate the backupos-pbs and backupos-xcp Go services on the same host were comparing the bearer secret with `!==` which is not timing-safe.

## Changes

**New helper** `apps/web/lib/internal-auth.ts` exporting `checkInternalAuth(req)`:
- Returns 503 if `BACKUPOS_INTERNAL_SECRET` env var is unset
- Returns 401 for any auth-header mismatch
- Length check first to prevent leaking secret length via comparison-length variance
- Uses `crypto.timingSafeEqual()` for the actual comparison

**Routes updated** to use the shared helper:
- `/api/v1/integration/restore-runs` (POST)
- `/api/v1/integration/restore-runs/[id]` (GET)
- `/api/v1/integration/runs` (POST) — also removed local `checkInternalAuth` function
- `/api/v1/integration/runs/[id]` (GET)

**Unit test** `apps/web/lib/internal-auth.test.ts` with 6 cases:
- Missing secret → 503
- No header → 401
- Wrong secret → 401
- Right length, wrong content → 401
- "Bearer " prefix only → 401
- Correct bearer → null (pass)

All tests pass.