### PR TITLE
fix(auth): migrate batch 4 (monitors, bandwidth, escrow)

### DIFF
--- a/apps/web/app/actions/bandwidth.ts
+++ b/apps/web/app/actions/bandwidth.ts
@@ -4,10 +4,10 @@ import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { getDb, bandwidthProfiles, bandwidthRules, backupJobs } from '@backupos/db'
 import { eq } from '@backupos/db'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 export async function createProfile(formData: FormData): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const name        = (formData.get('name') as string).trim()
   const description = (formData.get('description') as string | null)?.trim() || null
   const isGlobal    = formData.get('isGlobal') === 'on'
@@ -34,7 +34,7 @@ export async function createProfile(formData: FormData): Promise<void> {
 }
 
 export async function deleteProfile(id: string): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db.update(backupJobs)
     .set({ bandwidthProfileId: null })
@@ -47,7 +47,7 @@ export async function deleteProfile(id: string): Promise<void> {
 }
 
 export async function addRule(profileId: string, formData: FormData): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const startHour = parseInt(formData.get('startHour') as string, 10)
   const endHour   = parseInt(formData.get('endHour')   as string, 10)
   const limitRaw  = (formData.get('limitKbps') as string).trim()
@@ -70,7 +70,7 @@ export async function addRule(profileId: string, formData: FormData): Promise<vo
 }
 
 export async function deleteRule(id: string): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db.delete(bandwidthRules).where(eq(bandwidthRules.id, id)).run()
   revalidatePath('/settings/bandwidth')
@@ -78,7 +78,7 @@ export async function deleteRule(id: string): Promise<void> {
 }
 
 export async function setJobProfile(jobId: string, formData: FormData): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const profileId = (formData.get('profileId') as string) || null
   const db = getDb()
   await db.update(backupJobs)

--- a/apps/web/app/actions/escrow.ts
+++ b/apps/web/app/actions/escrow.ts
@@ -4,10 +4,10 @@ import { revalidatePath } from 'next/cache'
 import { getDb, repositories } from '@backupos/db'
 import { eq } from '@backupos/db'
 import { encryptPassword, decryptPassword } from '@/lib/escrow'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 export async function setEscrow(repoId: string, formData: FormData): Promise<{ error?: string }> {
-  await requireAdmin()
+  await requireAdminAction()
   const password   = ((formData.get('password')   ?? '') as string).trim()
   const passphrase = (formData.get('passphrase')  ?? '') as string             // no trim — spaces are valid
   const confirm    = (formData.get('confirm')     ?? '') as string             // no trim — match raw input
@@ -24,20 +24,20 @@ export async function setEscrow(repoId: string, formData: FormData): Promise<{ e
 }
 
 export async function setEscrowAction(repoId: string, formData: FormData): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const result = await setEscrow(repoId, formData)
   if (result.error) throw new Error(result.error)
 }
 
 export async function clearEscrow(repoId: string): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db.update(repositories).set({ escrowedKey: null }).where(eq(repositories.id, repoId)).run()
   revalidatePath(`/repositories/${repoId}`)
 }
 
 export async function recoverPassword(repoId: string, formData: FormData): Promise<{ password?: string; error?: string }> {
-  await requireAdmin()
+  await requireAdminAction()
   const passphrase = (formData.get('passphrase') ?? '') as string  // no trim
   if (!passphrase) return { error: 'Recovery passphrase is required.' }
 

--- a/apps/web/app/actions/monitors.ts
+++ b/apps/web/app/actions/monitors.ts
@@ -5,11 +5,11 @@ import { redirect } from 'next/navigation'
 import { getDb, backupMonitors, repositories, eq } from '@backupos/db'
 import { type PBSConfig } from '@backupos/monitors'
 import { performMonitorSync } from '@/lib/monitors'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 import { assertSafeUrl, SSRFViolation } from '@/lib/ssrf-guard'
 
 export async function promoteMonitorToRepo(monitorId: string, formData: FormData): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const password = (formData.get('password') as string)?.trim()
   if (!password) return
 
@@ -41,7 +41,7 @@ export async function promoteMonitorToRepo(monitorId: string, formData: FormData
 }
 
 export async function createMonitor(formData: FormData): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const name   = (formData.get('name')   as string)?.trim()
   const type   = (formData.get('type')   as string)
   const url    = (formData.get('url')    as string)?.trim()
@@ -100,7 +100,7 @@ export async function testMonitorConnection(url: string): Promise<{ ok: boolean;
 }
 
 export async function updateMonitor(id: string, formData: FormData): Promise<{ error: string } | void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const name   = (formData.get('name')   as string)?.trim()
   const url    = (formData.get('url')    as string)?.trim()
   const apiKey = (formData.get('apiKey') as string)?.trim() || null
@@ -128,14 +128,14 @@ export async function updateMonitor(id: string, formData: FormData): Promise<{ e
 }
 
 export async function deleteMonitor(id: string): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const db = getDb()
   await db.delete(backupMonitors).where(eq(backupMonitors.id, id))
   redirect('/monitors')
 }
 
 export async function syncMonitor(monitorId: string): Promise<{ ok: boolean; error?: string }> {
-  await requireAdmin()
+  await requireAdminAction()
   const db     = getDb()
   const result = await performMonitorSync(monitorId, db)
   if (result.ok) revalidatePath(`/monitors/${monitorId}`)


### PR DESCRIPTION
Audit finding #7 migration, batch 4 of 5.

Migrates 14 calls + 3 imports across:
- `monitors.ts` (5 calls)
- `bandwidth.ts` (5 calls)
- `escrow.ts` (4 calls)

## Verification

- `pnpm typecheck` clean
- `pnpm --filter @backupos/web build` clean

## Migration progress

- ✓ Foundation (PR #452)
- ✓ Batch 1: restore.ts (PR #453)
- ✓ Batch 2: jobs.ts + alerts.ts (PR #454)
- ✓ Batch 3: repositories, snapshots, pbs-datastores (PR #455)
- ✓ Batch 4: this PR
- Batch 5: remaining 18 files (~51 calls)