### PR TITLE
fix(auth): migrate jobs.ts + alerts.ts to requireAdminAction (batch 2/5)

### DIFF
--- a/apps/web/app/actions/alerts.ts
+++ b/apps/web/app/actions/alerts.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { getDb, alerts, alertChannels, eq, ne, count } from '@backupos/db'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 import { enforceLimit, LicenseLimitError } from '@/lib/license'
 import { dispatchToChannel, ALL_ALERT_TYPES, type AlertType } from '@/lib/alerts'
 import { encryptChannelConfig } from '@/lib/alert-channel-crypto'
@@ -63,7 +63,7 @@ function buildConfig(type: string, fd: FormData): Record<string, string> | null 
 }
 
 export async function snoozeAlert(id: string, hours: number): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   if (!id || hours <= 0) return
   const db = getDb()
   const until = new Date(Date.now() + hours * 60 * 60 * 1000)
@@ -72,7 +72,7 @@ export async function snoozeAlert(id: string, hours: number): Promise<void> {
 }
 
 export async function createAlertChannel(formData: FormData): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const name = str(formData, 'name')
   const type = str(formData, 'type')
 
@@ -110,7 +110,7 @@ export async function createAlertChannel(formData: FormData): Promise<void> {
 }
 
 export async function deleteAlertChannel(id: string): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   if (!id) return
   const db = getDb()
   await db.delete(alertChannels).where(eq(alertChannels.id, id))
@@ -118,7 +118,7 @@ export async function deleteAlertChannel(id: string): Promise<void> {
 }
 
 export async function createAlertChannelForType(integType: string, formData: FormData): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const name = str(formData, 'name')
   if (!name) return
   if (!(VALID_CHANNEL_TYPES as readonly string[]).includes(integType)) return
@@ -137,7 +137,7 @@ export async function createAlertChannelForType(integType: string, formData: For
 }
 
 export async function deleteAlertChannelForType(channelId: string, integType: string): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   if (!channelId) return
   const db = getDb()
   await db.delete(alertChannels).where(eq(alertChannels.id, channelId))
@@ -153,7 +153,7 @@ export type TestAlertChannelResult =
   | { ok: false; error: string }
 
 export async function testAlertChannel(input: TestAlertChannelInput): Promise<TestAlertChannelResult> {
-  await requireAdmin()
+  await requireAdminAction()
 
   let testChannel: { id: string; type: string; config: string }
 
@@ -185,7 +185,7 @@ export async function testAlertChannel(input: TestAlertChannelInput): Promise<Te
 }
 
 export async function updateChannelSubscriptions(channelId: string, events: AlertType[]): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   if (!channelId) return
   const db = getDb()
   await db.update(alertChannels)
@@ -195,13 +195,13 @@ export async function updateChannelSubscriptions(channelId: string, events: Aler
 }
 
 export async function saveChannelSubscriptions(channelId: string, formData: FormData): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const events = ALL_ALERT_TYPES.filter(t => formData.get(`event_${t}`) === 'on')
   await updateChannelSubscriptions(channelId, events)
 }
 
 export async function sendTestAlert(channelId: string): Promise<{ ok: boolean; error?: string }> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   const [channel] = await db.select().from(alertChannels).where(eq(alertChannels.id, channelId)).limit(1)
   if (!channel) return { ok: false, error: 'Channel not found' }

--- a/apps/web/app/actions/jobs.ts
+++ b/apps/web/app/actions/jobs.ts
@@ -9,7 +9,7 @@ import { validateCron } from '@/lib/cron-validate'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 import { isWithinWindow } from '@/lib/schedule-window'
 import { appendLog } from '@/lib/logger'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 function parseSourceConfig(sourceType: string, fd: FormData): string {
   const str = (k: string) => (fd.get(k) as string | null)?.trim() || undefined
@@ -61,7 +61,7 @@ function parseSourceConfig(sourceType: string, fd: FormData): string {
 }
 
 export async function createJob(formData: FormData): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const name           = (formData.get('name')           as string)?.trim()
   const sourceType     = (formData.get('sourceType')     as string)
   const agentId        = (formData.get('agentId')        as string) || null
@@ -101,7 +101,7 @@ export async function createJob(formData: FormData): Promise<void> {
 }
 
 export async function pauseJobs(ids: string[]): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   if (!ids.length) return
   const db = getDb()
   await db.update(backupJobs).set({ enabled: false }).where(inArray(backupJobs.id, ids))
@@ -109,7 +109,7 @@ export async function pauseJobs(ids: string[]): Promise<void> {
 }
 
 export async function resumeJobs(ids: string[]): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   if (!ids.length) return
   const db = getDb()
   await db.update(backupJobs).set({ enabled: true }).where(inArray(backupJobs.id, ids))
@@ -117,7 +117,7 @@ export async function resumeJobs(ids: string[]): Promise<void> {
 }
 
 export async function deleteJobs(ids: string[]): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   if (!ids.length) return
   const db = getDb()
   await db.delete(backupRuns).where(inArray(backupRuns.jobId, ids))
@@ -151,7 +151,7 @@ async function resolveBandwidthLimitKbps(db: ReturnType<typeof getDb>, jobId: st
 }
 
 export async function triggerJob(id: string): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db  = getDb()
   const now = new Date()
 
@@ -190,7 +190,7 @@ export async function triggerJob(id: string): Promise<void> {
 }
 
 export async function updateJob(id: string, formData: FormData): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const name         = (formData.get('name')         as string)?.trim()
   const sourceType   = (formData.get('sourceType')   as string)
   const agentId      = (formData.get('agentId')      as string) || null
@@ -226,7 +226,7 @@ export async function updateJob(id: string, formData: FormData): Promise<void> {
 }
 
 export async function retryRun(jobId: string): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db  = getDb()
   const now = new Date()
 
@@ -368,7 +368,7 @@ export async function retryRun(jobId: string): Promise<void> {
 }
 
 export async function cancelJob(jobId: string): Promise<{ ok: boolean; error?: string }> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   const [run] = await db
     .select()
@@ -410,7 +410,7 @@ export async function cancelJobFormAction(jobId: string): Promise<void> {
 }
 
 export async function saveJobRetention(id: string, formData: FormData): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const parse = (key: string) => {
     const v = parseInt(formData.get(key) as string, 10)
     return isNaN(v) || v === 0 ? null : v


### PR DESCRIPTION
Audit finding #7 migration, batch 2 of 5.

Migrates 9 calls in `jobs.ts` and 9 calls in `alerts.ts` (plus 2 imports) from `requireAdmin()` to `requireAdminAction()`. Mechanical sed, no logic changes.

## Verification

- `pnpm typecheck` clean
- `pnpm --filter @backupos/web build` clean
- `grep -E 'requireAdmin[^A]'` in both files returns nothing

## Migration progress

- ✓ Foundation (PR #452)
- ✓ Batch 1: restore.ts (PR #453)
- ✓ Batch 2: jobs.ts + alerts.ts  ← this PR
- Batch 3: repositories.ts (8), snapshots.ts (6), pbs-datastores.ts (6)
- Batch 4: monitors.ts (6), bandwidth.ts (6), escrow.ts (5)
- Batch 5: remaining 18 files (~51 calls)