### PR TITLE
feat(auth): add requireAdminAction() + missing /access-denied page

### DIFF
--- a/apps/web/lib/user.ts
+++ b/apps/web/lib/user.ts
@@ -6,6 +6,24 @@ import { eq }                        from '@backupos/db'
 
 export type AuthUser = typeof auth.$Infer.Session.user & { role: string }
 
+/**
+ * Authentication errors thrown by requireAdminAction() / requireUserAction().
+ * Caught by Next.js's server-action error boundary and returned to the
+ * client as a structured error object instead of an HTML redirect.
+ *
+ * IMPORTANT: never use this from page components — pages should use
+ * requireAdmin() / requireUser() which redirect for the correct UX.
+ */
+export class AuthError extends Error {
+  constructor(
+    public readonly status: 401 | 403,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'AuthError'
+  }
+}
+
 export async function getCurrentUser(): Promise<AuthUser | null> {
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session?.user) return null
@@ -15,10 +33,31 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
   return { ...session.user, role: row?.role ?? 'admin' }
 }
 
+/**
+ * For PAGE components and layouts: redirect on auth failure.
+ * Calling this from a server action will return an HTML redirect to the
+ * client which expects JSON — use requireAdminAction() instead.
+ */
 export async function requireAdmin(): Promise<AuthUser> {
   const u = await getCurrentUser()
   if (!u) redirect('/login')
   if (u.role !== 'admin') redirect('/access-denied')
+  return u
+}
+
+/**
+ * For SERVER ACTIONS: throw AuthError on auth failure.
+ * Next.js's server-action error boundary will catch this and propagate it
+ * as a structured error to the client form, instead of an HTML redirect.
+ *
+ * Status semantics:
+ *   401 — not authenticated (no session)
+ *   403 — authenticated but not authorized (non-admin role)
+ */
+export async function requireAdminAction(): Promise<AuthUser> {
+  const u = await getCurrentUser()
+  if (!u)                  throw new AuthError(401, 'Authentication required')
+  if (u.role !== 'admin')  throw new AuthError(403, 'Admin role required')
   return u
 }
 


### PR DESCRIPTION
Foundation PR for audit finding #7 migration. Adds the function and the missing redirect target page; does NOT migrate any call sites yet.

## Why

`requireAdmin()` calls `redirect()` on auth failure. This is correct for page components but wrong for server actions — the client expects a JSON action result and instead gets an HTML redirect document, causing silent failures or hydration weirdness.

## Changes

- New `requireAdminAction()` in `apps/web/lib/user.ts` — throws `AuthError(401|403)` instead of redirecting. Next.js's server-action error boundary catches the throw and propagates a structured error to the client form.
- New `AuthError` class with typed `.status` property.
- New `/access-denied` page — this was the redirect target for `requireAdmin()` non-admin path but the page didn't exist. Page styled with the BackupOS design tokens (--surf, --err, --accent).

## What's NOT in this PR

The 121 server-action call sites still use `requireAdmin()` (which redirects). Those will be migrated in 5 follow-up PRs:

| Batch | Files | Calls |
|---|---|---|
| 1 | restore.ts | 13 |
| 2 | jobs.ts, alerts.ts | 20 |
| 3 | repositories.ts, snapshots.ts, pbs-datastores.ts | 20 |
| 4 | monitors.ts, bandwidth.ts, escrow.ts | 17 |
| 5 | remaining 18 files | ~51 |

After migrations, `requireAdmin()` gets renamed to `requireAdminPage()`.

## Verification

- `pnpm typecheck` clean
- `pnpm --filter @backupos/web build` clean
- No behavior change for any existing call site (this PR only adds new exports)