### PR TITLE
fix(auth): migrate batch 3 (repositories, snapshots, pbs-datastores)

### DIFF
--- a/apps/web/app/actions/pbs-datastores.ts
+++ b/apps/web/app/actions/pbs-datastores.ts
@@ -8,7 +8,7 @@ import { randomBytes }    from 'node:crypto'
 import { request as httpsRequest, Agent } from 'node:https'
 import { getDb, pbsDatastores, eq } from '@backupos/db'
 import { FsChunkStore }   from '@backupos/pbs-storage'
-import { requireAdmin }   from '@/lib/user'
+import { requireAdminAction }   from '@/lib/user'
 import { appendAuditEntry } from '@/lib/audit'
 import { getPbsServerInfo } from '@/lib/pbs-server'
 
@@ -107,7 +107,7 @@ export interface CreatePbsDatastoreResult {
 export async function createPbsDatastore(
   formData: FormData,
 ): Promise<CreatePbsDatastoreResult> {
-  const adminUser = await requireAdmin()
+  const adminUser = await requireAdminAction()
   const name = (formData.get('name') as string | null)?.trim()
 
   if (!name) return { error: 'Datastore name is required' }
@@ -164,7 +164,7 @@ export async function createPbsDatastore(
 }
 
 export async function deletePbsDatastore(id: string): Promise<{ error?: string }> {
-  const adminUser = await requireAdmin()
+  const adminUser = await requireAdminAction()
   const db = getDb()
 
   const rows = await db
@@ -207,7 +207,7 @@ export interface UpdatePbsDatastoreInput {
 }
 
 export async function updatePbsDatastore(input: UpdatePbsDatastoreInput): Promise<{ error?: string }> {
-  const adminUser = await requireAdmin()
+  const adminUser = await requireAdminAction()
   const db = getDb()
 
   if (input.pruneSchedule !== null && input.pruneSchedule.length > 64) {
@@ -250,7 +250,7 @@ export interface SyncStatsResult {
 }
 
 export async function syncPbsDatastoreStats(id: string): Promise<SyncStatsResult> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
 
   const [ds] = await db.select().from(pbsDatastores).where(eq(pbsDatastores.id, id)).limit(1)
@@ -288,7 +288,7 @@ export interface TriggerGcResult {
 }
 
 export async function triggerPbsGc(id: string): Promise<TriggerGcResult> {
-  const adminUser = await requireAdmin()
+  const adminUser = await requireAdminAction()
   const db = getDb()
 
   const [ds] = await db.select().from(pbsDatastores).where(eq(pbsDatastores.id, id)).limit(1)

--- a/apps/web/app/actions/repositories.ts
+++ b/apps/web/app/actions/repositories.ts
@@ -5,7 +5,7 @@ import { redirect }                 from 'next/navigation'
 import { getDb, repositories, backupJobs, backupDefaults, eq, and, count } from '@backupos/db'
 import { ResticEngine }             from '@backupos/engine'
 import { encryptField, decryptField } from '@/lib/repo-crypto'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 import { enforceLimit, LicenseLimitError } from '@/lib/license'
 
 function parseRepoConfig(raw: string): Record<string, string> {
@@ -23,7 +23,7 @@ function parseSmbSharePath(raw: string): { host: string; remotePath: string } | 
 }
 
 export async function createRepository(formData: FormData): Promise<{ error: string } | never> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const name     = (formData.get('name') as string)?.trim()
   const backend  = formData.get('backend') as string
   const password = formData.get('password') as string
@@ -138,7 +138,7 @@ export async function createRepository(formData: FormData): Promise<{ error: str
 }
 
 export async function updateRepository(id: string, formData: FormData): Promise<{ error: string } | undefined> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const name     = (formData.get('name') as string)?.trim()
   const password = (formData.get('password') as string)?.trim()
   const group    = (formData.get('group') as string)?.trim() || null
@@ -245,7 +245,7 @@ export async function updateRepository(id: string, formData: FormData): Promise<
 }
 
 export async function deleteRepository(id: string): Promise<{ error: string } | undefined> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const db = getDb()
   await db.delete(backupJobs).where(eq(backupJobs.repositoryId, id))
   await db.delete(repositories).where(eq(repositories.id, id))
@@ -331,7 +331,7 @@ export interface ReplicaEntry {
 }
 
 export async function setReplicas(repoId: string, replicas: ReplicaEntry[]): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db
     .update(repositories)
@@ -346,7 +346,7 @@ function parseReplicas(raw: string | null): ReplicaEntry[] {
 }
 
 export async function addReplica(repoId: string, entry: ReplicaEntry): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db      = getDb()
   const [repo]  = await db.select({ replicas: repositories.replicas }).from(repositories).where(eq(repositories.id, repoId)).limit(1)
   if (!repo) return
@@ -355,7 +355,7 @@ export async function addReplica(repoId: string, entry: ReplicaEntry): Promise<v
 }
 
 export async function removeReplicaAt(repoId: string, index: number): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db      = getDb()
   const [repo]  = await db.select({ replicas: repositories.replicas }).from(repositories).where(eq(repositories.id, repoId)).limit(1)
   if (!repo) return
@@ -407,7 +407,7 @@ export async function pruneRepository(repoId: string): Promise<{
   jobsProcessed?: number
   error?: string
 }> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const db     = getDb()
   const [repo] = await db.select().from(repositories).where(eq(repositories.id, repoId)).limit(1)
   if (!repo) return { ok: false, error: 'Repository not found' }

--- a/apps/web/app/actions/snapshots.ts
+++ b/apps/web/app/actions/snapshots.ts
@@ -3,17 +3,17 @@
 import { revalidatePath } from 'next/cache'
 import { getDb, snapshots } from '@backupos/db'
 import { eq } from '@backupos/db'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 export async function pinSnapshot(id: string, pinned: boolean): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db.update(snapshots).set({ pinned }).where(eq(snapshots.id, id)).run()
   revalidatePath('/snapshots')
 }
 
 export async function addCustomTag(id: string, tag: string): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const trimmed = tag.trim().toLowerCase().replace(/[^a-z0-9-_]/g, '')
   if (!trimmed) return
 
@@ -34,7 +34,7 @@ export async function addCustomTag(id: string, tag: string): Promise<void> {
 }
 
 export async function removeCustomTag(id: string, tag: string): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db.transaction(async tx => {
     const snapshot = await tx.select({ customTags: snapshots.customTags })
@@ -50,7 +50,7 @@ export async function removeCustomTag(id: string, tag: string): Promise<void> {
 }
 
 export async function setRetentionHold(id: string, reason: string, expiresAt: Date | null): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db.update(snapshots)
     .set({ retentionHold: true, holdReason: reason.trim() || null, holdExpiresAt: expiresAt })
@@ -59,7 +59,7 @@ export async function setRetentionHold(id: string, reason: string, expiresAt: Da
 }
 
 export async function clearRetentionHold(id: string): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db.update(snapshots)
     .set({ retentionHold: false, holdReason: null, holdExpiresAt: null })


### PR DESCRIPTION
Audit finding #7 migration, batch 3 of 5.

Migrates 17 calls across 3 files (plus 3 imports):
- `repositories.ts` (7)
- `snapshots.ts` (5)
- `pbs-datastores.ts` (5)

`pbs-datastores.ts` used aligned-import whitespace style (`import { requireAdmin }   from ...`) which needed a separate sed pattern. Caught by typecheck.

## Verification

- `pnpm typecheck` clean
- `pnpm --filter @backupos/web build` clean

## Migration progress

- ✓ Foundation (PR #452)
- ✓ Batch 1: restore.ts (PR #453)
- ✓ Batch 2: jobs.ts + alerts.ts (PR #454)
- ✓ Batch 3: this PR
- Batch 4: monitors.ts, bandwidth.ts, escrow.ts
- Batch 5: remaining 18 files