### PR TITLE
docs(security): document in-memory rate-limit scope

### DIFF
--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -133,6 +133,14 @@ export const auth = betterAuth({
       maxAge:  60 * 5,
     },
   },
+  // Better-auth's built-in rate limiter, applied to /api/auth/* endpoints.
+  // 10 requests per 60-second window per IP.
+  //
+  // SCOPE LIMITATION (audit finding #11): better-auth defaults to an in-memory
+  // store. Counter resets on every service restart (including deploys) and is
+  // not shared across multiple BackupOS instances. Acceptable for single-
+  // instance deployments. To be backed by SQLite/Redis when BackupOS supports
+  // horizontal scaling (V2 / multi-instance roadmap).
   rateLimit: {
     enabled: true,
     window:  60,

--- a/apps/web/lib/forgot-password-rate-limit.ts
+++ b/apps/web/lib/forgot-password-rate-limit.ts
@@ -1,6 +1,12 @@
 // Per-process in-memory rate limiter for /forgot-password.
 // Two independent buckets: per-email (5 req / 15 min) and per-IP (20 req / 60 min).
-// Resets on process restart — acceptable for self-hosted single-instance deployment.
+//
+// SCOPE LIMITATION (audit finding #11): this state lives in process memory.
+// - Resets on every service restart (including deploys).
+// - Not shared across multiple BackupOS instances.
+// Acceptable for single-instance deployments. To be replaced with a
+// SQLite-backed limiter when BackupOS supports horizontal scaling
+// (V2 / multi-instance roadmap).
 
 interface Bucket { count: number; resetAt: number }
 

--- a/apps/web/lib/integration-auth.ts
+++ b/apps/web/lib/integration-auth.ts
@@ -5,7 +5,15 @@ import { eq }                        from '@backupos/db'
 import { hashToken, parseScopes, validateScope, isExpired, isRevoked } from './integration-tokens'
 import { appendAuditEntry }          from './audit'
 
-// Per-process in-memory rate limiter — resets every 60 s
+// Per-process in-memory rate limiter for integration tokens.
+// Counter resets every 60 s; per-token quota from rateLimitRpm column.
+//
+// SCOPE LIMITATION (audit finding #11): this state lives in process memory.
+// - Resets on every service restart (including deploys).
+// - Not shared across multiple BackupOS instances.
+// Acceptable for single-instance deployments. To be replaced with a
+// SQLite-backed limiter when BackupOS supports horizontal scaling
+// (V2 / multi-instance roadmap).
 const rateLimitStore = new Map<string, { count: number; resetAt: number }>()
 
 function checkRateLimit(tokenId: string, limitRpm: number): boolean {


### PR DESCRIPTION
Audit finding #11 acknowledged via documentation.

Three rate-limiters live in process memory:
- `forgot-password-rate-limit.ts` — per-email + per-IP buckets for /forgot-password
- `integration-auth.ts` — per-token quota for integration API tokens
- `auth.ts` — better-auth's built-in /api/auth/* limiter

All reset on service restart and don't share state across multiple BackupOS instances. Acceptable for V1 single-instance deployments.

Each location now carries a SCOPE LIMITATION block referencing the audit finding and the V2 / multi-instance roadmap migration plan.

No behavior change — comments only.