### PR TITLE
fix(auth): migrate batch 5 (final batch, 18 files) to requireAdminAction

### DIFF
--- a/apps/web/app/actions/agents.ts
+++ b/apps/web/app/actions/agents.ts
@@ -3,10 +3,10 @@
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { getDb, agents, eq } from '@backupos/db'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 export async function enrollAgent(formData: FormData): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const name = (formData.get('name') as string)?.trim()
   if (!name) return
 
@@ -29,7 +29,7 @@ export async function setAgentUpdateChannel(
   agentId: string,
   channel: 'stable' | 'beta' | 'pinned',
 ): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db.update(agents).set({ updateChannel: channel }).where(eq(agents.id, agentId))
   revalidatePath(`/agents/${agentId}`)
@@ -44,7 +44,7 @@ export async function setAgentChannelFromForm(agentId: string, formData: FormDat
 }
 
 export async function forceUpdateAgent(agentId: string): Promise<{ ok: boolean; error?: string }> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   try {
     const port = process.env['PORT'] ?? '3000'
     const res  = await fetch(`http://127.0.0.1:${port}/api/agents/${agentId}/force-update`, { method: 'POST' })

--- a/apps/web/app/actions/api-tokens.ts
+++ b/apps/web/app/actions/api-tokens.ts
@@ -4,10 +4,10 @@ import { revalidatePath } from 'next/cache'
 import { randomBytes, createHash } from 'crypto'
 import { getDb, apiTokens, eq } from '@backupos/db'
 import { headers } from 'next/headers'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 export async function createApiToken(formData: FormData): Promise<{ token?: string; id?: string; error?: string }> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const { auth } = await import('@/lib/auth')
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session) return { error: 'Not authenticated' }
@@ -39,7 +39,7 @@ export async function createApiToken(formData: FormData): Promise<{ token?: stri
 }
 
 export async function revokeApiToken(id: string) {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const db = getDb()
   await db.delete(apiTokens).where(eq(apiTokens.id, id))
   revalidatePath('/settings/api-tokens')

--- a/apps/web/app/actions/compose-restore.ts
+++ b/apps/web/app/actions/compose-restore.ts
@@ -7,10 +7,10 @@ import { dispatchToAgent } from '@/lib/internal-dispatch'
 import { connectedAgentIds } from '@/lib/ws-state'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
 import type { ComposeProjectConfig } from '@backupos/agent-protocol'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 export async function triggerComposeRestore(formData: FormData): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const jobId                 = (formData.get('jobId')                 as string | null)?.trim() ?? ''
   const sourceRunId           = (formData.get('sourceRunId')           as string | null)?.trim() ?? ''
   const rawMode = (formData.get('mode') as string | null)?.trim()

--- a/apps/web/app/actions/hypervisors.ts
+++ b/apps/web/app/actions/hypervisors.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache'
 import { getDb, hypervisorIntegrations, hypervisorTargets, eq } from '@backupos/db'
 import { ProxmoxHypervisorDriver, VMwareHypervisorDriver } from '@backupos/hypervisors'
 import type { ProxmoxConfig, VMwareConfig } from '@backupos/hypervisors'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 type DiscoverResult = { ok: boolean; count?: number; error?: string }
 
@@ -21,7 +21,7 @@ type TargetRow = {
 }
 
 export async function discoverHypervisorTargets(integrationId: string): Promise<DiscoverResult> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   const [integration] = await db
     .select()
@@ -135,7 +135,7 @@ export async function updateHypervisorIntegration(
   id: string,
   formData: FormData,
 ): Promise<{ error: string } | undefined> {
-  await requireAdmin()
+  await requireAdminAction()
 
   const name            = String(formData.get('name') ?? '').trim()
   const host            = String(formData.get('host') ?? '').trim()
@@ -190,7 +190,7 @@ export async function updateHypervisorIntegration(
 export async function deleteHypervisorIntegration(
   id: string,
 ): Promise<{ error: string } | undefined> {
-  await requireAdmin()
+  await requireAdminAction()
 
   const db = getDb()
 

--- a/apps/web/app/actions/infra-os.ts
+++ b/apps/web/app/actions/infra-os.ts
@@ -5,10 +5,10 @@ import { revalidatePath } from 'next/cache'
 import { getDb, infraOsServices, backupJobs } from '@backupos/db'
 import { eq } from '@backupos/db'
 import { randomUUID } from 'crypto'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 export async function addInfraService(formData: FormData): Promise<{ error?: string }> {
-  await requireAdmin()
+  await requireAdminAction()
   const name        = ((formData.get('name')        ?? '') as string).trim()
   const serviceType = ((formData.get('serviceType') ?? '') as string).trim()
   const host        = ((formData.get('host')        ?? '') as string).trim()
@@ -33,14 +33,14 @@ export async function addInfraService(formData: FormData): Promise<{ error?: str
 }
 
 export async function addInfraServiceAction(formData: FormData): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const result = await addInfraService(formData)
   if (result.error) throw new Error(result.error)
   redirect('/settings/infra-os?saved=1')
 }
 
 export async function removeInfraService(id: string): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db.update(backupJobs).set({ infraServiceId: null }).where(eq(backupJobs.infraServiceId, id)).run()
   await db.delete(infraOsServices).where(eq(infraOsServices.id, id)).run()

--- a/apps/web/app/actions/integration-tokens.ts
+++ b/apps/web/app/actions/integration-tokens.ts
@@ -2,13 +2,13 @@
 
 import { revalidatePath } from 'next/cache'
 import { getDb, integrationTokens, eq, count } from '@backupos/db'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 import { enforceLimit, LicenseLimitError } from '@/lib/license'
 import { appendAuditEntry } from '@/lib/audit'
 import { generateRawToken, hashToken, extractPrefix, ALL_SCOPES } from '@/lib/integration-tokens'
 
 export async function createIntegrationToken(formData: FormData): Promise<{ token?: string; id?: string; error?: string }> {
-  const adminUser     = await requireAdmin()
+  const adminUser     = await requireAdminAction()
   const name          = (formData.get('name') as string | null)?.trim()
   const expiresInDays = parseInt((formData.get('expiresInDays') as string | null) ?? '90', 10)
   const scopesRaw     = formData.getAll('scopes') as string[]
@@ -63,7 +63,7 @@ export async function createIntegrationToken(formData: FormData): Promise<{ toke
 }
 
 export async function revokeIntegrationToken(id: string): Promise<{ error?: string }> {
-  const adminUser = await requireAdmin()
+  const adminUser = await requireAdminAction()
   const db = getDb()
 
   const [existing] = await db.select().from(integrationTokens).where(eq(integrationTokens.id, id)).limit(1)
@@ -85,7 +85,7 @@ export async function revokeIntegrationToken(id: string): Promise<{ error?: stri
 }
 
 export async function rotateIntegrationToken(id: string): Promise<{ token?: string; newId?: string; error?: string }> {
-  const adminUser = await requireAdmin()
+  const adminUser = await requireAdminAction()
   const db = getDb()
 
   const [existing] = await db.select().from(integrationTokens).where(eq(integrationTokens.id, id)).limit(1)

--- a/apps/web/app/actions/invite.ts
+++ b/apps/web/app/actions/invite.ts
@@ -5,7 +5,7 @@ import { randomBytes }              from 'crypto'
 import { getDb, invite, user }      from '@backupos/db'
 import { eq, and, isNull, count }   from '@backupos/db'
 import { auth }                     from '@/lib/auth'
-import { getCurrentUser, requireAdmin } from '@/lib/user'
+import { getCurrentUser, requireAdminAction } from '@/lib/user'
 import { enforceLimit, LicenseLimitError } from '@/lib/license'
 import { sendInviteEmail }          from '@/lib/mailer'
 import { appendAuditEntry }         from '@/lib/audit'
@@ -193,7 +193,7 @@ export async function createUserDirect(formData: FormData): Promise<{
 }
 
 export async function updateUserRole(userId: string, role: 'admin' | 'viewer'): Promise<{ error?: string }> {
-  const admin = await requireAdmin()
+  const admin = await requireAdminAction()
   if (userId === admin.id) return { error: 'Cannot change your own role' }
   if (role !== 'admin' && role !== 'viewer') return { error: 'Invalid role' }
 

--- a/apps/web/app/actions/license.ts
+++ b/apps/web/app/actions/license.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache'
 import { getDb, licenseState } from '@backupos/db'
 import { eq } from '@backupos/db'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 import type { TierName } from '@backupos/license-client'
 
 export async function getLicenseSummary(): Promise<{
@@ -22,7 +22,7 @@ export async function getLicenseSummary(): Promise<{
 }
 
 export async function applyLicenseKey(_prevState: { error?: string } | undefined, formData: FormData): Promise<{ error?: string }> {
-  await requireAdmin()
+  await requireAdminAction()
   const key = (formData.get('licenseKey') as string | null)?.trim()
   if (!key) return { error: 'License key is required' }
 
@@ -38,7 +38,7 @@ export async function applyLicenseKey(_prevState: { error?: string } | undefined
 }
 
 export async function clearLicenseKey(): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db.update(licenseState)
     .set({ licenseKey: null, tier: 'free', updatedAt: new Date() })

--- a/apps/web/app/actions/logging-config.ts
+++ b/apps/web/app/actions/logging-config.ts
@@ -2,7 +2,7 @@
 
 import { redirect }             from 'next/navigation'
 import { getDb, loggingConfig } from '@backupos/db'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 const ACTIVITY_OPTIONS = ['30d', '90d', '180d', '365d', 'forever'] as const
 const AUDIT_OPTIONS    = ['90d', '365d', '3y', '7y', 'forever']    as const
@@ -33,7 +33,7 @@ export async function getLoggingConfig(): Promise<LoggingConfigValues> {
 }
 
 export async function saveLoggingConfig(formData: FormData): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const activityRetention = (formData.get('activityRetention') ?? '') as string
   const auditRetention    = (formData.get('auditRetention')    ?? '') as string
   const opsRetention      = (formData.get('opsRetention')      ?? '') as string

--- a/apps/web/app/actions/oidc-config.ts
+++ b/apps/web/app/actions/oidc-config.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 import { upsertOidcConfig, disableOidc as disableOidcDb } from '@/lib/oidc-config'
 import { appendAuditEntry } from '@/lib/audit'
 import { requireFeature, LicenseFeatureError } from '@/lib/license'
@@ -15,7 +15,7 @@ export async function saveOidcConfig(input: {
   scopes:        string
   buttonLabel:   string
 }): Promise<{ error?: string }> {
-  const admin = await requireAdmin()
+  const admin = await requireAdminAction()
 
   try { await requireFeature('oidc_sso') } catch (e) {
     if (e instanceof LicenseFeatureError) return { error: e.message }
@@ -46,7 +46,7 @@ export async function saveOidcConfig(input: {
 }
 
 export async function disableOidc(): Promise<{ error?: string }> {
-  const admin = await requireAdmin()
+  const admin = await requireAdminAction()
   try {
     disableOidcDb()
   } catch (err) {
@@ -66,7 +66,7 @@ export async function disableOidc(): Promise<{ error?: string }> {
 }
 
 export async function testOidcDiscovery(discoveryUrl: string): Promise<{ ok: boolean; message: string }> {
-  await requireAdmin()
+  await requireAdminAction()
   if (!discoveryUrl.trim()) return { ok: false, message: 'No URL provided' }
 
   let parsed: URL

--- a/apps/web/app/actions/pbs-connect.ts
+++ b/apps/web/app/actions/pbs-connect.ts
@@ -2,7 +2,7 @@
 
 import { request as httpsRequest, Agent } from 'node:https'
 import { getDb, pbsTokens, pbsDatastores, eq } from '@backupos/db'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 import { getPbsServerInfo } from '@/lib/pbs-server'
 
 export interface TestConnectionResult {
@@ -17,7 +17,7 @@ export async function testPbsConnection(input: {
   tokenId:       string
   datastoreName: string
 }): Promise<TestConnectionResult> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
 
   const [tokenRow] = await db

--- a/apps/web/app/actions/pbs-tokens.ts
+++ b/apps/web/app/actions/pbs-tokens.ts
@@ -3,7 +3,7 @@
 import { revalidatePath }                          from 'next/cache'
 import { randomBytes }                             from 'crypto'
 import { getDb, pbsTokens, eq, and }               from '@backupos/db'
-import { requireAdmin }                            from '@/lib/user'
+import { requireAdminAction }                            from '@/lib/user'
 import { generatePbsSecret, hashPbsSecret }        from '@/lib/pbs-tokens'
 import { appendAuditEntry }                        from '@/lib/audit'
 import { headers }                                 from 'next/headers'
@@ -17,7 +17,7 @@ export async function createPbsToken(formData: FormData): Promise<{
   id?:      string
   error?:   string
 }> {
-  await requireAdmin()
+  await requireAdminAction()
   const { api } = auth
   const session = await api.getSession({ headers: await headers() })
   if (!session) return { error: 'Not authenticated' }
@@ -77,7 +77,7 @@ export async function createPbsToken(formData: FormData): Promise<{
 }
 
 export async function revokePbsToken(id: string): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db.delete(pbsTokens).where(eq(pbsTokens.id, id))
   await appendAuditEntry({

--- a/apps/web/app/actions/preflight.ts
+++ b/apps/web/app/actions/preflight.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache'
 import { getDb, backupJobs, backupRuns, agents, repositories } from '@backupos/db'
 import { eq, desc } from '@backupos/db'
 import { runPreflightChecks, overallStatus, CheckResult } from '@/lib/preflight'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 export async function runPreflight(jobId: string): Promise<CheckResult[]> {
   const db  = getDb()
@@ -54,7 +54,7 @@ export async function runPreflight(jobId: string): Promise<CheckResult[]> {
 }
 
 export async function togglePreflight(jobId: string, formData: FormData): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const enabled = formData.get('preflightEnabled') === 'on'
   const db = getDb()
   await db.update(backupJobs)

--- a/apps/web/app/actions/repository-cost.ts
+++ b/apps/web/app/actions/repository-cost.ts
@@ -3,10 +3,10 @@
 import { revalidatePath } from 'next/cache'
 import { getDb, repositories } from '@backupos/db'
 import { eq } from '@backupos/db'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 export async function saveCostConfig(repoId: string, formData: FormData): Promise<void> {
-  await requireAdmin()
+  await requireAdminAction()
   const costStr   = ((formData.get('costPerGbMonth')    ?? '') as string).trim()
   const budgetStr = ((formData.get('monthlyBudgetCents') ?? '') as string).trim()
 

--- a/apps/web/app/actions/security.ts
+++ b/apps/web/app/actions/security.ts
@@ -2,7 +2,7 @@
 
 import { writeFileSync, copyFileSync, readFileSync } from 'node:fs'
 import { randomBytes } from 'node:crypto'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 import { rotateEncryptionKey, type RotationStats } from '@/lib/key-rotation'
 
 const ENV_FILE_PATH = process.env['BACKUPOS_ENV_FILE'] ?? '/etc/backupos/server.env'
@@ -25,7 +25,7 @@ export interface RotateResult {
  * env file is untouched.
  */
 export async function rotateEncryptionKeyAction(): Promise<RotateResult> {
-  await requireAdmin()
+  await requireAdminAction()
 
   const oldKey = process.env['ENCRYPTION_KEY']
   if (!oldKey || oldKey.length < 64) {

--- a/apps/web/app/actions/settings.ts
+++ b/apps/web/app/actions/settings.ts
@@ -4,10 +4,10 @@ import { redirect } from 'next/navigation'
 import nodemailer from 'nodemailer'
 import { getDb, instanceSettings, smtpConfig, backupDefaults } from '@backupos/db'
 import { encryptField, decryptField } from '@/lib/repo-crypto'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 
 export async function saveInstanceSettings(formData: FormData) {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const db = getDb()
   const rawUrl = String(formData.get('serverPublicUrl') ?? '').trim()
   // Validate URL if provided: must be http:// or https://
@@ -24,7 +24,7 @@ export async function saveInstanceSettings(formData: FormData) {
 }
 
 export async function saveSmtpConfig(formData: FormData) {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const db = getDb()
   const rawPassword = (formData.get('password') as string | null) ?? ''
 
@@ -63,7 +63,7 @@ export async function saveSmtpConfig(formData: FormData) {
 }
 
 export async function saveBackupDefaults(formData: FormData) {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const db = getDb()
   const values = {
     keepLast:      Number(formData.get('keepLast') ?? 10),

--- a/apps/web/app/actions/verification.ts
+++ b/apps/web/app/actions/verification.ts
@@ -7,7 +7,7 @@ import { encryptField, decryptField } from '@/lib/repo-crypto'
 import { dispatchToAgent } from '@/lib/internal-dispatch'
 import { connectedAgentIds } from '@/lib/ws-state'
 import { ensureRepoMountedOnAgent } from '@/lib/repo-mount'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 import { appendAuditEntry } from '@/lib/audit'
 import { parseExpression } from 'cron-parser'
 
@@ -26,7 +26,7 @@ export async function createVerificationTest(data: {
     cleanupRemote?: boolean
   } | null
 }): Promise<void> {
-  await requireAdmin() // admin only
+  await requireAdminAction() // admin only
   const { name, jobId, targetType, validationHook, schedule, targetConfig } = data
   if (!name || !jobId || !targetType || !schedule) return
 
@@ -155,7 +155,7 @@ export interface UpdateVerificationTestInput {
 }
 
 export async function updateVerificationTest(input: UpdateVerificationTestInput): Promise<{ error?: string }> {
-  const adminUser = await requireAdmin()
+  const adminUser = await requireAdminAction()
   const db = getDb()
 
   if (!input.name?.trim()) return { error: 'Name is required' }
@@ -218,7 +218,7 @@ export async function updateVerificationTest(input: UpdateVerificationTestInput)
 }
 
 export async function deleteVerificationTest(id: string): Promise<{ error?: string }> {
-  const adminUser = await requireAdmin()
+  const adminUser = await requireAdminAction()
   const db = getDb()
 
   const [existing] = await db.select().from(verificationTests).where(eq(verificationTests.id, id)).limit(1)

--- a/apps/web/app/actions/xcp-pools.ts
+++ b/apps/web/app/actions/xcp-pools.ts
@@ -1,5 +1,5 @@
 'use server'
-import { requireAdmin } from '@/lib/user'
+import { requireAdminAction } from '@/lib/user'
 import { getDb, xcpPools, xcpVms, eq } from '@backupos/db'
 import { XCPNGHypervisorDriver } from '@backupos/hypervisors'
 import type { XCPNGConfig } from '@backupos/hypervisors'
@@ -17,7 +17,7 @@ interface AddXcpPoolInput {
 export async function addXcpPool(
   input: AddXcpPoolInput,
 ): Promise<{ ok: true; poolId: string } | { ok: false; error: string }> {
-  await requireAdmin()
+  await requireAdminAction()
   const config: XCPNGConfig = {
     poolMasterUrl:   input.poolMasterUrl,
     username:        input.username,
@@ -55,7 +55,7 @@ export async function addXcpPool(
 export async function refreshXcpPool(
   poolId: string,
 ): Promise<{ ok: true; vmCount: number } | { ok: false; error: string }> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   const [pool] = await db.select().from(xcpPools).where(eq(xcpPools.id, poolId)).limit(1)
   if (!pool) return { ok: false, error: 'Pool not found' }
@@ -114,7 +114,7 @@ export async function refreshXcpPool(
 export async function deleteXcpPool(
   poolId: string,
 ): Promise<{ ok: boolean; error?: string }> {
-  await requireAdmin()
+  await requireAdminAction()
   const db = getDb()
   await db.delete(xcpPools).where(eq(xcpPools.id, poolId))
   return { ok: true }


### PR DESCRIPTION
Audit finding #7 migration, **batch 5 of 5 — final batch**.

Migrates the remaining 18 server-action files. After merge, every server action in `apps/web/app/actions/` uses `requireAdminAction()` instead of `requireAdmin()`.

## Files in this PR

agents, api-tokens, compose-restore, hypervisors, infra-os, integration-tokens, invite, license, logging-config, oidc-config, pbs-connect, pbs-tokens, preflight, repository-cost, security, settings, verification, xcp-pools

## Edge case

`invite.ts` used a combined import:
```ts
import { getCurrentUser, requireAdmin } from '@/lib/user'
```
which needed a dedicated sed pattern (the bulk perl regex assumed a single-name import).

## Verification

- `pnpm typecheck` clean
- `pnpm --filter @backupos/web build` clean
- `grep -rn 'requireAdmin\\b[^A]' apps/web/app/actions/*.ts` returns nothing

## Migration progress

- ✓ Foundation (PR #452)
- ✓ Batch 1: restore.ts (PR #453)
- ✓ Batch 2: jobs.ts + alerts.ts (PR #454)
- ✓ Batch 3: repositories, snapshots, pbs-datastores (PR #455)
- ✓ Batch 4: monitors, bandwidth, escrow (PR #456)
- ✓ Batch 5: this PR — **migration complete**

## What's NOT in this PR

- The `requireAdmin()` function itself remains in `lib/user.ts`. It's still used by the 2 page components (correct usage). A follow-up could rename it to `requireAdminPage()` for clarity, but that's purely cosmetic.
- Audit finding #7 is now closed.