### PR TITLE
fix(security): disable public signup endpoint (closes #460)

### DIFF
--- a/apps/web/app/(auth)/login/form.tsx
+++ b/apps/web/app/(auth)/login/form.tsx
@@ -9,9 +9,10 @@ import { SsoButton } from './sso-button'
 interface Props {
   ssoEnabled?:     boolean
   ssoButtonLabel?: string
+  hasUsers?:       boolean
 }
 
-export function LoginForm({ ssoEnabled = false, ssoButtonLabel = 'Sign in with SSO' }: Props) {
+export function LoginForm({ ssoEnabled = false, ssoButtonLabel = 'Sign in with SSO', hasUsers = false }: Props) {
   const router = useRouter()
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
@@ -95,10 +96,12 @@ export function LoginForm({ ssoEnabled = false, ssoButtonLabel = 'Sign in with S
           {ssoEnabled && <SsoButton buttonLabel={ssoButtonLabel} />}
         </form>
 
-        <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginTop: 20, textAlign: 'center' }}>
-          Don&apos;t have an account?{' '}
-          <Link href="/signup" style={{ color: 'var(--accent)', textDecoration: 'none' }}>Create one</Link>
-        </p>
+        {!hasUsers && (
+          <p style={{ fontSize: 13, color: 'var(--fg-mute)', marginTop: 20, textAlign: 'center' }}>
+            Don&apos;t have an account?{' '}
+            <Link href="/signup" style={{ color: 'var(--accent)', textDecoration: 'none' }}>Create one</Link>
+          </p>
+        )}
       </div>
     </div>
   )

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -17,6 +17,7 @@ export default async function LoginPage() {
     <LoginForm
       ssoEnabled={!!oidc?.enabled}
       ssoButtonLabel={oidc?.buttonLabel ?? 'Sign in with SSO'}
+      hasUsers={true}
     />
   )
 }

--- a/apps/web/app/actions/invite.ts
+++ b/apps/web/app/actions/invite.ts
@@ -5,6 +5,7 @@ import { randomBytes }              from 'crypto'
 import { getDb, invite, user }      from '@backupos/db'
 import { eq, and, isNull, count }   from '@backupos/db'
 import { auth }                     from '@/lib/auth'
+import { trustedSignup }            from '@/lib/signup-trust'
 import { getCurrentUser, requireAdminAction } from '@/lib/user'
 import { enforceLimit, LicenseLimitError } from '@/lib/license'
 import { sendInviteEmail }          from '@/lib/mailer'
@@ -92,8 +93,10 @@ export async function acceptInvite(
   await db.update(invite).set({ usedAt: now }).where(eq(invite.token, token))
 
   try {
-    await auth.api.signUpEmail({
-      body: { email: row.email, name: name.trim() || row.name || row.email, password },
+    await trustedSignup.run({}, async () => {
+      await auth.api.signUpEmail({
+        body: { email: row.email, name: name.trim() || row.name || row.email, password },
+      })
     })
   } catch (err) {
     // Roll back so the invite can be retried
@@ -157,7 +160,9 @@ export async function createUserDirect(formData: FormData): Promise<{
   const isAutoGenPw  = rawPw === null
 
   try {
-    await auth.api.signUpEmail({ body: { email, name, password } })
+    await trustedSignup.run({}, async () => {
+      await auth.api.signUpEmail({ body: { email, name, password } })
+    })
   } catch (err) {
     return { error: err instanceof Error ? err.message : 'Could not create account' }
   }

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,9 +1,10 @@
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { twoFactor as twoFactorPlugin, genericOAuth } from 'better-auth/plugins'
-import { getDb, user, session, account, verification, twoFactor, eq } from '@backupos/db'
+import { getDb, user, session, account, verification, twoFactor, eq, count } from '@backupos/db'
 import { isPrivateOrigin } from './private-origin'
 import { getOidcConfigDecrypted } from './oidc-config'
+import { isTrustedSignupContext } from './signup-trust'
 
 function buildPlugins(): ReturnType<typeof twoFactorPlugin>[] {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -55,6 +56,21 @@ export const auth = betterAuth({
     },
   },
   databaseHooks: {
+    user: {
+      create: {
+        async before(data: Record<string, unknown>) {
+          if (isTrustedSignupContext()) return { data }
+
+          const db   = getDb()
+          const rows = await db.select({ n: count(user.id) }).from(user).all()
+          const n    = rows[0]?.n ?? 0
+
+          if (n === 0) return { data }
+
+          throw new Error('Public signup is disabled. Contact an administrator for an invitation.')
+        },
+      },
+    },
     session: {
       create: {
         async after(session, context) {

--- a/apps/web/lib/signup-trust.ts
+++ b/apps/web/lib/signup-trust.ts
@@ -1,0 +1,18 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+// AsyncLocalStorage flag indicating the current async context is allowed
+// to create a user via auth.api.signUpEmail. Without this flag set, the
+// before-create hook in apps/web/lib/auth.ts will reject the call.
+//
+// Trusted callers wrap their auth.api.signUpEmail invocation:
+//   await trustedSignup.run({}, async () => {
+//     await auth.api.signUpEmail({ body: {...} })
+//   })
+//
+// Untrusted callers (the public HTTP endpoint /api/auth/sign-up/email)
+// do not have this context set and will be rejected.
+export const trustedSignup = new AsyncLocalStorage<object>()
+
+export function isTrustedSignupContext(): boolean {
+  return trustedSignup.getStore() !== undefined
+}

--- a/apps/web/scripts/seed-user.ts
+++ b/apps/web/scripts/seed-user.ts
@@ -1,13 +1,16 @@
-import { auth } from '../lib/auth'
+import { auth }          from '../lib/auth'
+import { trustedSignup } from '../lib/signup-trust'
 
 async function seed() {
   try {
-    await auth.api.signUpEmail({
-      body: {
-        name:     'Admin',
-        email:    'admin@backupos.local',
-        password: 'changeme',
-      },
+    await trustedSignup.run({}, async () => {
+      await auth.api.signUpEmail({
+        body: {
+          name:     'Admin',
+          email:    'admin@backupos.local',
+          password: 'changeme',
+        },
+      })
     })
     console.log('Default user created: admin@backupos.local / changeme')
   } catch (err: unknown) {

--- a/scripts/security/test-public-signup-blocked.sh
+++ b/scripts/security/test-public-signup-blocked.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Verifies that POST /api/auth/sign-up/email is rejected when users exist.
+# Run after deploy. Must be invoked with BACKUPOS_URL env set.
+#
+# Exits 0 on PASS (signup rejected), 1 on FAIL (signup succeeded).
+
+set -euo pipefail
+
+URL="${BACKUPOS_URL:-http://localhost:3093}"
+
+echo "==> Probing $URL/api/auth/sign-up/email with anonymous POST"
+echo "    (this should be rejected with non-200)"
+
+RAND="security-probe-$(date +%s)-$RANDOM@example.local"
+
+STATUS=$(curl -sk -o /tmp/signup-probe.json -w "%{http_code}" \
+  -X POST "$URL/api/auth/sign-up/email" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$RAND\",\"name\":\"probe\",\"password\":\"hunter2hunter2\"}")
+
+echo "    HTTP $STATUS"
+echo "    Body: $(head -c 400 /tmp/signup-probe.json)"
+
+if [ "$STATUS" -ge 200 ] && [ "$STATUS" -lt 300 ]; then
+  echo "==> FAIL — anonymous signup returned $STATUS (vulnerability still present)"
+  exit 1
+fi
+
+echo "==> PASS — anonymous signup rejected (HTTP $STATUS)"
+exit 0


### PR DESCRIPTION
Closes #460. P0 security fix — adds databaseHooks.user.create.before to reject anonymous signup unless zero users exist or AsyncLocalStorage trustedSignup context is active. Wraps acceptInvite, createUserDirect, and seed-user.ts in trustedSignup.run(). Hides Create-one link on login when users exist. Includes regression test scripts/security/test-public-signup-blocked.sh.